### PR TITLE
fix(#50): wrap api install-token calls in 401-retry helper

### DIFF
--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -35,7 +35,7 @@ from adapters.install_store import (
 )
 from adapters.user_store import User
 from auth.dependencies import require_authenticated
-from github_app_auth import get_install_token
+from github_app_auth import get_install_token, with_install_token_retry
 
 log = logging.getLogger("grug.api.installations")
 
@@ -90,40 +90,47 @@ def list_install_repos(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="install not found")
     _ensure_can_access(install, user)
 
-    token = get_install_token(install_id)
-    repos: list[dict[str, Any]] = []
-    page = 1
-    with httpx.Client(timeout=10) as client:
-        while True:
-            resp = client.get(
-                f"{_GH_API}/installation/repositories",
-                headers={
-                    "Authorization": f"token {token}",
-                    "Accept": "application/vnd.github+json",
-                },
-                params={"per_page": 100, "page": page},
-            )
-            resp.raise_for_status()
-            body = resp.json()
-            for r in body.get("repositories", []):
-                cfg = get_repo_config(install_id, r["id"])
-                repos.append({
-                    "repo_id": r["id"],
-                    "full_name": r["full_name"],
-                    "private": r.get("private", False),
-                    "default_branch": r.get("default_branch", "main"),
-                    "config": cfg,
-                })
-            if len(body.get("repositories", [])) < 100:
-                break
-            page += 1
-            if page > 10:  # 1000 repos is plenty for v1
-                log.warning(
-                    "list_repos_pagination_cap",
-                    extra={"install_id": install_id, "user": user.login},
+    # Wrapped in with_install_token_retry so a 401 from GitHub
+    # (App reinstall, perm change, secret rotation revoking the cached
+    # token mid-warm-container) invalidates the cache + re-fetches
+    # before retry. Otherwise the warm Lambda burns the bad token for
+    # up to 55min. Closes #50.
+    def _fetch(token: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        page = 1
+        with httpx.Client(timeout=10) as client:
+            while True:
+                resp = client.get(
+                    f"{_GH_API}/installation/repositories",
+                    headers={
+                        "Authorization": f"token {token}",
+                        "Accept": "application/vnd.github+json",
+                    },
+                    params={"per_page": 100, "page": page},
                 )
-                break
+                resp.raise_for_status()
+                body = resp.json()
+                for r in body.get("repositories", []):
+                    cfg = get_repo_config(install_id, r["id"])
+                    out.append({
+                        "repo_id": r["id"],
+                        "full_name": r["full_name"],
+                        "private": r.get("private", False),
+                        "default_branch": r.get("default_branch", "main"),
+                        "config": cfg,
+                    })
+                if len(body.get("repositories", [])) < 100:
+                    break
+                page += 1
+                if page > 10:  # 1000 repos is plenty for v1
+                    log.warning(
+                        "list_repos_pagination_cap",
+                        extra={"install_id": install_id, "user": user.login},
+                    )
+                    break
+        return out
 
+    repos = with_install_token_retry(install_id, _fetch)
     return {"repos": repos}
 
 
@@ -148,34 +155,33 @@ def update_repo_config(
     # Now enumerate via `GET /installation/repositories` (the dedicated
     # endpoint that lists ONLY this install's repos) and verify
     # membership.
-    token = get_install_token(install_id)
-    full_name = ""
-    found = False
-    page = 1
-    with httpx.Client(timeout=10) as client:
-        while not found:
-            resp = client.get(
-                f"{_GH_API}/installation/repositories",
-                headers={
-                    "Authorization": f"token {token}",
-                    "Accept": "application/vnd.github+json",
-                },
-                params={"per_page": 100, "page": page},
-            )
-            resp.raise_for_status()
-            body_json = resp.json()
-            for r in body_json.get("repositories", []):
-                if r["id"] == repo_id:
-                    found = True
-                    full_name = r["full_name"]
-                    break
-            if found or len(body_json.get("repositories", [])) < 100:
-                break
-            page += 1
-            # No page cap — single-repo membership lookup must scan all
-            # pages on large org installs (>1000 repos). Codex P2
-            # follow-up to the Sentry CRITICAL fix. Worst case ~Npages*
-            # 100ms; acceptable for an admin write path.
+    # Wrapped in with_install_token_retry — see list_repos above.
+    def _lookup(token: str) -> tuple[bool, str]:
+        page = 1
+        with httpx.Client(timeout=10) as client:
+            while True:
+                resp = client.get(
+                    f"{_GH_API}/installation/repositories",
+                    headers={
+                        "Authorization": f"token {token}",
+                        "Accept": "application/vnd.github+json",
+                    },
+                    params={"per_page": 100, "page": page},
+                )
+                resp.raise_for_status()
+                body_json = resp.json()
+                for r in body_json.get("repositories", []):
+                    if r["id"] == repo_id:
+                        return True, r["full_name"]
+                if len(body_json.get("repositories", [])) < 100:
+                    return False, ""
+                page += 1
+                # No page cap — single-repo membership lookup must scan
+                # all pages on large org installs (>1000 repos). Codex
+                # P2 follow-up to the Sentry CRITICAL fix. Worst case
+                # ~Npages*100ms; acceptable for an admin write path.
+
+    found, full_name = with_install_token_retry(install_id, _lookup)
     if not found:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="repo not visible to install")
 

--- a/services/api/tests/test_install_token_retry.py
+++ b/services/api/tests/test_install_token_retry.py
@@ -1,0 +1,83 @@
+"""Regression test for #50 — `with_install_token_retry` must invalidate
+the cache + re-fetch on httpx 401, then retry once.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import github_app_auth as gh_auth
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    @property
+    def text(self) -> str:
+        return ""
+
+
+@pytest.fixture(autouse=True)
+def _stub_token(monkeypatch: pytest.MonkeyPatch):
+    """Avoid SSM + JWT signing — return a sentinel token per call."""
+    counter = {"n": 0}
+
+    def fake_get(installation_id: int, *, force_refresh: bool = False) -> str:
+        counter["n"] += 1
+        return f"token-{counter['n']}-refresh={force_refresh}"
+
+    monkeypatch.setattr(gh_auth, "get_install_token", fake_get)
+    return counter
+
+
+def test_retry_on_401_invalidates_and_refetches(_stub_token):
+    calls: list[str] = []
+
+    def fn(token: str) -> str:
+        calls.append(token)
+        if len(calls) == 1:
+            raise httpx.HTTPStatusError(
+                "401",
+                request=httpx.Request("GET", "https://api.github.com/repos"),
+                response=httpx.Response(401),
+            )
+        return "ok"
+
+    result = gh_auth.with_install_token_retry(123, fn)
+
+    assert result == "ok"
+    assert len(calls) == 2, "fn must be called twice (once + retry)"
+    assert calls[0] == "token-1-refresh=False", "first call uses cached token"
+    assert calls[1] == "token-2-refresh=True", \
+        "retry must force_refresh — otherwise cache returns same bad token"
+
+
+def test_non_401_status_propagates_without_retry(_stub_token):
+    calls: list[str] = []
+
+    def fn(token: str) -> str:
+        calls.append(token)
+        raise httpx.HTTPStatusError(
+            "500",
+            request=httpx.Request("GET", "https://api.github.com/repos"),
+            response=httpx.Response(500),
+        )
+
+    with pytest.raises(httpx.HTTPStatusError) as ei:
+        gh_auth.with_install_token_retry(123, fn)
+    assert ei.value.response.status_code == 500
+    assert len(calls) == 1, "non-401 must NOT retry"
+
+
+def test_success_first_try_does_not_refresh(_stub_token):
+    calls: list[str] = []
+
+    def fn(token: str) -> str:
+        calls.append(token)
+        return "ok"
+
+    assert gh_auth.with_install_token_retry(123, fn) == "ok"
+    assert len(calls) == 1
+    assert calls[0] == "token-1-refresh=False"

--- a/services/webhook/tests/test_install_token_retry.py
+++ b/services/webhook/tests/test_install_token_retry.py
@@ -1,0 +1,83 @@
+"""Regression test for #50 — `with_install_token_retry` must invalidate
+the cache + re-fetch on httpx 401, then retry once.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import github_app_auth as gh_auth
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    @property
+    def text(self) -> str:
+        return ""
+
+
+@pytest.fixture(autouse=True)
+def _stub_token(monkeypatch: pytest.MonkeyPatch):
+    """Avoid SSM + JWT signing — return a sentinel token per call."""
+    counter = {"n": 0}
+
+    def fake_get(installation_id: int, *, force_refresh: bool = False) -> str:
+        counter["n"] += 1
+        return f"token-{counter['n']}-refresh={force_refresh}"
+
+    monkeypatch.setattr(gh_auth, "get_install_token", fake_get)
+    return counter
+
+
+def test_retry_on_401_invalidates_and_refetches(_stub_token):
+    calls: list[str] = []
+
+    def fn(token: str) -> str:
+        calls.append(token)
+        if len(calls) == 1:
+            raise httpx.HTTPStatusError(
+                "401",
+                request=httpx.Request("GET", "https://api.github.com/repos"),
+                response=httpx.Response(401),
+            )
+        return "ok"
+
+    result = gh_auth.with_install_token_retry(123, fn)
+
+    assert result == "ok"
+    assert len(calls) == 2, "fn must be called twice (once + retry)"
+    assert calls[0] == "token-1-refresh=False", "first call uses cached token"
+    assert calls[1] == "token-2-refresh=True", \
+        "retry must force_refresh — otherwise cache returns same bad token"
+
+
+def test_non_401_status_propagates_without_retry(_stub_token):
+    calls: list[str] = []
+
+    def fn(token: str) -> str:
+        calls.append(token)
+        raise httpx.HTTPStatusError(
+            "500",
+            request=httpx.Request("GET", "https://api.github.com/repos"),
+            response=httpx.Response(500),
+        )
+
+    with pytest.raises(httpx.HTTPStatusError) as ei:
+        gh_auth.with_install_token_retry(123, fn)
+    assert ei.value.response.status_code == 500
+    assert len(calls) == 1, "non-401 must NOT retry"
+
+
+def test_success_first_try_does_not_refresh(_stub_token):
+    calls: list[str] = []
+
+    def fn(token: str) -> str:
+        calls.append(token)
+        return "ok"
+
+    assert gh_auth.with_install_token_retry(123, fn) == "ok"
+    assert len(calls) == 1
+    assert calls[0] == "token-1-refresh=False"


### PR DESCRIPTION
Closes #50.

## Why

Codex post-Slice-4 review: `get_install_token(install_id)` returns a 55-min cached token. If GitHub revokes that token mid-TTL — App reinstall, permission change, secret rotation — every subsequent warm-Lambda call burns the bad token and 401s. The retry helper exists in `github_app_auth` already (built in Slice 4) but `services/api/installations.py` wasn't using it on its two GitHub call sites.

## Acceptance criteria

- [x] api/installations.list_repos uses `with_install_token_retry`
- [x] api/installations.update_repo_config repo-membership lookup uses `with_install_token_retry`
- [x] Test: 401-then-200 → exactly 2 fn calls, second uses force_refresh=True
- [x] Test: non-401 status → no retry, propagates
- [x] Test: success on first try → no retry
- [x] Mirror tests in services/api/tests + services/webhook/tests

## Test plan

- [ ] CI green
- [ ] Manual: revoke install in GH UI mid-session, hit /api/v1/installations/{id}/repos, expect 200 (not 401) on second tick

## Out of scope

- Adding the wrapper to webhook persona (already wrapped — Slice 4 verified above)
- DdbTokenCache for cross-container invalidation (post-MVP per PRD #21 Q17)

**Size:** S