### PR TITLE
fix: parameterize Project v2 auto-add — public-fork-safe (closes #11)

### DIFF
--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -31,13 +31,33 @@ on:
         required: false
         type: string
         default: "weekly"
+      project_owner:
+        description: "GitHub user or org that owns the target Project v2 board. Required for project auto-add."
+        required: false
+        type: string
+        default: ""
+      project_number:
+        description: "Project v2 board number (the digit in the project URL: /projects/<N>)."
+        required: false
+        type: number
+        default: 0
+      project_status_field_id:
+        description: "Optional. Project v2 single-select field ID for Status. If both this and project_status_option_id are set, the pulse issue is moved to that column after add."
+        required: false
+        type: string
+        default: ""
+      project_status_option_id:
+        description: "Optional. Status option ID (e.g. the 'Triage' column). Paired with project_status_field_id."
+        required: false
+        type: string
+        default: ""
     secrets:
       gh_token:
         required: false
       poolside_api_key:
         required: false
-      grugboard_pat:
-        description: "Optional PAT with project:write scope. If set, auto-adds the pulse issue to GitHub Project #1 (Grugboard) and lands it in the Triage column."
+      project_pat:
+        description: "Optional PAT with project:write scope. If set together with project_owner + project_number, auto-adds the pulse issue to that Project v2 board."
         required: false
 
 permissions:
@@ -91,33 +111,35 @@ jobs:
           echo "$ISSUE_URL" > /tmp/issue_url.txt
         id: open_issue
 
-      - name: Land pulse issue on Grugboard (Triage column)
+      - name: Auto-add pulse issue to Project v2 (optional)
         env:
-          GH_TOKEN: ${{ secrets.grugboard_pat }}
-          PROJECT_OWNER: githumps
-          PROJECT_NUMBER: 1
-          STATUS_FIELD_ID: PVTSSF_lAHOA4Uvvc4A8kYPzgwh4fE
-          TRIAGE_OPTION_ID: 3e0a104b
+          GH_TOKEN: ${{ secrets.project_pat }}
+          PROJECT_OWNER: ${{ inputs.project_owner }}
+          PROJECT_NUMBER: ${{ inputs.project_number }}
+          STATUS_FIELD_ID: ${{ inputs.project_status_field_id }}
+          STATUS_OPTION_ID: ${{ inputs.project_status_option_id }}
         run: |
           # Same set+e rationale as pr-gate wrapper: GitHub Actions runs
-          # with implicit `set -eo pipefail`. We branch on RC manually +
-          # always exit 0 (Grugboard add is best-effort, never blocks).
+          # with implicit `set -eo pipefail`. Branch on RC manually +
+          # always exit 0 (project add is best-effort, never blocks).
           set +e
           set -uo pipefail
-          if [[ -z "${GH_TOKEN}" ]]; then
-            echo "Grugboard PAT not provided; skipping project add. Set 'grugboard_pat' secret to enable."
+          if [[ -z "${GH_TOKEN}" || -z "${PROJECT_OWNER}" || "${PROJECT_NUMBER}" == "0" ]]; then
+            echo "Project auto-add not configured; skipping. To enable, set inputs.project_owner + inputs.project_number on the caller and pass a PAT as secrets.project_pat."
             exit 0
           fi
-          ISSUE_URL=$(cat /tmp/issue_url.txt 2>/dev/null) || { echo "::warning::No issue URL captured; skipping Grugboard add."; exit 0; }
-          # Add to project + capture item id.
+          ISSUE_URL=$(cat /tmp/issue_url.txt 2>/dev/null) || { echo "::warning::No issue URL captured; skipping project add."; exit 0; }
           ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json --jq '.id' 2>/dev/null) \
-            || { echo "::warning::Grugboard item-add failed (PAT may lack project:write or repo not in scope). Skipping."; exit 0; }
-          PROJECT_ID=$(gh project list --owner "$PROJECT_OWNER" --format json --jq ".projects[] | select(.number == $PROJECT_NUMBER) | .id")
-          gh project item-edit \
-            --id "$ITEM_ID" \
-            --project-id "$PROJECT_ID" \
-            --field-id "$STATUS_FIELD_ID" \
-            --single-select-option-id "$TRIAGE_OPTION_ID" \
-            >/dev/null 2>&1 \
-            || echo "::warning::Grugboard status set to Triage failed (added to project but column not set)."
-          echo "✓ Pulse issue landed on Grugboard Triage: $ISSUE_URL"
+            || { echo "::warning::project item-add failed (PAT may lack project:write, or owner/number wrong). Skipping."; exit 0; }
+          echo "✓ Pulse issue added to project ${PROJECT_OWNER}/${PROJECT_NUMBER}: $ISSUE_URL"
+          if [[ -n "${STATUS_FIELD_ID}" && -n "${STATUS_OPTION_ID}" ]]; then
+            PROJECT_ID=$(gh project list --owner "$PROJECT_OWNER" --format json --jq ".projects[] | select(.number == $PROJECT_NUMBER) | .id")
+            gh project item-edit \
+              --id "$ITEM_ID" \
+              --project-id "$PROJECT_ID" \
+              --field-id "$STATUS_FIELD_ID" \
+              --single-select-option-id "$STATUS_OPTION_ID" \
+              >/dev/null 2>&1 \
+              && echo "✓ Status set on item." \
+              || echo "::warning::Status field set failed (added to project but column not moved)."
+          fi

--- a/.github/workflows/grug.pulse.yml
+++ b/.github/workflows/grug.pulse.yml
@@ -20,6 +20,13 @@ jobs:
     with:
       issue_label: "grug-pulse"
       mode: "weekly"
+      # Project auto-add (optional). Values below match the maintainer's
+      # Grugboard project; fork consumers can pass their own (or omit
+      # all four to skip auto-add).
+      project_owner: "githumps"
+      project_number: 1
+      project_status_field_id: "PVTSSF_lAHOA4Uvvc4A8kYPzgwh4fE"
+      project_status_option_id: "3e0a104b"   # Triage column
     secrets:
       poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}
-      grugboard_pat: ${{ secrets.GRUGBOARD_PROJECT_TOKEN }}
+      project_pat: ${{ secrets.GRUGBOARD_PROJECT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -60,10 +60,29 @@ jobs:
 3. `GITHUB_TOKEN` auto-provided.
 4. (Optional) Create label `grug-pulse` so the weekly issue is
    filterable; the workflow soft-warns + creates on first run if absent.
-5. (Optional) **Grugboard auto-add**: set `GRUGBOARD_PROJECT_TOKEN` env
-   secret (PAT with `project:write`). Pass through in the pulse caller
-   as `grugboard_pat`. Pulse issues land in the Grugboard "Triage"
-   column on issue creation. If unset, pulse just opens the issue.
+5. (Optional) **Project v2 auto-add**: pass your project's `owner` +
+   `number` (and a PAT with `project:write` as `project_pat`). Pulse
+   issues are added to that project on creation. If you also want them
+   to land in a specific column (e.g. "Triage"), pass
+   `project_status_field_id` + `project_status_option_id`.
+
+   ```yaml
+   with:
+     issue_label: "grug-pulse"
+     mode: "weekly"
+     project_owner: "<your-user-or-org>"
+     project_number: 1                          # /projects/<N> in URL
+     project_status_field_id: "PVTSSF_..."      # optional
+     project_status_option_id: "<option-id>"    # optional, paired
+   secrets:
+     poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}
+     project_pat: ${{ secrets.PROJECT_PAT }}
+   ```
+
+   Find field + option IDs via `gh project field-list <N> --owner <owner> --format json`.
+
+   If any of `project_owner` / `project_number` / `project_pat` is
+   unset, the project step no-ops (silent + safe).
 
 ## What Grug checks (Definition of Ready)
 

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -1,4 +1,4 @@
-"""Grug — automated TPM for Grugboard-managed projects.
+"""Grug — automated TPM bot for GitHub PRs + iteration pulse.
 
 Two modes:
   pr-gate <pr-number>      Check a PR against the Definition of Ready.
@@ -8,7 +8,6 @@ Reads:
   - GH_TOKEN env (or auth via `gh auth status` from runner)
   - POOLSIDE_API_KEY env (LLM reasoning; if unset → static checks only)
   - GH_REPOSITORY env (owner/repo)
-  - GRUGBOARD_PROJECT (default 1, the user's "Grugboard" project)
 
 Writes:
   - PR-gate: sticky comment on PR + sets check status (via exit code)
@@ -223,9 +222,9 @@ def poolside_review(pr: dict[str, Any]) -> str | None:
     prompt = textwrap.dedent(
         f"""
         You are Grug, an automated TPM bot that reviews PRs for a solo
-        developer's project board (Grugboard). Your job is NOT to review
-        code correctness — that's Sentry's job. Your job is to flag
-        process/scope issues:
+        or small-team project board. Your job is NOT to review code
+        correctness — that's Sentry's / Seer's / DD's job. Your job is
+        to flag process/scope issues:
 
         - Is the PR scope sane? (XL = should be split; <3 file changes
           but described as L = inflated estimate)


### PR DESCRIPTION
## Why

You caught the hardcode. Reusable pulse workflow had `PROJECT_OWNER: githumps`, `PROJECT_NUMBER: 1`, `STATUS_FIELD_ID: PVTSSF_...`, `TRIAGE_OPTION_ID: 3e0a104b` baked into the step. Anyone forking grug or pointing their consumer repos at the reusable would get THEIR pulse issues silently routed to OUR Grugboard. Not safe-for-public. Same for tpm.py docstring + LLM prompt mentioning "Grugboard" by proper noun + an unused `GRUGBOARD_PROJECT` env var doc.

After this lands, the reusable knows nothing about any specific project. Consumers opt in by passing inputs.

## Acceptance criteria

- [x] Reusable pulse accepts `project_owner` / `project_number` / `project_status_field_id` / `project_status_option_id` inputs (all default empty/0 = no-op)
- [x] Secret renamed `grugboard_pat` → `project_pat` (generic name)
- [x] Reusable's auto-add step no-ops silently if any of owner/number/pat unset
- [x] Self-host caller (`grug.pulse.yml` in this repo) keeps the maintainer's values — fork consumers don't inherit
- [x] tpm.py docstring drops `GRUGBOARD_PROJECT` (was never read by the code)
- [x] tpm.py LLM prompt drops "Grugboard" proper noun → "small-team project board"
- [x] README updated with full project-auto-add example using parameterized inputs
- [x] Final grep confirms remaining `githumps` / `PVTSSF_` refs only in maintainer's caller (fine — that's our config)

## Size

**Size:** S

## Dependencies

closes #11 (filed below)

## Out of scope

- Migrating already-shipped consumer caller workflows to the new `project_pat` secret name — separate follow-up. The old name `grugboard_pat` was never wired in any consumer's caller (only on grug self-host, fixed here), so no breakage.
- README cosmetics (caveman-tone passes, etc.)
- LICENSE / contributing guide for fork onboarding
