### PR TITLE
feat(pulse): subsume actions/stale into Grug — single bot for TPM mutation (closes #13)

### DIFF
--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -31,6 +31,26 @@ on:
         required: false
         type: string
         default: "weekly"
+      label_stale:
+        description: "If true, runs label-stale before the pulse summary — labels open issues quiet ≥ stale_days with stale_label."
+        required: false
+        type: boolean
+        default: true
+      stale_days:
+        description: "Days of inactivity before an issue is considered stale."
+        required: false
+        type: number
+        default: 90
+      stale_label:
+        description: "Label to apply to stale issues."
+        required: false
+        type: string
+        default: "stale"
+      stale_exempt_labels:
+        description: "Comma-separated labels that exempt an issue from stale-labelling."
+        required: false
+        type: string
+        default: "epic,pinned,security,grug-pulse"
       project_owner:
         description: "GitHub user or org that owns the target Project v2 board. Required for project auto-add."
         required: false
@@ -87,6 +107,21 @@ jobs:
           python-version: "3.13"
 
       - run: pip install --quiet "openai>=1.0,<2.0"
+
+      - name: Label stale issues (subsumes actions/stale)
+        if: ${{ inputs.label_stale }}
+        env:
+          GH_TOKEN: ${{ secrets.gh_token != '' && secrets.gh_token || secrets.GITHUB_TOKEN }}
+          GH_REPOSITORY: ${{ github.repository }}
+          STALE_DAYS: ${{ inputs.stale_days }}
+          STALE_LABEL: ${{ inputs.stale_label }}
+          STALE_EXEMPT_LABELS: ${{ inputs.stale_exempt_labels }}
+        run: |
+          # Best-effort: never blocks pulse summary.
+          set +e
+          set -uo pipefail
+          python grug/scripts/tpm.py label-stale \
+            || echo "::warning::label-stale exited non-zero; pulse continues"
 
       - name: Compute pulse + open issue
         env:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ LLM scope review (advisory) — Poolside `laguna-m.1`:
 
 Grug is the **process gate**, not the **code review gate**.
 
+## Stale issue labelling
+
+Pulse also labels stale open issues by default (subsumes `actions/stale`
+so all TPM mutation lives in one bot). Tunable via caller inputs:
+
+```yaml
+with:
+  label_stale: true            # set false to disable
+  stale_days: 90               # threshold
+  stale_label: "stale"         # label name
+  stale_exempt_labels: "epic,pinned,security,grug-pulse"
+```
+
+Behavior is idempotent — already-stale issues skip; exempt-labelled
+issues skip; mutations cap at 30/run to stay under API limits. Never
+auto-closes anything.
+
 ## Degradation behavior
 
 Poolside outage / rate limit / missing key → LLM section shows

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -485,6 +485,90 @@ def cmd_pulse() -> int:
     return 0
 
 
+# ─── label-stale: per-issue mutator ──────────────────────────────────────
+
+
+def cmd_label_stale() -> int:
+    """Walk open issues; label each ≥ STALE_DAYS quiet with STALE_LABEL.
+
+    Idempotent: skips issues already carrying the stale label or any
+    label in STALE_EXEMPT_LABELS. Caps mutations at STALE_OPS_PER_RUN.
+
+    Subsumes the standalone `actions/stale` workflow so all TPM-side
+    mutation lives in Grug.
+    """
+    from datetime import datetime, timezone
+
+    repo = os.environ.get("GH_REPOSITORY", "")
+    if not repo:
+        print("ERROR: GH_REPOSITORY env unset", file=sys.stderr)
+        return 2
+
+    stale_days = int(os.environ.get("STALE_DAYS", "90"))
+    stale_label = os.environ.get("STALE_LABEL", "stale")
+    exempt_raw = os.environ.get(
+        "STALE_EXEMPT_LABELS", "epic,pinned,security,grug-pulse"
+    )
+    exempt = {x.strip() for x in exempt_raw.split(",") if x.strip()}
+    ops_cap = int(os.environ.get("STALE_OPS_PER_RUN", "30"))
+
+    open_issues = _gh(
+        "issue", "list", "-R", repo, "--state", "open",
+        "--json", "number,title,updatedAt,labels",
+        "--limit", "200",
+        json_out=True,
+    )
+
+    now = datetime.now(timezone.utc)
+    threshold_seconds = stale_days * 86400
+    labelled = 0
+    skipped_exempt = 0
+    skipped_already = 0
+    skipped_fresh = 0
+
+    for issue in open_issues:
+        if labelled >= ops_cap:
+            print(f"reached ops cap ({ops_cap}); deferring rest to next run")
+            break
+
+        label_names = {l["name"] for l in issue.get("labels", [])}
+        if stale_label in label_names:
+            skipped_already += 1
+            continue
+        if label_names & exempt:
+            skipped_exempt += 1
+            continue
+
+        updated = datetime.fromisoformat(issue["updatedAt"].replace("Z", "+00:00"))
+        if (now - updated).total_seconds() < threshold_seconds:
+            skipped_fresh += 1
+            continue
+
+        try:
+            _gh("issue", "edit", str(issue["number"]), "-R", repo,
+                "--add-label", stale_label)
+            comment = (
+                f"This issue has been quiet for {stale_days} days. "
+                f"Adding the `{stale_label}` label so triage views can sort it.\n\n"
+                "If still relevant: comment to refresh the activity timestamp + remove the label.\n"
+                "If obsolete: close with reason `not planned`.\n"
+                "If parking-lot: classify on the project board so it's visible in the long-term backlog view."
+            )
+            _gh("issue", "comment", str(issue["number"]), "-R", repo, "--body", comment)
+            labelled += 1
+            print(f"  labelled #{issue['number']}: {issue['title'][:60]}")
+        except RuntimeError as e:
+            # Single failure doesn't stop the sweep.
+            print(f"::warning::failed to label #{issue['number']}: {e}", file=sys.stderr)
+
+    print(
+        f"\nlabel-stale done — labelled={labelled} "
+        f"already-stale={skipped_already} exempt={skipped_exempt} "
+        f"fresh={skipped_fresh}"
+    )
+    return 0
+
+
 # ─── CLI dispatch ────────────────────────────────────────────────────────
 
 
@@ -493,13 +577,17 @@ def main(argv: list[str]) -> int:
 
     Exit-code contract (Sentry MEDIUM — caller workflow used to
     treat any non-zero exit as DoR fail):
-      0  — DoR pass (mode pr-gate) OR pulse complete (mode pulse)
+      0  — DoR pass (mode pr-gate) OR pulse complete (mode pulse) OR
+           stale-labelling complete (mode label-stale)
       1  — DoR fail (mode pr-gate ONLY); PR has fixable structural gaps
       2  — Unexpected script error (bad args, missing env, gh/poolside
            crash). Caller workflow MUST treat exit 2 differently from 1.
     """
     if len(argv) < 2:
-        print("usage: tpm.py {pr-gate <pr#> | pulse}", file=sys.stderr)
+        print(
+            "usage: tpm.py {pr-gate <pr#> | pulse | label-stale}",
+            file=sys.stderr,
+        )
         return 2
     mode = argv[1]
     try:
@@ -514,6 +602,8 @@ def main(argv: list[str]) -> int:
             return cmd_pr_gate(repo, int(argv[2]))
         if mode == "pulse":
             return cmd_pulse()
+        if mode == "label-stale":
+            return cmd_label_stale()
         print(f"unknown mode: {mode}", file=sys.stderr)
         return 2
     except Exception as e:

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -512,6 +512,17 @@ def cmd_label_stale() -> int:
     exempt = {x.strip() for x in exempt_raw.split(",") if x.strip()}
     ops_cap = int(os.environ.get("STALE_OPS_PER_RUN", "30"))
 
+    # Ensure the label exists. `gh label create` fails if present, but we
+    # ignore that case — first run on a fresh repo creates it; subsequent
+    # runs no-op.
+    try:
+        _gh("label", "create", stale_label, "-R", repo,
+            "--color", "ededed",
+            "--description", f"Open ≥ {stale_days} days without activity. Auto-applied by Grug.")
+        print(f"created `{stale_label}` label on {repo}")
+    except RuntimeError:
+        pass  # already exists; harmless
+
     open_issues = _gh(
         "issue", "list", "-R", repo, "--state", "open",
         "--json", "number,title,updatedAt,labels",


### PR DESCRIPTION
## Why

User flagged the architectural mismatch: `actions/stale` runs as a separate workflow on somatic-scripts (pre-dates Grug rollout by ~3h on that repo). All TPM-side issue mutation should live in Grug — single source of truth, zero third-party action dep, reuses Grug's reusable-workflow distribution path. After this lands, deleting `stale.yml` on consumer repos is a clean sweep.

## Acceptance criteria

- [x] `tpm.py` exposes `label-stale` mode (subcommand)
- [x] Reusable pulse workflow runs `label-stale` before pulse summary by default (gated by `inputs.label_stale`)
- [x] Caller inputs control behavior: `label_stale`, `stale_days`, `stale_label`, `stale_exempt_labels`
- [x] Idempotent: re-running on same repo skips already-stale + exempt issues
- [x] Caps mutations at 30/run to stay under API rate limits
- [x] Never auto-closes
- [ ] Self-host pulse on grug repo runs cleanly post-merge — labels any stale issues + posts pulse
- [ ] Sweep deletes `stale.yml` from somatic-scripts in a follow-up PR (out of scope here)

## Size

**Size:** S

## Dependencies

closes #13

## Out of scope

- Stale-PR labelling (PRs in flight, not really stale)
- Auto-close behavior (never auto-close)
- Sweep + delete `stale.yml` from consumer repos — separate follow-up PR

## Test plan

After merge:
- [ ] `gh workflow run grug.pulse.yml --repo githumps/grug` — verify label-stale step runs + pulse summary still posts
- [ ] Re-run a 2nd time — verify already-stale issues are skipped
- [ ] Verify `stale` label exists on grug repo (workflow auto-creates? actions/stale used to do this; tpm.py does NOT — labels must pre-exist)
