### PR TITLE
fix: bump checkout + setup-python to Node 24 (closes #9)

### DIFF
--- a/.github/workflows/_reusable.grug-pr-gate.yml
+++ b/.github/workflows/_reusable.grug-pr-gate.yml
@@ -53,7 +53,7 @@ jobs:
     environment: grug-bot
     steps:
       - name: Checkout grug
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: githumps/grug
           ref: main
@@ -63,7 +63,7 @@ jobs:
           # supply a PAT secret with `contents: read` on grug.
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -56,13 +56,13 @@ jobs:
     # secret-scope parity.
     environment: grug-bot
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: githumps/grug
           ref: main
           path: grug
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
 


### PR DESCRIPTION
## Why

GitHub deprecates Node 20 actions on **2026-06-02** (forced Node 24) and removes Node 20 entirely on 2026-09-16. The two `actions/*` deps pinned in our reusable workflows run on Node 20 today — every PR-gate + pulse run across all 11 consumer repos breaks on the June deadline if we don't bump now.

## Acceptance criteria

- [x] `_reusable.grug-pr-gate.yml` uses `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2, Node 24)
- [x] `_reusable.grug-pr-gate.yml` uses `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6.2.0, Node 24)
- [x] Same bumps in `_reusable.grug-pulse.yml`
- [ ] Self-host PR-gate runs cleanly on this PR — sticky comment posts
- [ ] No `Node.js 20 actions are deprecated` warning in run log
- [ ] Pulse on grug repo dispatches cleanly post-merge

## Size

**Size:** XS

## Dependencies

closes #9

## Out of scope

- Bumping any third-party actions (none in reusable workflows)
- Migrating Python install path (canonical setup-python action stays)
- Bumping consumer-repo workflows that aren't Grug callers
