### PR TITLE
feat(#66): drift-lint CI for paired services/api/ + services/webhook/ files

### DIFF
--- a/.github/workflows/drift-lint.yml
+++ b/.github/workflows/drift-lint.yml
@@ -1,0 +1,28 @@
+name: Drift lint · paired services/ files
+
+# Closes #66. Catches accidental one-side edits when services/api/ +
+# services/webhook/ duplicate-file pattern (PRD #21 v1 trade-off) drifts.
+# Replace with a real shared-package extraction at v1.5.
+
+on:
+  pull_request:
+    paths:
+      - 'services/api/**'
+      - 'services/webhook/**'
+      - 'scripts/check-mirrored-files.sh'
+      - '.github/workflows/drift-lint.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/api/**'
+      - 'services/webhook/**'
+      - 'scripts/check-mirrored-files.sh'
+
+jobs:
+  drift-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Check mirrored services/api/ + services/webhook/ files
+        run: bash scripts/check-mirrored-files.sh

--- a/.github/workflows/drift-lint.yml
+++ b/.github/workflows/drift-lint.yml
@@ -4,6 +4,9 @@ name: Drift lint · paired services/ files
 # services/webhook/ duplicate-file pattern (PRD #21 v1 trade-off) drifts.
 # Replace with a real shared-package extraction at v1.5.
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -247,3 +247,19 @@ Webhook handler `receive_github_webhook` is **sync `def`**, NOT `async def`.
 **Why**: every downstream call is sync I/O (boto3 DynamoDB, sync httpx GitHub posts, sync KMS via `crypto.kms_envelope`). An `async def` handler would block the event loop on each ~30-500ms call. FastAPI runs sync `def` handlers in a threadpool via Starlette's `run_in_threadpool`, so concurrent invocations don't starve each other.
 
 **Re-evaluate when**: we add genuine concurrent-fan-out (e.g. parallel GitHub calls for multi-repo PR scans via `asyncio.gather`). At that point migrate the relevant section to `httpx.AsyncClient` + `aioboto3` and switch the handler back to `async def`. Closes #68.
+
+### Mirrored files between services/api/ + services/webhook/
+
+Both Lambda services duplicate ~12 modules (adapters, ports, personas,
+github_app_auth, etc.) until the v1.5 shared-package extraction lands.
+
+`.github/workflows/drift-lint.yml` runs `scripts/check-mirrored-files.sh`
+on every PR touching either service. The script byte-compares each file
+in `MIRRORED_FILES` and fails with a clear diff when they diverge.
+
+When you patch a mirrored file, ALWAYS apply the same change to both
+copies. The lint catches misses at PR time.
+
+Files that intentionally diverge (FastAPI app, Lambda handler entrypoint,
+logger name) are simply not in `MIRRORED_FILES` — the allowlist is
+opt-in by omission. Closes #66.

--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Drift-detection lint for files that MUST stay byte-identical between
+# services/api/ and services/webhook/. Closes #66.
+#
+# v1 trade-off (PRD #21): both Lambda services duplicate shared modules
+# instead of importing from a shared package. Until extraction lands,
+# this script catches accidental one-side edits at PR time.
+#
+# Files that intentionally differ (FastAPI app, lambda handler entrypoint,
+# logger name) are NOT in MIRRORED_FILES — they're allowlisted to diverge.
+#
+# Add new mirrored files to MIRRORED_FILES below. Add intentionally-
+# diverging files NOWHERE — they're skipped by omission.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MIRRORED_FILES=(
+  "adapters/__init__.py"
+  "adapters/install_store.py"
+  "conftest.py"
+  "github_app_auth/__init__.py"
+  "github_checks_client.py"
+  "observability.py"
+  "personas/__init__.py"
+  "personas/tpm/__init__.py"
+  "personas/tpm/dor_checks.py"
+  "ports/__init__.py"
+  "ports/token_cache.py"
+  "secrets_loader.py"
+)
+
+DIVERGED=()
+MISSING=()
+
+for f in "${MIRRORED_FILES[@]}"; do
+  api="services/api/$f"
+  webhook="services/webhook/$f"
+  if [ ! -f "$api" ]; then
+    MISSING+=("$api")
+    continue
+  fi
+  if [ ! -f "$webhook" ]; then
+    MISSING+=("$webhook")
+    continue
+  fi
+  if ! diff -q "$api" "$webhook" >/dev/null 2>&1; then
+    DIVERGED+=("$f")
+  fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo "ERROR: missing mirror files (one side absent):"
+  for m in "${MISSING[@]}"; do echo "  - $m"; done
+  echo
+  echo "Either remove from MIRRORED_FILES in scripts/check-mirrored-files.sh"
+  echo "OR create the missing copy."
+  exit 2
+fi
+
+if [ ${#DIVERGED[@]} -gt 0 ]; then
+  echo "ERROR: paired files diverged between services/api/ + services/webhook/:"
+  for d in "${DIVERGED[@]}"; do
+    echo
+    echo "=== $d ==="
+    diff -u "services/api/$d" "services/webhook/$d" | head -50
+  done
+  echo
+  echo "Both copies must stay byte-identical (PRD #21 v1 duplicate-file pattern)."
+  echo "Apply the same change to both. Until shared-package extraction lands,"
+  echo "this lint catches accidental one-side edits."
+  exit 1
+fi
+
+echo "OK: ${#MIRRORED_FILES[@]} mirrored file pairs are byte-identical."


### PR DESCRIPTION
Closes #66.

## Why

Greptile P2 PR #41: services/api/adapters/install_store.py and services/webhook/adapters/install_store.py are byte-identical, but no tooling catches drift if a maintainer edits only one side.

PRD #21 v1 trade-off: extract to shared package later. Short-term win is a CI drift-lint. v1.5 tracking issue #77 filed for the real extraction.

## Acceptance criteria

- [x] scripts/check-mirrored-files.sh byte-compares 12 paired modules
- [x] Clear diff output naming both files when they diverge
- [x] CI workflow runs on PRs + pushes touching either service
- [x] RUNBOOK section documents allowlist-by-omission semantics
- [x] v1.5 ticket #77 filed for shared-package extraction

## Test plan

- [ ] CI green on this PR (script returns 'OK: 12 mirrored file pairs are byte-identical')
- [ ] Manual: edit one side of adapters/install_store.py, push, expect drift-lint to fail with diff

## Out of scope

- Real shared-package extraction (#77, v1.5)

**Size:** S