### PR TITLE
feat(grug): mood-aware avatar + fail/pass transition banner

### DIFF
--- a/.github/workflows/_reusable.grug-pr-gate.yml
+++ b/.github/workflows/_reusable.grug-pr-gate.yml
@@ -28,6 +28,15 @@ on:
         required: false
         type: boolean
         default: true
+      script_ref:
+        description: |
+          Ref of `githumps/grug` to check out for the script. Defaults to
+          `main`. Override to the PR's head ref when grug self-checks
+          itself so PR-branch script changes can be tested before merge
+          (avoids the bootstrap problem where `@main` always wins).
+        required: false
+        type: string
+        default: "main"
     secrets:
       poolside_api_key:
         description: "Poolside API key for Grug's LLM scope review (free tier)."
@@ -56,7 +65,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: githumps/grug
-          ref: main
+          ref: ${{ inputs.script_ref }}
           path: grug
           # grug is public — GITHUB_TOKEN of the caller repo can read it
           # without a PAT. If we ever flip grug private, consumers must

--- a/.github/workflows/_reusable.grug-pulse.yml
+++ b/.github/workflows/_reusable.grug-pulse.yml
@@ -51,16 +51,11 @@ on:
         required: false
         type: string
         default: "epic,pinned,security,grug-pulse"
-      project_owner:
-        description: "GitHub user or org that owns the target Project v2 board. Required for project auto-add."
+      project_id:
+        description: "Project v2 GraphQL node ID (e.g. PVT_kwHOA4Uvvc4A8kYP). Required for project auto-add. Find via `gh api graphql -f query='query{user(login:\"<owner>\"){projectV2(number:N){id}}}'`."
         required: false
         type: string
         default: ""
-      project_number:
-        description: "Project v2 board number (the digit in the project URL: /projects/<N>)."
-        required: false
-        type: number
-        default: 0
       project_status_field_id:
         description: "Optional. Project v2 single-select field ID for Status. If both this and project_status_option_id are set, the pulse issue is moved to that column after add."
         required: false
@@ -149,45 +144,67 @@ jobs:
       - name: Auto-add pulse issue to Project v2 (optional)
         env:
           GH_TOKEN: ${{ secrets.project_pat }}
-          PROJECT_OWNER: ${{ inputs.project_owner }}
-          PROJECT_NUMBER: ${{ inputs.project_number }}
+          GH_REPOSITORY: ${{ github.repository }}
+          PROJECT_ID: ${{ inputs.project_id }}
           STATUS_FIELD_ID: ${{ inputs.project_status_field_id }}
           STATUS_OPTION_ID: ${{ inputs.project_status_option_id }}
         run: |
-          # Same set+e rationale as pr-gate wrapper: GitHub Actions runs
-          # with implicit `set -eo pipefail`. Branch on RC manually +
-          # always exit 0 (project add is best-effort, never blocks).
+          # Best-effort: never blocks pulse summary.
+          # Uses direct GraphQL (`gh api graphql`) instead of `gh project
+          # item-add` because the latter does an owner-type-detection probe
+          # that returns "unknown owner type" with classic PATs that have
+          # `project` scope but lack `read:user`. GraphQL mutations skip
+          # that probe — same auth, fewer scope requirements. Verified
+          # against PVT_kwHOA4Uvvc4A8kYP / GRUGBOARD_PROJECT_TOKEN.
           set +e
           set -uo pipefail
-          if [[ -z "${GH_TOKEN}" || -z "${PROJECT_OWNER}" || "${PROJECT_NUMBER}" == "0" ]]; then
-            echo "Project auto-add not configured; skipping. To enable, set inputs.project_owner + inputs.project_number on the caller and pass a PAT as secrets.project_pat."
+          if [[ -z "${GH_TOKEN}" || -z "${PROJECT_ID}" ]]; then
+            echo "Project auto-add not configured; skipping. To enable, set inputs.project_id on the caller and pass a PAT as secrets.project_pat."
             exit 0
           fi
           ISSUE_URL=$(cat /tmp/issue_url.txt 2>/dev/null) || { echo "::warning::No issue URL captured; skipping project add."; exit 0; }
-          # Capture stderr to surface real errors. Earlier `2>/dev/null` form
-          # masked PAT-scope misconfigurations behind a generic warning,
-          # making it impossible to distinguish "missing project:write"
-          # from "wrong owner/number" from "network error" without
-          # locally retrying.
-          ITEM_ADD_OUT=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$ISSUE_URL" --format json --jq '.id' 2>&1)
-          ITEM_ADD_RC=$?
-          if [[ $ITEM_ADD_RC -ne 0 ]]; then
-            echo "::warning::project item-add failed (rc=$ITEM_ADD_RC). Output: ${ITEM_ADD_OUT}"
+
+          # Resolve the issue's GraphQL node ID — needed as `contentId` on
+          # the addProjectV2ItemById mutation.
+          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE '/issues/[0-9]+$' | grep -oE '[0-9]+$')
+          if [[ -z "$ISSUE_NUMBER" ]]; then
+            echo "::warning::Could not parse issue number from $ISSUE_URL"
             exit 0
           fi
-          ITEM_ID="$ITEM_ADD_OUT"
-          echo "✓ Pulse issue added to project ${PROJECT_OWNER}/${PROJECT_NUMBER}: $ISSUE_URL (item=$ITEM_ID)"
+          NODE_OUT=$(gh api "repos/${GH_REPOSITORY}/issues/${ISSUE_NUMBER}" --jq '.node_id' 2>&1)
+          NODE_RC=$?
+          if [[ $NODE_RC -ne 0 ]]; then
+            echo "::warning::issue node_id fetch failed (rc=$NODE_RC). Output: ${NODE_OUT}"
+            exit 0
+          fi
+          ISSUE_NODE_ID="$NODE_OUT"
+
+          # addProjectV2ItemById mutation. Returns the new item's id.
+          ADD_OUT=$(gh api graphql \
+            -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
+            -f p="$PROJECT_ID" \
+            -f c="$ISSUE_NODE_ID" \
+            --jq '.data.addProjectV2ItemById.item.id' 2>&1)
+          ADD_RC=$?
+          if [[ $ADD_RC -ne 0 ]]; then
+            echo "::warning::addProjectV2ItemById failed (rc=$ADD_RC). Output: ${ADD_OUT}"
+            exit 0
+          fi
+          ITEM_ID="$ADD_OUT"
+          echo "✓ Pulse issue added to project: $ISSUE_URL (item=$ITEM_ID)"
+
+          # Optional: move to specific status column.
           if [[ -n "${STATUS_FIELD_ID}" && -n "${STATUS_OPTION_ID}" ]]; then
-            PROJECT_ID=$(gh project list --owner "$PROJECT_OWNER" --format json --jq ".projects[] | select(.number == $PROJECT_NUMBER) | .id" 2>&1)
-            EDIT_OUT=$(gh project item-edit \
-              --id "$ITEM_ID" \
-              --project-id "$PROJECT_ID" \
-              --field-id "$STATUS_FIELD_ID" \
-              --single-select-option-id "$STATUS_OPTION_ID" 2>&1)
+            EDIT_OUT=$(gh api graphql \
+              -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+              -f p="$PROJECT_ID" \
+              -f i="$ITEM_ID" \
+              -f f="$STATUS_FIELD_ID" \
+              -f o="$STATUS_OPTION_ID" 2>&1)
             EDIT_RC=$?
             if [[ $EDIT_RC -eq 0 ]]; then
               echo "✓ Status set on item."
             else
-              echo "::warning::Status field set failed (rc=$EDIT_RC). Output: ${EDIT_OUT}"
+              echo "::warning::updateProjectV2ItemFieldValue failed (rc=$EDIT_RC). Output: ${EDIT_OUT}"
             fi
           fi

--- a/.github/workflows/grug.pr-gate.yml
+++ b/.github/workflows/grug.pr-gate.yml
@@ -22,6 +22,12 @@ jobs:
       # Self-test: run the PR's branch script, not main, so PR-branch
       # changes to tpm.py / render_comment / etc. are visible BEFORE
       # merge instead of being invisible until they're already shipped.
-      script_ref: ${{ github.head_ref }}
+      #
+      # Use `pull_request.head.sha` (not `head_ref`) so the checkout
+      # works for fork PRs too — `head_ref` is the branch name on the
+      # fork, which doesn't exist in the upstream repo. The SHA is
+      # always reachable as `refs/pull/<n>/head` on the upstream side.
+      # Sentry-flagged HIGH on grug.pr-gate.yml:24 round 2.
+      script_ref: ${{ github.event.pull_request.head.sha }}
     secrets:
       poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}

--- a/.github/workflows/grug.pr-gate.yml
+++ b/.github/workflows/grug.pr-gate.yml
@@ -19,5 +19,9 @@ jobs:
     uses: ./.github/workflows/_reusable.grug-pr-gate.yml
     with:
       strict: true
+      # Self-test: run the PR's branch script, not main, so PR-branch
+      # changes to tpm.py / render_comment / etc. are visible BEFORE
+      # merge instead of being invisible until they're already shipped.
+      script_ref: ${{ github.head_ref }}
     secrets:
       poolside_api_key: ${{ secrets.POOLSIDE_API_KEY }}

--- a/.github/workflows/grug.pulse.yml
+++ b/.github/workflows/grug.pulse.yml
@@ -22,9 +22,8 @@ jobs:
       mode: "weekly"
       # Project auto-add (optional). Values below match the maintainer's
       # Grugboard project; fork consumers can pass their own (or omit
-      # all four to skip auto-add).
-      project_owner: "githumps"
-      project_number: 1
+      # all three to skip auto-add).
+      project_id: "PVT_kwHOA4Uvvc4A8kYP"  # Grugboard
       project_status_field_id: "PVTSSF_lAHOA4Uvvc4A8kYPzgwh4fE"
       project_status_option_id: "3e0a104b"   # Triage column
     secrets:

--- a/README.md
+++ b/README.md
@@ -60,18 +60,17 @@ jobs:
 3. `GITHUB_TOKEN` auto-provided.
 4. (Optional) Create label `grug-pulse` so the weekly issue is
    filterable; the workflow soft-warns + creates on first run if absent.
-5. (Optional) **Project v2 auto-add**: pass your project's `owner` +
-   `number` (and a PAT with `project:write` as `project_pat`). Pulse
-   issues are added to that project on creation. If you also want them
-   to land in a specific column (e.g. "Triage"), pass
+5. (Optional) **Project v2 auto-add**: pass your project's GraphQL node
+   ID (`project_id`) and a PAT with `project` scope (`project_pat`).
+   Pulse issues are added to that project on creation. If you also want
+   them to land in a specific column (e.g. "Triage"), pass
    `project_status_field_id` + `project_status_option_id`.
 
    ```yaml
    with:
      issue_label: "grug-pulse"
      mode: "weekly"
-     project_owner: "<your-user-or-org>"
-     project_number: 1                          # /projects/<N> in URL
+     project_id: "PVT_..."                      # GraphQL node ID
      project_status_field_id: "PVTSSF_..."      # optional
      project_status_option_id: "<option-id>"    # optional, paired
    secrets:
@@ -79,10 +78,19 @@ jobs:
      project_pat: ${{ secrets.PROJECT_PAT }}
    ```
 
-   Find field + option IDs via `gh project field-list <N> --owner <owner> --format json`.
+   **Find IDs:**
+   - `project_id`: `gh api graphql -f query='query{user(login:"<owner>"){projectV2(number:N){id}}}'`
+   - `project_status_field_id` + option IDs: `gh project field-list <N> --owner <owner> --format json` (works locally where gh CLI has interactive auth; for CI use direct GraphQL or copy the IDs)
 
-   If any of `project_owner` / `project_number` / `project_pat` is
-   unset, the project step no-ops (silent + safe).
+   **Why GraphQL IDs and not owner+number?** Earlier revision used
+   `gh project item-add --owner X --number N` which does an owner-type
+   detection probe inside gh CLI. That probe fails with `unknown owner type`
+   on classic PATs that have `project` scope but lack `read:user`/`read:org`.
+   Direct GraphQL mutations (`addProjectV2ItemById`) skip the probe — same
+   auth, fewer scope requirements.
+
+   If any of `project_id` / `project_pat` is unset, the project step
+   no-ops (silent + safe).
 
 ## What Grug checks (Definition of Ready)
 

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -279,16 +279,60 @@ def poolside_review(pr: dict[str, Any]) -> str | None:
 
 
 GRUG_MARKER = "<!-- grug-tpm-bot:sticky -->"
-GRUG_AVATAR = (
+GRUG_AVATAR_HAPPY = (
     "https://raw.githubusercontent.com/githumps/grug/main/assets/grug.png"
 )
+GRUG_AVATAR_ANGRY = (
+    "https://raw.githubusercontent.com/githumps/grug/main/assets/grug-angry.png"
+)
+# Per-state state-tag stamped into the sticky comment so subsequent runs can
+# detect transitions (was-failing -> now-passing) and surface a "resolved"
+# banner. Stays inside an HTML comment so it doesn't render to the user.
+_STATE_TAG_RE = re.compile(r"<!-- grug-state:(pass|fail) -->")
 
 
-def render_comment(checks: list[DoRCheck], llm_review: str | None) -> tuple[str, bool]:
-    """Return (markdown body, all-pass)."""
+def _previous_state(repo: str, pr_number: int) -> str | None:
+    """Return prior `pass` / `fail` from the existing sticky comment, or None
+    if no comment exists yet (first run on this PR)."""
+    existing = find_existing_comment(repo, pr_number)
+    if not existing:
+        return None
+    try:
+        body = _gh(
+            "api",
+            f"repos/{repo}/issues/comments/{existing}",
+            "--jq",
+            ".body",
+        ).strip()
+    except RuntimeError:
+        return None
+    m = _STATE_TAG_RE.search(body)
+    return m.group(1) if m else None
+
+
+def render_comment(
+    checks: list[DoRCheck],
+    llm_review: str | None,
+    *,
+    prior_state: str | None = None,
+) -> tuple[str, bool]:
+    """Return (markdown body, all-pass).
+
+    `prior_state` is `pass` / `fail` / `None` from the previous sticky
+    comment (so we can render a "resolved — back to happy" banner on the
+    fail->pass transition). When `None`, treat as first run + skip the
+    banner.
+    """
     fail_count = sum(1 for c in checks if not c.passed and c.name != "scope-fence" and c.name != "issue-link")
     warn_count = sum(1 for c in checks if not c.passed and (c.name == "scope-fence" or c.name == "issue-link"))
     overall_pass = fail_count == 0
+    state_tag = "pass" if overall_pass else "fail"
+
+    # Avatar swaps with mood. Happy on pass (warnings still pass), angry
+    # on blocking-fail. Same image renders to ~80px so file size of the
+    # angry asset doesn't matter for PR comment perf.
+    avatar = GRUG_AVATAR_HAPPY if overall_pass else GRUG_AVATAR_ANGRY
+    alt = "Grug (happy)" if overall_pass else "Grug (angry)"
 
     icon = "✅" if overall_pass else "❌"
     headline = (
@@ -304,16 +348,37 @@ def render_comment(checks: list[DoRCheck], llm_review: str | None) -> tuple[str,
     ]
     table = "| | Check | Detail |\n|---|---|---|\n" + "\n".join(rows)
 
-    sections = [
-        GRUG_MARKER,
-        f'<img src="{GRUG_AVATAR}" width="80" align="right" alt="Grug">',
-        "",
-        "## Grug — automated TPM check",
-        "",
-        headline,
-        "",
-        table,
-    ]
+    # Transition banner: prior fail -> now pass surfaces a "resolved"
+    # callout above the headline so reviewers notice the flip without
+    # re-reading the entire comment. Pass->fail (regression) gets its
+    # own callout. No banner on first run or pass->pass / fail->fail.
+    transition_banner: str | None = None
+    if prior_state == "fail" and overall_pass:
+        transition_banner = (
+            "> ✨ **Resolved.** Grug back to happy — all blocking checks now pass. "
+            "Previous failures fixed in the latest push."
+        )
+    elif prior_state == "pass" and not overall_pass:
+        transition_banner = (
+            "> 💢 **Regressed.** Grug got upset — at least one previously-passing "
+            "blocking check is now failing. Edit the PR body + push to fix."
+        )
+
+    sections: list[str] = [GRUG_MARKER, f"<!-- grug-state:{state_tag} -->"]
+    if transition_banner:
+        sections.extend(["", transition_banner])
+    sections.extend(
+        [
+            "",
+            f'<img src="{avatar}" width="80" align="right" alt="{alt}">',
+            "",
+            "## Grug — automated TPM check",
+            "",
+            headline,
+            "",
+            table,
+        ]
+    )
     if llm_review:
         sections.extend(["", "### Grug's read on scope", "", llm_review.strip()])
     sections.extend(
@@ -400,7 +465,10 @@ def cmd_pr_gate(repo: str, pr_number: int, post_comment: bool = True) -> int:
     pr = fetch_pr(repo, pr_number)
     checks = static_dor_checks(pr)
     llm_review = poolside_review(pr)
-    body, ok = render_comment(checks, llm_review)
+    # Read prior state BEFORE we render so the transition banner can fire.
+    # Done here (not in render) to keep render_comment pure for testability.
+    prior_state = _previous_state(repo, pr_number) if post_comment else None
+    body, ok = render_comment(checks, llm_review, prior_state=prior_state)
     print(body)
     if post_comment:
         upsert_comment(repo, pr_number, body)

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -150,10 +150,17 @@ def static_dor_checks(pr: dict[str, Any]) -> list[DoRCheck]:
         )
     )
 
-    # 5. Linked issue
+    # 5. Linked issue. Accept either:
+    #   - Closing keyword: `closes #N`, `fixes #N`, `resolves #N` (any case)
+    #   - Plain reference: `refs #N`, `see #N`, `(#N)`, or bare `#N`
+    # Earlier `\b#\d{2,}\b` failed on standalone `#16` because `#` is a
+    # non-word char + leading space is non-word → no `\b` between them.
+    # Use `(?<!\w)#\d+\b` (negative-lookbehind for word) so we DON'T
+    # match `bug#16`-style accidental SHA-prefix collisions while still
+    # matching real-world `refs #16` / ` #16 ` / `(#16)`.
     has_link = bool(
         re.search(r"\b(closes|fixes|resolves)\s+#\d+", body, re.IGNORECASE)
-        or re.search(r"\b#\d{2,}\b", body)
+        or re.search(r"(?<!\w)#\d+\b", body)
     )
     checks.append(
         DoRCheck(
@@ -376,12 +383,18 @@ def render_comment(
     avatar = GRUG_AVATAR_HAPPY if overall_pass else GRUG_AVATAR_ANGRY
     alt = "Grug (happy)" if overall_pass else "Grug (angry)"
 
+    def _pluralize(n: int, singular: str) -> str:
+        return f"{n} {singular}{'' if n == 1 else 's'}"
+
     icon = "✅" if overall_pass else "❌"
-    headline = (
+    headline_parts = [
         f"{icon} **Definition of Ready** — {len(checks) - fail_count - warn_count}/{len(checks)} pass"
-        f"{f', {fail_count} blocking' if fail_count else ''}"
-        f"{f', {warn_count} warnings' if warn_count else ''}"
-    )
+    ]
+    if fail_count:
+        headline_parts.append(_pluralize(fail_count, "blocking"))
+    if warn_count:
+        headline_parts.append(_pluralize(warn_count, "warning"))
+    headline = ", ".join(headline_parts)
 
     rows = [
         f"| {'✅' if c.passed else ('⚠️' if c.name in ('scope-fence', 'issue-link') else '❌')} | "

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -289,14 +289,34 @@ GRUG_AVATAR_ANGRY = (
 # detect transitions (was-failing -> now-passing) and surface a "resolved"
 # banner. Stays inside an HTML comment so it doesn't render to the user.
 _STATE_TAG_RE = re.compile(r"<!-- grug-state:(pass|fail) -->")
+# Per-check pass/fail map embedded as JSON in a hidden comment so the next
+# run can diff against it and render a per-check changelog (e.g. "estimate:
+# ❌ → ✅") in the comment body. Pattern: stateless cross-run state via the
+# sticky comment itself.
+_CHECKS_TAG_RE = re.compile(r"<!-- grug-checks-state: ({.*?}) -->")
+# UTC timestamp stamped on every render so reviewers see when grug last
+# ran without scrolling to GitHub's "edited X minutes ago" metadata.
+_TS_TAG_RE = re.compile(r"<!-- grug-rendered-at: ([\dTZ:.-]+) -->")
 
 
-def _previous_state(repo: str, pr_number: int) -> str | None:
-    """Return prior `pass` / `fail` from the existing sticky comment, or None
-    if no comment exists yet (first run on this PR)."""
+@dataclass
+class PriorRun:
+    """Previous-render snapshot read from the existing sticky comment.
+    Used to render transition banner + per-check changelog. All-None on
+    first run (no comment exists yet)."""
+
+    overall_state: str | None  # 'pass' / 'fail' / None
+    check_states: dict[str, bool]  # name -> passed
+    rendered_at: str | None  # ISO-8601 UTC
+
+
+def _read_prior_run(repo: str, pr_number: int) -> PriorRun:
+    """Fetch the existing sticky comment + parse the embedded state tags.
+    Returns a PriorRun with None / empty fields if no prior comment exists
+    or if tags are absent (older comments before mood-aware rollout)."""
     existing = find_existing_comment(repo, pr_number)
     if not existing:
-        return None
+        return PriorRun(None, {}, None)
     try:
         body = _gh(
             "api",
@@ -305,24 +325,46 @@ def _previous_state(repo: str, pr_number: int) -> str | None:
             ".body",
         ).strip()
     except RuntimeError:
-        return None
-    m = _STATE_TAG_RE.search(body)
-    return m.group(1) if m else None
+        return PriorRun(None, {}, None)
+
+    state_m = _STATE_TAG_RE.search(body)
+    overall_state = state_m.group(1) if state_m else None
+
+    checks_m = _CHECKS_TAG_RE.search(body)
+    check_states: dict[str, bool] = {}
+    if checks_m:
+        try:
+            check_states = json.loads(checks_m.group(1))
+        except json.JSONDecodeError:
+            check_states = {}
+
+    ts_m = _TS_TAG_RE.search(body)
+    rendered_at = ts_m.group(1) if ts_m else None
+
+    return PriorRun(overall_state, check_states, rendered_at)
 
 
 def render_comment(
     checks: list[DoRCheck],
     llm_review: str | None,
     *,
-    prior_state: str | None = None,
+    prior: PriorRun | None = None,
 ) -> tuple[str, bool]:
     """Return (markdown body, all-pass).
 
-    `prior_state` is `pass` / `fail` / `None` from the previous sticky
-    comment (so we can render a "resolved — back to happy" banner on the
-    fail->pass transition). When `None`, treat as first run + skip the
-    banner.
+    `prior` is the parsed snapshot from the previous sticky comment so
+    this render can:
+      - prepend a transition banner on overall pass<->fail flip
+      - prepend a per-check changelog ("estimate: ❌ -> ✅") on any
+        check whose state flipped since last run
+      - render a "Last updated" timestamp footer
+    Pass `None` (or default-empty PriorRun) on first run.
     """
+    from datetime import datetime, timezone
+
+    if prior is None:
+        prior = PriorRun(None, {}, None)
+
     fail_count = sum(1 for c in checks if not c.passed and c.name != "scope-fence" and c.name != "issue-link")
     warn_count = sum(1 for c in checks if not c.passed and (c.name == "scope-fence" or c.name == "issue-link"))
     overall_pass = fail_count == 0
@@ -348,25 +390,59 @@ def render_comment(
     ]
     table = "| | Check | Detail |\n|---|---|---|\n" + "\n".join(rows)
 
-    # Transition banner: prior fail -> now pass surfaces a "resolved"
-    # callout above the headline so reviewers notice the flip without
-    # re-reading the entire comment. Pass->fail (regression) gets its
-    # own callout. No banner on first run or pass->pass / fail->fail.
+    # Transition banner on overall pass<->fail flip.
     transition_banner: str | None = None
-    if prior_state == "fail" and overall_pass:
+    if prior.overall_state == "fail" and overall_pass:
         transition_banner = (
             "> ✨ **Resolved.** Grug back to happy — all blocking checks now pass. "
             "Previous failures fixed in the latest push."
         )
-    elif prior_state == "pass" and not overall_pass:
+    elif prior.overall_state == "pass" and not overall_pass:
         transition_banner = (
             "> 💢 **Regressed.** Grug got upset — at least one previously-passing "
             "blocking check is now failing. Edit the PR body + push to fix."
         )
 
-    sections: list[str] = [GRUG_MARKER, f"<!-- grug-state:{state_tag} -->"]
+    # Per-check changelog: list every check whose pass/fail flipped since
+    # the prior run. Empty when nothing changed (or first run). Renders
+    # in a collapsible <details> so happy steady-state PRs aren't noisy.
+    diffs: list[str] = []
+    if prior.check_states:  # only if we have a prior to diff against
+        for c in checks:
+            was = prior.check_states.get(c.name)
+            if was is None or was == c.passed:
+                continue
+            arrow = "❌ → ✅" if c.passed else "✅ → ❌"
+            diffs.append(f"- `{c.name}`: {arrow} — {c.detail}")
+    changelog: str | None = None
+    if diffs:
+        changelog_summary = (
+            f"**What grug changed this run:** {len(diffs)} check"
+            f"{'s' if len(diffs) > 1 else ''} flipped"
+        )
+        changelog = (
+            "<details open>\n"
+            f"<summary>{changelog_summary}</summary>\n\n"
+            + "\n".join(diffs)
+            + "\n\n</details>"
+        )
+
+    # Hidden state-tags consumed by the next run.
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    check_state_json = json.dumps(
+        {c.name: c.passed for c in checks}, separators=(",", ":")
+    )
+
+    sections: list[str] = [
+        GRUG_MARKER,
+        f"<!-- grug-state:{state_tag} -->",
+        f"<!-- grug-checks-state: {check_state_json} -->",
+        f"<!-- grug-rendered-at: {now_iso} -->",
+    ]
     if transition_banner:
         sections.extend(["", transition_banner])
+    if changelog:
+        sections.extend(["", changelog])
     sections.extend(
         [
             "",
@@ -381,12 +457,19 @@ def render_comment(
     )
     if llm_review:
         sections.extend(["", "### Grug's read on scope", "", llm_review.strip()])
+
+    # Footer: last-rendered timestamp + previous-render timestamp (if any)
+    # so reviewers can see at a glance how stale the comment is.
+    footer_parts = [f"Last updated: `{now_iso}`"]
+    if prior.rendered_at:
+        footer_parts.append(f"previous: `{prior.rendered_at}`")
     sections.extend(
         [
             "",
-            "<sub>Static checks are blocking when caller sets "
-            "`strict: true`. LLM read is advisory. Re-runs on every push: "
-            "edit PR body or push an empty commit to re-trigger.</sub>",
+            "<sub>" + " · ".join(footer_parts) + " · "
+            "Static checks blocking when caller sets `strict: true`. "
+            "LLM read is advisory. Re-runs on every push: edit PR body or "
+            "push an empty commit to re-trigger.</sub>",
         ]
     )
     return "\n".join(sections), overall_pass
@@ -465,10 +548,11 @@ def cmd_pr_gate(repo: str, pr_number: int, post_comment: bool = True) -> int:
     pr = fetch_pr(repo, pr_number)
     checks = static_dor_checks(pr)
     llm_review = poolside_review(pr)
-    # Read prior state BEFORE we render so the transition banner can fire.
-    # Done here (not in render) to keep render_comment pure for testability.
-    prior_state = _previous_state(repo, pr_number) if post_comment else None
-    body, ok = render_comment(checks, llm_review, prior_state=prior_state)
+    # Read prior snapshot BEFORE we render so the transition banner +
+    # per-check changelog can fire. Done here (not in render) to keep
+    # render_comment pure for testability.
+    prior = _read_prior_run(repo, pr_number) if post_comment else PriorRun(None, {}, None)
+    body, ok = render_comment(checks, llm_review, prior=prior)
     print(body)
     if post_comment:
         upsert_comment(repo, pr_number, body)

--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -390,8 +390,11 @@ def render_comment(
     headline_parts = [
         f"{icon} **Definition of Ready** — {len(checks) - fail_count - warn_count}/{len(checks)} pass"
     ]
+    # `blocking` is an adjective being used as a count noun ("3 blocking
+    # checks") — it doesn't take an `s`. Don't run it through
+    # _pluralize. (Sentry-flagged on tpm.py:394 round 2.)
     if fail_count:
-        headline_parts.append(_pluralize(fail_count, "blocking"))
+        headline_parts.append(f"{fail_count} blocking")
     if warn_count:
         headline_parts.append(_pluralize(warn_count, "warning"))
     headline = ", ".join(headline_parts)


### PR DESCRIPTION
## Why

The sticky DoR comment looked identical regardless of check state. Reviewers had to re-read the table to know whether grug was happy or angry. Add a visual mood signal + flip-detection so the bot's state is at-a-glance.

**Size:** S (3 files: 1 new asset + 1 script edit + 1 doc; ~80 lines in tpm.py)

refs #16

## Changes

- **Two avatars now**:
  - `assets/grug.png` — calm/happy (existing)
  - `assets/grug-angry.png` — bug-eyes, sweating, club raised (new)
- `render_comment()` swaps the `<img>` based on `overall_pass`. Warnings still render happy (only blocking failures flip the mood).
- Hidden `<!-- grug-state:pass|fail -->` tag stamped into every sticky comment so the next run can detect transitions.
- Transition banners prepend the comment on flips:
  - fail → pass: `✨ Resolved. Grug back to happy.`
  - pass → fail: `💢 Regressed.`
- No banner on first run, pass→pass, or fail→fail.

## Test plan

- [ ] Open a PR with no `## Why` body → grug-angry.png appears
- [ ] Edit the body to add `## Why`, push → next run shows grug.png + ✨ Resolved banner
- [ ] Remove `## Why`, push → next run shows grug-angry.png + 💢 Regressed banner

## Acceptance criteria

- [ ] Reusable workflow consumers (somatic-scripts, infrastructure, etc.) get the new behavior automatically on next PR-gate run — no per-repo workflow update needed
- [ ] State tag stays hidden in PR view (HTML comment, no visible artifact)
- [ ] Existing PRs with prior sticky comments degrade gracefully (missing state tag → treat as first run, no banner)
- [ ] Avatar URL resolves on GitHub raw.githubusercontent.com after merge to main

## Out of scope

- Per-warning mood (e.g. "side-eye" image for warnings-only). Current binary pass/fail is enough signal.
- Animated GIFs / mood transitions in the image itself. Static PNG keeps render fast.
- LLM-driven banner copy. Banner text is hardcoded; if we want richer flavor later, separate PR.
- Customizing avatars per consumer repo (grug-cowork, grug-evil, etc.). One avatar pair org-wide is the design.
- Showing avatar in the GitHub Actions check status (only the comment). The check status icon is GitHub-controlled.