### PR TITLE
fix(#68): webhook handler async → sync, blocks-loop hazard

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -237,3 +237,13 @@ Note: KMS CMK enters 7-day pending-deletion. Within that window, `pulumi up` aga
 | `GRUG_ADMIN_INSTALL_ID` | 129256114 | INST# row to backfill (skip on org-account migrations where install_id changed) |
 
 Override per-recovery: `GRUG_ADMIN_USER_ID=123 make rebuild`
+
+## Architecture decisions
+
+### Sync-vs-async route handlers
+
+Webhook handler `receive_github_webhook` is **sync `def`**, NOT `async def`.
+
+**Why**: every downstream call is sync I/O (boto3 DynamoDB, sync httpx GitHub posts, sync KMS via `crypto.kms_envelope`). An `async def` handler would block the event loop on each ~30-500ms call. FastAPI runs sync `def` handlers in a threadpool via Starlette's `run_in_threadpool`, so concurrent invocations don't starve each other.
+
+**Re-evaluate when**: we add genuine concurrent-fan-out (e.g. parallel GitHub calls for multi-repo PR scans via `asyncio.gather`). At that point migrate the relevant section to `httpx.AsyncClient` + `aioboto3` and switch the handler back to `async def`. Closes #68.

--- a/services/webhook/main.py
+++ b/services/webhook/main.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import os
 
-from fastapi import FastAPI, Header, HTTPException, Request, status
+from fastapi import Body, FastAPI, Header, HTTPException, status
 
 from hmac_verify import verify_signature
 from observability import configure_logging
@@ -51,13 +51,20 @@ def readyz() -> dict[str, str]:
 
 
 @app.post("/webhook/github")
-async def receive_github_webhook(
-    request: Request,
+def receive_github_webhook(
+    body: bytes = Body(...),
     x_github_event: str = Header(default=""),
     x_github_delivery: str = Header(default=""),
     x_hub_signature_256: str = Header(default=""),
 ) -> dict[str, str]:
-    body = await request.body()
+    # Handler is `def`, not `async def`. Every downstream call (DDB
+    # boto3, httpx GitHub posts, KMS) is sync I/O — running them on
+    # the asyncio event loop blocks every other coroutine in the
+    # process. FastAPI runs sync `def` handlers in a threadpool via
+    # Starlette's run_in_threadpool, so concurrent invocations don't
+    # starve each other. Mangum supports both signatures.
+    # Body injected via `bytes = Body(...)` (raw body, no JSON parse)
+    # because HMAC verify needs the exact wire bytes. Closes #68.
 
     secret = get_webhook_secret()
     if not verify_signature(secret, body, x_hub_signature_256):


### PR DESCRIPTION
Closes #68.

## Why

Graphify audit caught webhook handler as `async def` while every downstream call is sync I/O (boto3 DDB, sync httpx GitHub posts, sync KMS). Current zero impact (1-coroutine Lambda) but a future fan-out, batch, or concurrency bump turns this into a latency multiplier.

Picked option A from the issue (drop async). Cleanest, no library swap.

## Acceptance criteria

- [x] receive_github_webhook: `async def` → `def`
- [x] Body via `bytes = Body(...)` (raw, not JSON-parsed — HMAC needs wire bytes)
- [x] Imports: drop Request, add Body
- [x] RUNBOOK 'Architecture decisions' section documents the choice + re-evaluate trigger

## Test plan

- [ ] CI green (unit tests don't exercise the handler directly; CI deploys + smoke)
- [ ] Manual post-deploy: fire a fake `pull_request` payload from GH, check DD APM trace shows handler runs in threadpool

## Out of scope

- `async def` in services/api/crypto/kms_envelope.py — those internal helpers are MIRRORED from somatic-scripts/pasto-api and unused locally; leave alone for the rule-of-three extraction
- Migrating to async libs (option C) — re-evaluate when fan-out lands

**Size:** S