### PR TITLE
feat(slice-5): allowlist gate + installation event handling

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -15,6 +15,7 @@ on:
       - 'feat/23-*'
       - 'feat/24-*'
       - 'feat/25-*'
+      - 'feat/26-*'
     tags: ['v*']
   workflow_dispatch:
     inputs:

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -93,7 +93,7 @@ gha_deploy_role = oidc_role.create(
     repo="githumps/grug",
     # `main` and SaaS-conversion feature branches (epic-grug-saas).
     # Tighten back to `main` only once Slice 13 (#34) ships.
-    branches=["main", "feat/22-*", "feat/23-*", "feat/24-*", "feat/25-*"],
+    branches=["main", "feat/22-*", "feat/23-*", "feat/24-*", "feat/25-*", "feat/26-*"],
     tags_pattern="v*",
 )
 
@@ -137,6 +137,9 @@ webhook = lambda_service.create(
         # Lambda has IAM read on the params already; safe to inject.
         "GITHUB_APP_CLIENT_ID_SSM": secrets["github-app-client-id"].name,
         "GITHUB_APP_CLIENT_SECRET_SSM": secrets["github-app-client-secret"].name,
+        # DDB allowlist gate (Slice 5 #26). Webhook reads INST# + USER#
+        # rows directly (no KMS — token blobs are api-Lambda-only).
+        "GRUG_DDB_TABLE": grug_main_table.name,
         # Datadog APM (datadog_lambda wrapper finds real handler via
         # DD_LAMBDA_HANDLER; layer adds the trace agent + log forwarder).
         "DD_LAMBDA_HANDLER": "lambda_handler.handler",
@@ -253,6 +256,34 @@ _aws.iam.RolePolicy(
                             "dynamodb:BatchWriteItem",
                         ],
                         "Resource": [arn, f"{arn}/index/*"],
+                    },
+                ],
+            },
+        ),
+    ),
+)
+
+# DDB IAM for webhook Lambda (Slice 5 #26 allowlist gate). Tighter
+# scope than api: GetItem + PutItem + DeleteItem only (no Query, no
+# UpdateItem — webhook only records install rows + reads INST/USER for
+# allowlist checks). Explicitly NO KMS perms — token blobs stay
+# api-Lambda-only per locked encryption decision.
+_aws.iam.RolePolicy(
+    "grug-webhook-ddb-policy",
+    role=webhook.role.id,
+    policy=grug_main_table.arn.apply(
+        lambda arn: _json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "dynamodb:GetItem",
+                            "dynamodb:PutItem",
+                            "dynamodb:DeleteItem",
+                        ],
+                        "Resource": [arn],
                     },
                 ],
             },

--- a/infra/scripts/seed-admin.py
+++ b/infra/scripts/seed-admin.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Seed an admin user row in grug-main DDB.
+
+Usage:
+    AWS_PROFILE=... python3 infra/scripts/seed-admin.py \\
+        --github-user-id 59060157 --login githumps
+
+Idempotent: re-running on an existing row preserves OAuth blobs and
+created_at, only flips role + tier + allowlisted to admin/lifetime/true.
+Defaults match locked PRD: admin = Evan + GF; tier = lifetime.
+
+Slice 5 #26 — required to unblock the webhook allowlist gate. Without
+this, the webhook will no_op every PR until at least one admin row
+exists with allowlisted=true.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timezone
+
+import boto3
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--github-user-id", required=True, type=int,
+                   help="GitHub numeric user ID (curl https://api.github.com/users/<login> | jq .id)")
+    p.add_argument("--login", required=True, help="GitHub login (e.g. githumps)")
+    p.add_argument("--table", default="grug-main")
+    p.add_argument("--region", default="us-east-1")
+    p.add_argument("--role", default="admin", choices=["admin", "user"])
+    p.add_argument("--tier", default="lifetime",
+                   choices=["lifetime", "free", "paid"])
+    p.add_argument("--allowlisted-by", default="seed-admin.py")
+    p.add_argument("--install-id", type=int, default=None,
+                   help="Optional: also backfill INST#<id> META row for "
+                        "Apps installed BEFORE Slice 5 shipped (no `installation:created` "
+                        "event was processed). Use the install_id from the post-install "
+                        "redirect URL.")
+    p.add_argument("--account-login", default=None,
+                   help="Account login for --install-id row (defaults to --login)")
+    p.add_argument("--account-type", default="User",
+                   choices=["User", "Organization"])
+    args = p.parse_args()
+
+    table = boto3.resource("dynamodb", region_name=args.region).Table(args.table)
+    pk = f"USER#{args.github_user_id}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    existing = table.get_item(Key={"PK": pk, "SK": "META"}).get("Item") or {}
+
+    item = {
+        **existing,
+        "PK": pk,
+        "SK": "META",
+        "login": args.login,
+        "role": args.role,
+        "tier": args.tier,
+        "allowlisted": True,
+        "allowlisted_at": existing.get("allowlisted_at") or now,
+        "allowlisted_by": existing.get("allowlisted_by") or args.allowlisted_by,
+    }
+    if "created_at" not in item:
+        item["created_at"] = now
+
+    table.put_item(Item=item)
+    print(f"seeded USER#{args.github_user_id} ({args.login}) role={args.role} "
+          f"tier={args.tier} allowlisted=True")
+
+    if args.install_id is not None:
+        inst_pk = f"INST#{args.install_id}"
+        existing_inst = table.get_item(
+            Key={"PK": inst_pk, "SK": "META"}
+        ).get("Item") or {}
+        inst_item = {
+            **existing_inst,
+            "PK": inst_pk,
+            "SK": "META",
+            "account_login": args.account_login or args.login,
+            "account_type": args.account_type,
+            "installed_at": existing_inst.get("installed_at") or now,
+            "installed_by_user_id": str(args.github_user_id),
+            "GSI1PK": str(args.github_user_id),
+            "GSI1SK": inst_pk,
+        }
+        table.put_item(Item=inst_item)
+        print(f"seeded INST#{args.install_id} "
+              f"installed_by_user_id={args.github_user_id}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/api/adapters/install_store.py
+++ b/services/api/adapters/install_store.py
@@ -1,0 +1,116 @@
+"""Webhook-side install store + allowlist gate.
+
+Webhook Lambda has DDB read+write perms but NO KMS perms — it never
+touches OAuth tokens (those belong to api Lambda). This module exposes
+ONLY the bool `allowlisted` field plus install-row CRUD.
+
+Single-table layout:
+  PK = INST#<install_id>     SK = META
+    account_login, account_type, installed_at, installed_by_user_id
+  PK = USER#<github_user_id> SK = META
+    allowlisted (read here; oauth_*_blob untouched)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+
+log = logging.getLogger("grug.webhook.install_store")
+
+_TABLE_NAME = os.environ.get("GRUG_DDB_TABLE", "grug-main")
+_ddb = boto3.resource("dynamodb")
+_table = _ddb.Table(_TABLE_NAME)
+
+
+def _inst_pk(install_id: int | str) -> str:
+    return f"INST#{install_id}"
+
+
+def _user_pk(github_user_id: int | str) -> str:
+    return f"USER#{github_user_id}"
+
+
+def record_installation(
+    *,
+    install_id: int,
+    account_login: str,
+    account_type: str,
+    installed_by_user_id: int,
+) -> None:
+    """Idempotent upsert of INST#<id> META row on `installation:created`.
+
+    On `installation:deleted` callers should use `delete_installation`
+    instead — this function only writes.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    _table.put_item(
+        Item={
+            "PK": _inst_pk(install_id),
+            "SK": "META",
+            "account_login": account_login,
+            "account_type": account_type,
+            "installed_at": now,
+            "installed_by_user_id": str(installed_by_user_id),
+            # GSI1 — list installations by user (per PRD #21 schema).
+            "GSI1PK": str(installed_by_user_id),
+            "GSI1SK": _inst_pk(install_id),
+        }
+    )
+
+
+def delete_installation(install_id: int) -> None:
+    _table.delete_item(Key={"PK": _inst_pk(install_id), "SK": "META"})
+
+
+def get_installation(install_id: int) -> dict[str, Any] | None:
+    resp = _table.get_item(
+        Key={"PK": _inst_pk(install_id), "SK": "META"},
+        ConsistentRead=True,
+    )
+    return resp.get("Item")
+
+
+def is_install_allowlisted(install_id: int) -> bool:
+    """Return True iff INST#<id> exists AND its installer is allowlisted.
+
+    Two-hop lookup — INST# row holds installed_by_user_id; USER# row
+    holds the actual `allowlisted` bool. Returns False on any miss
+    (unknown install, unknown user, allowlisted=False/missing).
+
+    Webhook-safe: reads `allowlisted` directly, never touches token
+    blobs (no KMS Decrypt call).
+    """
+    inst = get_installation(install_id)
+    if not inst:
+        log.info("allowlist_miss_no_install", extra={"install_id": install_id})
+        return False
+    user_id = inst.get("installed_by_user_id")
+    if not user_id:
+        log.warning(
+            "allowlist_install_missing_user_id",
+            extra={"install_id": install_id},
+        )
+        return False
+    user = _table.get_item(
+        Key={"PK": _user_pk(user_id), "SK": "META"},
+        ConsistentRead=True,
+        ProjectionExpression="allowlisted",
+    ).get("Item")
+    if not user:
+        log.info(
+            "allowlist_miss_no_user",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+        return False
+    allowlisted = bool(user.get("allowlisted", False))
+    if not allowlisted:
+        log.info(
+            "allowlist_miss_user_not_allowlisted",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+    return allowlisted

--- a/services/webhook/adapters/install_store.py
+++ b/services/webhook/adapters/install_store.py
@@ -1,0 +1,116 @@
+"""Webhook-side install store + allowlist gate.
+
+Webhook Lambda has DDB read+write perms but NO KMS perms — it never
+touches OAuth tokens (those belong to api Lambda). This module exposes
+ONLY the bool `allowlisted` field plus install-row CRUD.
+
+Single-table layout:
+  PK = INST#<install_id>     SK = META
+    account_login, account_type, installed_at, installed_by_user_id
+  PK = USER#<github_user_id> SK = META
+    allowlisted (read here; oauth_*_blob untouched)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+
+log = logging.getLogger("grug.webhook.install_store")
+
+_TABLE_NAME = os.environ.get("GRUG_DDB_TABLE", "grug-main")
+_ddb = boto3.resource("dynamodb")
+_table = _ddb.Table(_TABLE_NAME)
+
+
+def _inst_pk(install_id: int | str) -> str:
+    return f"INST#{install_id}"
+
+
+def _user_pk(github_user_id: int | str) -> str:
+    return f"USER#{github_user_id}"
+
+
+def record_installation(
+    *,
+    install_id: int,
+    account_login: str,
+    account_type: str,
+    installed_by_user_id: int,
+) -> None:
+    """Idempotent upsert of INST#<id> META row on `installation:created`.
+
+    On `installation:deleted` callers should use `delete_installation`
+    instead — this function only writes.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    _table.put_item(
+        Item={
+            "PK": _inst_pk(install_id),
+            "SK": "META",
+            "account_login": account_login,
+            "account_type": account_type,
+            "installed_at": now,
+            "installed_by_user_id": str(installed_by_user_id),
+            # GSI1 — list installations by user (per PRD #21 schema).
+            "GSI1PK": str(installed_by_user_id),
+            "GSI1SK": _inst_pk(install_id),
+        }
+    )
+
+
+def delete_installation(install_id: int) -> None:
+    _table.delete_item(Key={"PK": _inst_pk(install_id), "SK": "META"})
+
+
+def get_installation(install_id: int) -> dict[str, Any] | None:
+    resp = _table.get_item(
+        Key={"PK": _inst_pk(install_id), "SK": "META"},
+        ConsistentRead=True,
+    )
+    return resp.get("Item")
+
+
+def is_install_allowlisted(install_id: int) -> bool:
+    """Return True iff INST#<id> exists AND its installer is allowlisted.
+
+    Two-hop lookup — INST# row holds installed_by_user_id; USER# row
+    holds the actual `allowlisted` bool. Returns False on any miss
+    (unknown install, unknown user, allowlisted=False/missing).
+
+    Webhook-safe: reads `allowlisted` directly, never touches token
+    blobs (no KMS Decrypt call).
+    """
+    inst = get_installation(install_id)
+    if not inst:
+        log.info("allowlist_miss_no_install", extra={"install_id": install_id})
+        return False
+    user_id = inst.get("installed_by_user_id")
+    if not user_id:
+        log.warning(
+            "allowlist_install_missing_user_id",
+            extra={"install_id": install_id},
+        )
+        return False
+    user = _table.get_item(
+        Key={"PK": _user_pk(user_id), "SK": "META"},
+        ConsistentRead=True,
+        ProjectionExpression="allowlisted",
+    ).get("Item")
+    if not user:
+        log.info(
+            "allowlist_miss_no_user",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+        return False
+    allowlisted = bool(user.get("allowlisted", False))
+    if not allowlisted:
+        log.info(
+            "allowlist_miss_user_not_allowlisted",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+    return allowlisted

--- a/services/webhook/dispatcher.py
+++ b/services/webhook/dispatcher.py
@@ -1,10 +1,13 @@
 """Webhook → persona dispatch.
 
-Routes GitHub events to active personas. v1 only handles
-pull_request → TPM persona. Future personas register here.
+Routes GitHub events to active personas. v1 handles:
+  - installation / installation_repositories: record + delete INST# rows
+  - pull_request: TPM persona (gated on installer allowlist)
+  - pull_request_review: placeholder for v1.5 code-reviewer persona
 
-Skips silently if installation not allowlisted (defense-in-depth — full
-allowlist gate logic lands in Slice 5 #26 with admin-flippable DDB flag).
+Allowlist gate (Slice 5 #26): non-allowlisted installs no_op silently
+BEFORE persona work runs. Defense-in-depth — App registration is
+public but webhook never acts on PRs from non-allowlisted users.
 """
 
 from __future__ import annotations
@@ -12,22 +15,60 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from adapters.install_store import (
+    delete_installation,
+    is_install_allowlisted,
+    record_installation,
+)
+
 log = logging.getLogger("grug.webhook.dispatcher")
 
 
 def dispatch(event_name: str, payload: dict[str, Any]) -> dict[str, str]:
     """Route a webhook event to its persona handlers. Returns audit dict."""
+    if event_name == "installation":
+        return _handle_installation(payload)
+    if event_name == "installation_repositories":
+        # Repo-list change on an existing install — install row already
+        # exists; nothing to record (per-repo config lands in Slice 7+).
+        return {"status": "no_op", "reason": "installation_repositories acknowledged"}
     if event_name == "pull_request":
         return _handle_pull_request(payload)
     if event_name == "pull_request_review":
-        # v1.5+ — code-reviewer persona consumes this
         return {"status": "no_op", "reason": "no persona for pull_request_review yet"}
     return {"status": "no_op", "reason": f"no handler for event {event_name}"}
 
 
+def _handle_installation(payload: dict[str, Any]) -> dict[str, str]:
+    action = payload.get("action", "")
+    install = payload.get("installation") or {}
+    install_id = install.get("id")
+    if not install_id:
+        return {"status": "skip", "reason": "no installation.id"}
+
+    if action == "deleted":
+        delete_installation(int(install_id))
+        return {"status": "recorded", "action": "deleted"}
+
+    if action in {"created", "new_permissions_accepted", "unsuspend"}:
+        account = install.get("account") or {}
+        sender = payload.get("sender") or {}
+        installed_by = sender.get("id") or account.get("id")
+        if not installed_by:
+            return {"status": "skip", "reason": "no sender.id or account.id"}
+        record_installation(
+            install_id=int(install_id),
+            account_login=account.get("login", ""),
+            account_type=account.get("type", "User"),
+            installed_by_user_id=int(installed_by),
+        )
+        return {"status": "recorded", "action": action}
+
+    return {"status": "no_op", "reason": f"installation action={action} unhandled"}
+
+
 def _handle_pull_request(payload: dict[str, Any]) -> dict[str, str]:
     action = payload.get("action", "")
-    # Only fire on actions that change the gate-relevant state
     if action not in {"opened", "edited", "synchronize", "ready_for_review", "reopened"}:
         return {"status": "no_op", "reason": f"pull_request action={action} not gated"}
 
@@ -53,6 +94,20 @@ def _handle_pull_request(payload: dict[str, Any]) -> dict[str, str]:
             },
         )
         return {"status": "skip", "reason": "incomplete_payload"}
+
+    # Allowlist gate (Slice 5 #26). Defense-in-depth — non-allowlisted
+    # installs no_op silently. Avoids any GitHub API calls (no install
+    # token request, no check-run post) so we don't leak Grug presence
+    # to repos whose installer hasn't been admin-approved.
+    if not is_install_allowlisted(int(installation_id)):
+        log.info(
+            "allowlist_gate_skip",
+            extra={
+                "installation_id": installation_id,
+                "owner": owner, "repo": repo_name, "pr_number": pr_number,
+            },
+        )
+        return {"status": "no_op", "reason": "installer not allowlisted"}
 
     # Lazy import — keeps cold-start cheap when only non-PR events fire
     from personas.tpm.persona import evaluate_pull_request  # type: ignore

--- a/services/webhook/tests/test_dispatcher.py
+++ b/services/webhook/tests/test_dispatcher.py
@@ -1,7 +1,8 @@
 """Tests for webhook → persona dispatcher.
 
-Covers routing decisions and payload-shape gates without invoking the
-real GitHub API (TPM evaluator is patched).
+Covers routing decisions, payload-shape gates, allowlist gating, and
+installation event handling. TPM evaluator + install_store are
+patched.
 """
 
 from __future__ import annotations
@@ -22,6 +23,11 @@ def test_pull_request_review_placeholder():
     assert out["status"] == "no_op" and "code-reviewer" not in out["reason"]
 
 
+def test_installation_repositories_no_op():
+    out = dispatch("installation_repositories", {})
+    assert out["status"] == "no_op"
+
+
 def test_pull_request_unhandled_action_skips():
     payload = {"action": "labeled", "pull_request": {}, "repository": {}}
     out = dispatch("pull_request", payload)
@@ -34,7 +40,7 @@ def test_pull_request_incomplete_payload_skips():
     assert out["status"] == "skip" and out["reason"] == "incomplete_payload"
 
 
-def _full_payload():
+def _full_pr_payload():
     return {
         "action": "opened",
         "pull_request": {
@@ -47,24 +53,81 @@ def _full_payload():
     }
 
 
-def test_pull_request_dispatches_to_tpm():
-    with patch("personas.tpm.persona.evaluate_pull_request") as mock_eval:
-        mock_result = type("R", (), {"passed": True})()
-        mock_eval.return_value = mock_result
-        out = dispatch("pull_request", _full_payload())
-        assert out["status"] == "dispatched"
-        assert out["persona"] == "tpm"
-        assert out["result"] == "pass"
-        mock_eval.assert_called_once()
-        kwargs = mock_eval.call_args.kwargs
-        assert kwargs["installation_id"] == 999
-        assert kwargs["owner"] == "githumps"
-        assert kwargs["repo"] == "infra"
-        assert kwargs["pr_number"] == 42
+def test_pull_request_dispatches_when_allowlisted():
+    with patch("dispatcher.is_install_allowlisted", return_value=True), \
+         patch("personas.tpm.persona.evaluate_pull_request") as mock_eval:
+        mock_eval.return_value = type("R", (), {"passed": True})()
+        out = dispatch("pull_request", _full_pr_payload())
+    assert out["status"] == "dispatched"
+    assert out["persona"] == "tpm"
+    assert out["result"] == "pass"
+    mock_eval.assert_called_once()
 
 
 def test_pull_request_fail_propagates():
-    with patch("personas.tpm.persona.evaluate_pull_request") as mock_eval:
+    with patch("dispatcher.is_install_allowlisted", return_value=True), \
+         patch("personas.tpm.persona.evaluate_pull_request") as mock_eval:
         mock_eval.return_value = type("R", (), {"passed": False})()
-        out = dispatch("pull_request", _full_payload())
-        assert out["result"] == "fail"
+        out = dispatch("pull_request", _full_pr_payload())
+    assert out["result"] == "fail"
+
+
+def test_pull_request_blocked_when_not_allowlisted():
+    """Defense-in-depth: non-allowlisted installs no_op silently and
+    NEVER reach the TPM evaluator (no GitHub API call, no check-run)."""
+    with patch("dispatcher.is_install_allowlisted", return_value=False), \
+         patch("personas.tpm.persona.evaluate_pull_request") as mock_eval:
+        out = dispatch("pull_request", _full_pr_payload())
+    assert out["status"] == "no_op" and "not allowlisted" in out["reason"]
+    mock_eval.assert_not_called()
+
+
+def test_installation_created_records_row():
+    payload = {
+        "action": "created",
+        "installation": {
+            "id": 555,
+            "account": {"login": "githumps", "type": "User", "id": 100},
+        },
+        "sender": {"id": 100, "login": "githumps"},
+    }
+    with patch("dispatcher.record_installation") as mock_rec:
+        out = dispatch("installation", payload)
+    assert out["status"] == "recorded" and out["action"] == "created"
+    mock_rec.assert_called_once_with(
+        install_id=555, account_login="githumps", account_type="User",
+        installed_by_user_id=100,
+    )
+
+
+def test_installation_created_org_uses_sender_id():
+    """Org installs: installed_by must be the human sender, not the org."""
+    payload = {
+        "action": "created",
+        "installation": {
+            "id": 555,
+            "account": {"login": "acme-org", "type": "Organization", "id": 9},
+        },
+        "sender": {"id": 100, "login": "evan"},
+    }
+    with patch("dispatcher.record_installation") as mock_rec:
+        dispatch("installation", payload)
+    assert mock_rec.call_args.kwargs["installed_by_user_id"] == 100
+
+
+def test_installation_deleted_removes_row():
+    payload = {"action": "deleted", "installation": {"id": 555}}
+    with patch("dispatcher.delete_installation") as mock_del:
+        out = dispatch("installation", payload)
+    assert out["status"] == "recorded" and out["action"] == "deleted"
+    mock_del.assert_called_once_with(555)
+
+
+def test_installation_no_id_skips():
+    out = dispatch("installation", {"action": "created", "installation": {}})
+    assert out["status"] == "skip"
+
+
+def test_installation_unhandled_action():
+    out = dispatch("installation", {"action": "suspend", "installation": {"id": 1}})
+    assert out["status"] == "no_op" and "suspend" in out["reason"]

--- a/services/webhook/tests/test_install_store.py
+++ b/services/webhook/tests/test_install_store.py
@@ -1,0 +1,122 @@
+"""Tests for install_store + allowlist gate.
+
+Uses moto to spin a local DDB so adapter logic runs against a real
+boto3 table — closer to prod than naive mock objects (matches
+`feedback_no_coding_by_analogy` — verify against ground-truth shape).
+"""
+
+from __future__ import annotations
+
+import os
+
+import boto3
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _ddb_table(monkeypatch):
+    """Spin a moto DDB grug-main with the production schema."""
+    moto = pytest.importorskip("moto")
+    from moto import mock_aws  # type: ignore
+
+    with mock_aws():
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+        monkeypatch.setenv("GRUG_DDB_TABLE", "grug-main-test")
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName="grug-main-test",
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "GSI1",
+                    "KeySchema": [
+                        {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                        {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                },
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        # Re-import after env-var set so module-scope _table picks up new name.
+        import importlib
+        import adapters.install_store as mod
+        importlib.reload(mod)
+        yield mod
+
+
+def test_record_then_lookup(_ddb_table):
+    mod = _ddb_table
+    mod.record_installation(
+        install_id=42, account_login="evan", account_type="User",
+        installed_by_user_id=99,
+    )
+    inst = mod.get_installation(42)
+    assert inst["account_login"] == "evan"
+    assert inst["installed_by_user_id"] == "99"
+
+
+def test_delete_installation(_ddb_table):
+    mod = _ddb_table
+    mod.record_installation(
+        install_id=42, account_login="x", account_type="User",
+        installed_by_user_id=1,
+    )
+    mod.delete_installation(42)
+    assert mod.get_installation(42) is None
+
+
+def test_allowlist_unknown_install_returns_false(_ddb_table):
+    assert _ddb_table.is_install_allowlisted(404) is False
+
+
+def test_allowlist_user_not_allowlisted_returns_false(_ddb_table):
+    mod = _ddb_table
+    mod.record_installation(
+        install_id=10, account_login="bob", account_type="User",
+        installed_by_user_id=200,
+    )
+    # USER#200 row missing entirely — should still return False, not crash.
+    assert mod.is_install_allowlisted(10) is False
+
+
+def test_allowlist_user_explicitly_false(_ddb_table):
+    mod = _ddb_table
+    table = boto3.resource("dynamodb", region_name="us-east-1").Table("grug-main-test")
+    table.put_item(Item={"PK": "USER#200", "SK": "META", "allowlisted": False})
+    mod.record_installation(
+        install_id=10, account_login="bob", account_type="User",
+        installed_by_user_id=200,
+    )
+    assert mod.is_install_allowlisted(10) is False
+
+
+def test_allowlist_user_true(_ddb_table):
+    mod = _ddb_table
+    table = boto3.resource("dynamodb", region_name="us-east-1").Table("grug-main-test")
+    table.put_item(Item={"PK": "USER#200", "SK": "META", "allowlisted": True})
+    mod.record_installation(
+        install_id=10, account_login="bob", account_type="User",
+        installed_by_user_id=200,
+    )
+    assert mod.is_install_allowlisted(10) is True
+
+
+def test_record_idempotent(_ddb_table):
+    """Re-recording the same install must not error."""
+    mod = _ddb_table
+    for _ in range(3):
+        mod.record_installation(
+            install_id=10, account_login="bob", account_type="User",
+            installed_by_user_id=200,
+        )
+    assert mod.get_installation(10)["account_login"] == "bob"


### PR DESCRIPTION
## Why

Slice 5 of [#21](https://github.com/githumps/grug/issues/21). Closes #26. Stacked on PR #40.

App registration is public (anyone can install Grug Boss on their repos). v1 needs a second-layer gate so only admin-approved installers actually trigger persona work — limits LLM/cost blast radius and keeps Grug invisible to non-allowlisted repos until invited.

## Acceptance criteria

- [x] \`adapters/install_store.py\` (mirrored to api): record/delete/get install rows + \`is_install_allowlisted()\` two-hop INST# → USER# lookup; webhook-safe (no KMS)
- [x] Dispatcher handles \`installation\` events (created/deleted/new_permissions_accepted/unsuspend) — org installs use sender.id (the human), not org account.id
- [x] \`pull_request\` events gate on \`is_install_allowlisted()\` BEFORE TPM dispatch — non-allowlisted = no_op silently, ZERO GitHub API calls
- [x] Pulumi: webhook Lambda gets \`GRUG_DDB_TABLE\` env + \`grug-webhook-ddb-policy\` IAM (GetItem + PutItem + DeleteItem only, NO KMS, NO Query)
- [x] OIDC trust + CI trigger widened to \`feat/26-*\` (chicken-egg gotcha; applied locally before push)
- [x] \`infra/scripts/seed-admin.py\` — idempotent admin USER# seed + optional INST# backfill flag for Apps installed before Slice 5 shipped
- [x] Already-seeded for live env: USER#59060157 (githumps, admin) + INST#129256114 (Evan's install across 12 repos)
- [x] 47 tests pass (7 new install_store via moto DDB, 6 new dispatcher scenarios)

## Test plan

- [ ] CI green — webhook image builds, Pulumi up succeeds, Lambda image rolls forward
- [ ] Live: push commit to PR #40 (or this PR) → check-run still appears (Evan's install allowlisted)
- [ ] Live negative: query DDB for non-allowlisted scenario — INST#129256114 with allowlisted=False → push commit → no check-run posted
- [ ] DD logs show \`allowlist_gate_skip\` for blocked PRs and \`webhook_dispatched persona=tpm\` for allowed PRs
- [ ] Future install events from a 2nd test installer record INST# row + remain blocked until admin allowlists

## Out of scope

- Admin UI for flipping allowlisted (Slice 8 / #29)
- Per-repo persona toggles (Slice 7 / #28)
- App suspend/unsuspend handling beyond record (acceptable v1 — \`unsuspend\` re-records, \`suspend\` unhandled is harmless since allowlist still gates)

**Size:** M

🤖 Generated with [Claude Code](https://claude.com/claude-code)