### PR TITLE
fix(api): bind gh_id into session HMAC — CRITICAL hotfix (Sentry + Codex on PR #39)

### DIFF
--- a/services/api/auth/github_oauth.py
+++ b/services/api/auth/github_oauth.py
@@ -78,6 +78,54 @@ def _verify_state(state: str) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Session token (separate format from CSRF state)
+# ---------------------------------------------------------------------------
+# Token = `<rand>.<ts>.<gh_id>.<hmac(rand.ts.gh_id)>`. Critical: gh_id is
+# bound INSIDE the signed payload — without that, a holder of any valid
+# session can swap the trailing component to impersonate any user. (Codex
+# post-hoc P1 + Sentry CRITICAL on PR #39 / Slice 3.)
+#
+# Also separates session TTL (7 days) from the 10-minute CSRF state TTL.
+# Earlier code used `_verify_state` for sessions which silently truncated
+# the cookie's intended 7-day lifetime to 10 minutes (Sentry CRITICAL).
+_SESSION_TTL_SECONDS = 86400 * 7  # 7 days
+
+
+def _make_session(gh_id: str) -> str:
+    rand = secrets.token_urlsafe(16)
+    ts = str(int(time.time()))
+    sig = hmac.new(
+        _state_secret().encode(),
+        f"{rand}.{ts}.{gh_id}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{rand}.{ts}.{gh_id}.{sig}"
+
+
+def _verify_session(token: str) -> str | None:
+    """Returns the GitHub user id on success, None on any failure."""
+    if not token:
+        return None
+    parts = token.split(".")
+    if len(parts) != 4:
+        return None
+    rand, ts, gh_id, sig = parts
+    expected = hmac.new(
+        _state_secret().encode(),
+        f"{rand}.{ts}.{gh_id}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(expected, sig):
+        return None
+    try:
+        if int(time.time()) - int(ts) > _SESSION_TTL_SECONDS:
+            return None
+    except ValueError:
+        return None
+    return gh_id
+
+
 def _client_id() -> str:
     from secrets_loader import _get_ssm_secure_string  # type: ignore
     name = os.environ.get("GITHUB_APP_CLIENT_ID_SSM", "")
@@ -168,14 +216,17 @@ def callback(
                "allowlisted": user.allowlisted, "role": user.role},
     )
 
-    # Set session cookie (signed gh_id + ts; stateless)
-    session_value = _make_state() + "." + gh_id  # rand.ts.sig.gh_id
+    # Set session cookie. Format binds gh_id INSIDE the HMAC payload —
+    # see _make_session docstring for the impersonation attack the
+    # earlier `_make_state() + "." + gh_id` was vulnerable to.
+    session_value = _make_session(gh_id)
     target = _DASHBOARD_URL if user.allowlisted else _WAITLIST_URL
     resp = RedirectResponse(url=target, status_code=302)
     resp.delete_cookie("grug_oauth_state")
     resp.set_cookie(
         "grug_session", session_value,
-        max_age=86400 * 7, httponly=True, secure=True, samesite="lax",
+        max_age=_SESSION_TTL_SECONDS,
+        httponly=True, secure=True, samesite="lax",
     )
     return resp
 
@@ -183,13 +234,8 @@ def callback(
 @router.get("/me")
 def me(grug_session: str = Cookie(default="")) -> dict[str, str | bool]:
     """Current user. Always 200 (auth'd or anon). SPA routes by `allowlisted`."""
-    if not grug_session:
-        return {"authenticated": False}
-    parts = grug_session.split(".")
-    if len(parts) != 4:
-        return {"authenticated": False}
-    rand, ts, sig, gh_id = parts
-    if not _verify_state(f"{rand}.{ts}.{sig}"):
+    gh_id = _verify_session(grug_session)
+    if gh_id is None:
         return {"authenticated": False}
 
     user = get_user(gh_id)

--- a/services/api/tests/test_session_signing.py
+++ b/services/api/tests/test_session_signing.py
@@ -1,0 +1,82 @@
+"""Regression tests for session HMAC binding.
+
+Earlier session format `rand.ts.sig.gh_id` left gh_id outside the HMAC,
+so any holder of a valid session could swap the trailing component to
+impersonate any user. New format binds gh_id into the signature.
+
+Sentry CRITICAL + Codex P1 on PR #39 / Slice 3.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_secret(monkeypatch):
+    """Avoid real SSM in unit tests by stubbing the state secret loader."""
+    monkeypatch.setenv("GITHUB_APP_WEBHOOK_SECRET_SSM", "/test/secret")
+    with patch(
+        "auth.github_oauth._state_secret",
+        return_value="unit-test-secret-do-not-deploy",
+    ):
+        yield
+
+
+def test_make_then_verify_session_round_trip():
+    from auth.github_oauth import _make_session, _verify_session
+    tok = _make_session("12345")
+    assert _verify_session(tok) == "12345"
+
+
+def test_swap_gh_id_invalidates_signature():
+    """The impersonation attack: take a valid session, swap gh_id."""
+    from auth.github_oauth import _make_session, _verify_session
+    tok = _make_session("12345")
+    rand, ts, _gh_id, sig = tok.split(".")
+    forged = f"{rand}.{ts}.99999.{sig}"
+    assert _verify_session(forged) is None
+
+
+def test_swap_signature_invalidates():
+    from auth.github_oauth import _make_session, _verify_session
+    tok = _make_session("12345")
+    rand, ts, gh_id, _sig = tok.split(".")
+    forged = f"{rand}.{ts}.{gh_id}.{'0' * 64}"
+    assert _verify_session(forged) is None
+
+
+def test_old_three_part_state_token_rejected():
+    """An attacker might try to pass the CSRF state cookie as a session."""
+    from auth.github_oauth import _make_state, _verify_session
+    state = _make_state()  # rand.ts.sig (3 parts, no gh_id)
+    assert _verify_session(state) is None
+
+
+def test_empty_or_malformed_returns_none():
+    from auth.github_oauth import _verify_session
+    assert _verify_session("") is None
+    assert _verify_session("a.b.c") is None
+    assert _verify_session("a.b.c.d.e") is None
+    assert _verify_session("a.b.c.d") is None  # bad sig + ts
+
+
+def test_expired_session_rejected(monkeypatch):
+    from auth.github_oauth import _make_session, _verify_session
+    import auth.github_oauth as mod
+
+    tok = _make_session("12345")
+    # Fast-forward past 7-day TTL (+1s safety margin)
+    real_time = __import__("time").time
+    monkeypatch.setattr(mod.time, "time", lambda: real_time() + mod._SESSION_TTL_SECONDS + 1)
+    assert _verify_session(tok) is None
+
+
+def test_csrf_state_still_3_parts_unaffected():
+    """Make sure the session refactor didn't break OAuth CSRF state."""
+    from auth.github_oauth import _make_state, _verify_state
+    state = _make_state()
+    assert state.count(".") == 2
+    assert _verify_state(state) is True


### PR DESCRIPTION
## Why

Sentry CRITICAL + Codex P1 on already-merged [PR #39 / Slice 3](https://github.com/githumps/grug/pull/39):

> When a user has any valid grug_session, the HMAC only covers rand.ts, while gh_id is appended outside the signature. A signed-in attacker can edit the final cookie segment to another GitHub user id and /me will load that user's row.

Sentry CRITICAL also flagged the cookie's 7-day max_age vs the 10-min _verify_state TTL — sessions silently truncated to 10min.

Both shipped on main with the merge of PR #39 on 2026-05-03.

**Mitigating factor**: zero users have OAuth-signed-in yet (only the App webhook flow has fired). Attack surface = empty until first sign-in. Closing pre-emptively.

Part of #21.

## Acceptance criteria

- [x] _make_session(gh_id) / _verify_session(token) — gh_id INSIDE the HMAC payload
- [x] Cookie TTL constant separate from CSRF state TTL (7 days vs 10 min)
- [x] /me + callback both use the new functions
- [x] 7 regression tests covering swap-attack, expired session, cross-token confusion
- [x] All tests pass locally
- [x] Codex review clean

## Test plan

- [ ] CI green
- [ ] Live: re-deploy → POST any forged session w/ swapped gh_id → /me returns authenticated:false (not the impersonated user)

## Out of scope

- FastAPI dependency-injected get_current_user / require_authenticated / require_admin (lands in [PR #43 / Slice 7](https://github.com/githumps/grug/pull/43))
- /waitlist route removal + SignOutButton — Slice 7 fixes

**Size:** S

🤖 Generated with [Claude Code](https://claude.com/claude-code)