### PR TITLE
debug(pulse): surface real stderr from gh project item-add

### DIFF
--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -164,17 +164,30 @@ jobs:
             exit 0
           fi
           ISSUE_URL=$(cat /tmp/issue_url.txt 2>/dev/null) || { echo "::warning::No issue URL captured; skipping project add."; exit 0; }
-          ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json --jq '.id' 2>/dev/null) \
-            || { echo "::warning::project item-add failed (PAT may lack project:write, or owner/number wrong). Skipping."; exit 0; }
-          echo "✓ Pulse issue added to project ${PROJECT_OWNER}/${PROJECT_NUMBER}: $ISSUE_URL"
+          # Capture stderr to surface real errors. Earlier `2>/dev/null` form
+          # masked PAT-scope misconfigurations behind a generic warning,
+          # making it impossible to distinguish "missing project:write"
+          # from "wrong owner/number" from "network error" without
+          # locally retrying.
+          ITEM_ADD_OUT=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json --jq '.id' 2>&1)
+          ITEM_ADD_RC=$?
+          if [[ $ITEM_ADD_RC -ne 0 ]]; then
+            echo "::warning::project item-add failed (rc=$ITEM_ADD_RC). Output: ${ITEM_ADD_OUT}"
+            exit 0
+          fi
+          ITEM_ID="$ITEM_ADD_OUT"
+          echo "✓ Pulse issue added to project ${PROJECT_OWNER}/${PROJECT_NUMBER}: $ISSUE_URL (item=$ITEM_ID)"
           if [[ -n "${STATUS_FIELD_ID}" && -n "${STATUS_OPTION_ID}" ]]; then
-            PROJECT_ID=$(gh project list --owner "$PROJECT_OWNER" --format json --jq ".projects[] | select(.number == $PROJECT_NUMBER) | .id")
-            gh project item-edit \
+            PROJECT_ID=$(gh project list --owner "$PROJECT_OWNER" --format json --jq ".projects[] | select(.number == $PROJECT_NUMBER) | .id" 2>&1)
+            EDIT_OUT=$(gh project item-edit \
               --id "$ITEM_ID" \
               --project-id "$PROJECT_ID" \
               --field-id "$STATUS_FIELD_ID" \
-              --single-select-option-id "$STATUS_OPTION_ID" \
-              >/dev/null 2>&1 \
-              && echo "✓ Status set on item." \
-              || echo "::warning::Status field set failed (added to project but column not moved)."
+              --single-select-option-id "$STATUS_OPTION_ID" 2>&1)
+            EDIT_RC=$?
+            if [[ $EDIT_RC -eq 0 ]]; then
+              echo "✓ Status set on item."
+            else
+              echo "::warning::Status field set failed (rc=$EDIT_RC). Output: ${EDIT_OUT}"
+            fi
           fi


### PR DESCRIPTION
## Why

Performance probe on the 11-repo Grug rollout (last 24h) showed every consumer's pulse "Auto-add to Project v2" step failing with a generic `project item-add failed (PAT may lack project:write, or owner/number wrong). Skipping.` warning. The earlier form swallowed stderr behind that warning, making it impossible to distinguish PAT-scope misconfiguration from wrong owner/number from network error.

Cross-checked: my local `gh` CLI (with `project` scope) adds items + edits status successfully. So the gh subcommand path is healthy — the failure is PAT-side. Need stderr surfaced to confirm root cause without cycling through PAT regenerations blindly.

## Acceptance criteria

- [x] Capture stderr + rc from `gh project item-add` and `gh project item-edit`
- [x] Surface real error message in the `::warning::` line (not generic placeholder)
- [x] Best-effort behavior preserved (`exit 0` on failure; pulse summary still ships)
- [ ] After merge: next pulse fire prints the actual error (PAT-scope, network, etc.)
- [ ] Once root cause is confirmed, file follow-up to either rotate PAT with correct scope OR adjust workflow auth model

## Size

**Size:** XS (1 step rewrite, no behavior change beyond logging verbosity)

## Dependencies

Refs grug performance probe in current session — 12 pulse issues manually added to Grugboard via local CLI as immediate value-shipping; this PR fixes the auto-add path for future pulse fires.

## Out of scope

- PAT scope verification — needs user to check at https://github.com/settings/tokens
- PAT rotation across 11 repos — separate operation if PAT scope is the issue
- Switching auth model from PAT to GitHub App project access — bigger refactor
