### PR TITLE
feat(dor): templates + strict self-host + Grugboard auto-add + footer fix

### DIFF
--- a/.github/ISSUE_TEMPLATE/work_item.md
+++ b/.github/ISSUE_TEMPLATE/work_item.md
@@ -1,0 +1,58 @@
+---
+name: Work item
+about: Standard work item — bug, idea, tech-debt. Must pass Grug DoR.
+title: 'feat(grug): '
+labels: ''
+assignees: ''
+---
+
+<!--
+Grug Definition of Ready (5 checks). Fill every section before this
+ticket leaves Triage. The PR that closes it must mirror the same shape.
+-->
+
+## Why
+
+<!--
+One paragraph. Why this work exists. What problem it solves, who feels
+it, and what changes once it ships. ≥1 sentence.
+-->
+
+## Acceptance criteria
+
+<!--
+Observable behavior at completion. ≥3 bullets. Each bullet is a check
+the reviewer can verify without reading code.
+-->
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Size
+
+<!--
+Effort estimate. XS = ≤30min, S = ≤2h, M = ≤1d, L = ≤3d.
+XL items must be split into ≥2 sub-issues before queueing.
+-->
+
+**Size:** S
+
+## Dependencies
+
+<!--
+Blocking issues / sibling repos / external prereqs. Use `Blocked by #N`,
+`Refs #N`, or `closes #N` so Grug's issue-link check passes and the
+graph is navigable.
+-->
+
+- 
+
+## Out of scope
+
+<!--
+Adjacent work that intentionally won't be done in this item. Prevents
+scope creep + tells the reviewer what to NOT review for.
+-->
+
+- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+Grug Definition of Ready (5 checks). Body must include every section
+or the self-hosted PR-gate fails (strict: true once the repo aligns).
+Mirror the shape from the issue this PR closes.
+-->
+
+## Why
+
+<!--
+One paragraph. Same rationale as the linked issue, restated for the
+reviewer landing here cold. ≥1 sentence.
+-->
+
+## Acceptance criteria
+
+<!--
+What the reviewer checks before merge. ≥3 bullets.
+-->
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Size
+
+**Size:** S
+
+## Dependencies
+
+<!--
+`closes #N` to auto-close the issue on merge. List blocking PRs
+(`Blocked by #N`) or sibling-repo prereqs (`Refs other-repo#N`).
+-->
+
+closes #
+
+## Out of scope
+
+<!--
+Adjacent changes not in this PR. Helps the reviewer skip past those.
+-->
+
+- 
+
+---
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.github/workflows/_reusable.grug-pr-gate.yml
+++ b/.github/workflows/_reusable.grug-pr-gate.yml
@@ -78,10 +78,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           STRICT: ${{ inputs.strict }}
         run: |
+          # GitHub Actions runs `run:` with implicit `set -eo pipefail`.
+          # Setting just `-uo pipefail` does NOT clear `-e`, so the python
+          # call below would terminate the script before $? could be read.
+          # Explicitly disable -e here; we branch on RC manually.
+          set +e
           set -uo pipefail
-          # NOT using -e because we need to inspect $? and branch on
-          # exit code 1 (DoR fail; user-fixable) vs 2 (script crash;
-          # not user-fixable — degrade to soft warning).
           python grug/scripts/tpm.py pr-gate "$PR_NUMBER"
           RC=$?
           if [ "$RC" -eq 0 ]; then

--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -36,6 +36,9 @@ on:
         required: false
       poolside_api_key:
         required: false
+      grugboard_pat:
+        description: "Optional PAT with project:write scope. If set, auto-adds the pulse issue to GitHub Project #1 (Grugboard) and lands it in the Triage column."
+        required: false
 
 permissions:
   contents: read
@@ -78,9 +81,39 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           TITLE="Grug pulse · ${MODE} · ${DATE}"
           echo "$PULSE_BODY" > /tmp/pulse.md
-          gh issue create \
+          ISSUE_URL=$(gh issue create \
             --repo "$GH_REPOSITORY" \
             --title "$TITLE" \
             --body-file /tmp/pulse.md \
-            --label "$PULSE_LABEL" \
-            || echo "::warning::Failed to create pulse issue (label may not exist; will create on first manual run)"
+            --label "$PULSE_LABEL" 2>&1) \
+            || { echo "::warning::Failed to create pulse issue: $ISSUE_URL"; exit 0; }
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          echo "$ISSUE_URL" > /tmp/issue_url.txt
+        id: open_issue
+
+      - name: Land pulse issue on Grugboard (Triage column)
+        env:
+          GH_TOKEN: ${{ secrets.grugboard_pat }}
+          PROJECT_OWNER: githumps
+          PROJECT_NUMBER: 1
+          STATUS_FIELD_ID: PVTSSF_lAHOA4Uvvc4A8kYPzgwh4fE
+          TRIAGE_OPTION_ID: 3e0a104b
+        run: |
+          set -uo pipefail
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "Grugboard PAT not provided; skipping project add. Set 'grugboard_pat' secret to enable."
+            exit 0
+          fi
+          ISSUE_URL=$(cat /tmp/issue_url.txt 2>/dev/null) || { echo "::warning::No issue URL captured; skipping Grugboard add."; exit 0; }
+          # Add to project + capture item id.
+          ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json --jq '.id' 2>/dev/null) \
+            || { echo "::warning::Grugboard item-add failed (PAT may lack project:write or repo not in scope). Skipping."; exit 0; }
+          PROJECT_ID=$(gh project list --owner "$PROJECT_OWNER" --format json --jq ".projects[] | select(.number == $PROJECT_NUMBER) | .id")
+          gh project item-edit \
+            --id "$ITEM_ID" \
+            --project-id "$PROJECT_ID" \
+            --field-id "$STATUS_FIELD_ID" \
+            --single-select-option-id "$TRIAGE_OPTION_ID" \
+            >/dev/null 2>&1 \
+            || echo "::warning::Grugboard status set to Triage failed (added to project but column not set)."
+          echo "✓ Pulse issue landed on Grugboard Triage: $ISSUE_URL"

--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -99,6 +99,10 @@ jobs:
           STATUS_FIELD_ID: PVTSSF_lAHOA4Uvvc4A8kYPzgwh4fE
           TRIAGE_OPTION_ID: 3e0a104b
         run: |
+          # Same set+e rationale as pr-gate wrapper: GitHub Actions runs
+          # with implicit `set -eo pipefail`. We branch on RC manually +
+          # always exit 0 (Grugboard add is best-effort, never blocks).
+          set +e
           set -uo pipefail
           if [[ -z "${GH_TOKEN}" ]]; then
             echo "Grugboard PAT not provided; skipping project add. Set 'grugboard_pat' secret to enable."

--- a/.github/workflows/grug.pr-gate.yml
+++ b/.github/workflows/grug.pr-gate.yml
@@ -18,6 +18,6 @@ jobs:
     name: Grug · self check
     uses: ./.github/workflows/_reusable.grug-pr-gate.yml
     with:
-      strict: false
+      strict: true
     secrets:
       poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}

--- a/.github/workflows/grug.pulse.yml
+++ b/.github/workflows/grug.pulse.yml
@@ -22,3 +22,4 @@ jobs:
       mode: "weekly"
     secrets:
       poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}
+      grugboard_pat: ${{ secrets.GRUGBOARD_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ jobs:
 3. `GITHUB_TOKEN` auto-provided.
 4. (Optional) Create label `grug-pulse` so the weekly issue is
    filterable; the workflow soft-warns + creates on first run if absent.
+5. (Optional) **Grugboard auto-add**: set `GRUGBOARD_PROJECT_TOKEN` env
+   secret (PAT with `project:write`). Pass through in the pulse caller
+   as `grugboard_pat`. Pulse issues land in the Grugboard "Triage"
+   column on issue creation. If unset, pulse just opens the issue.
 
 ## What Grug checks (Definition of Ready)
 

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -320,9 +320,9 @@ def render_comment(checks: list[DoRCheck], llm_review: str | None) -> tuple[str,
     sections.extend(
         [
             "",
-            "<sub>Static checks are blocking. LLM read is advisory. "
-            "Re-runs on every push. Edit PR body, push empty commit, or "
-            "comment `/grug recheck` to re-trigger.</sub>",
+            "<sub>Static checks are blocking when caller sets "
+            "`strict: true`. LLM read is advisory. Re-runs on every push: "
+            "edit PR body or push an empty commit to re-trigger.</sub>",
         ]
     )
     return "\n".join(sections), overall_pass


### PR DESCRIPTION
## Why

Lock in the DoR foundations on the grug repo itself before adding new bot features. We just extracted Grug to its own public repo and rolled it across 10 githumps repos — the bot now needs to dogfood the same Definition-of-Ready shape it enforces on consumers, plus drop a known-false UX promise (the `/grug recheck` footer advertising an unimplemented feature) and wire the Grugboard auto-add path so weekly pulse issues land in Triage automatically.

## Acceptance criteria

- [x] `.github/ISSUE_TEMPLATE/work_item.md` enforces 5-section DoR (Why, AC, Size, Dependencies, Out of scope)
- [x] `.github/pull_request_template.md` mirrors the same shape
- [x] Self-host PR-gate flips `strict: false` → `true` so future PRs are blocked on DoR fail
- [x] Reusable pulse accepts optional `grugboard_pat` secret + auto-adds pulse issue to Grugboard Triage column when present
- [x] Self-host pulse caller passes `GRUGBOARD_PROJECT_TOKEN` through as `grugboard_pat`
- [x] tpm.py footer drops `/grug recheck` false advertising (feature is grug#2, unimplemented)

## Size

**Size:** S

## Dependencies

Refs grug#2 (deferred — `/grug recheck` slash-command not yet built; footer corrected accordingly).

## Out of scope

- Implementing `/grug recheck` (grug#2 stays open as P1)
- Pulse-iteration metric enrichment (grug#4)
- Slack/Discord webhook output (grug#5)
- Real GitHub App with native bot avatar (grug#6)
- Setting `GRUGBOARD_PROJECT_TOKEN` env-secret on consumer repos other than this one — separate per-repo task
