### PR TITLE
fix(#60): KMS-encrypt Lambda env vars at rest (DD_API_KEY)

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -183,19 +183,22 @@ webhook = lambda_service.create(
 # BEFORE the DD extension or our handler boots. Scoped via
 # `kms:ViaService = lambda` so this perm can't be reused for other
 # KMS-protected resources. Closes #60.
+# Region resolved from the active aws provider so a future multi-region
+# deploy doesn't silently break this condition. Greptile P2 PR #79.
+_aws_region = aws.get_region().name
 aws.iam.RolePolicy(
     "grug-webhook-envvar-kms-policy",
     role=webhook.role.id,
-    policy=grug_tokens_cmk.arn.apply(
-        lambda arn: json.dumps({
+    policy=pulumi.Output.all(grug_tokens_cmk.arn, _aws_region).apply(
+        lambda args: json.dumps({
             "Version": "2012-10-17",
             "Statement": [{
                 "Effect": "Allow",
                 "Action": "kms:Decrypt",
-                "Resource": arn,
+                "Resource": args[0],
                 "Condition": {
                     "StringEquals": {
-                        "kms:ViaService": "lambda.us-east-1.amazonaws.com",
+                        "kms:ViaService": f"lambda.{args[1]}.amazonaws.com",
                     },
                 },
             }],

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -16,6 +16,8 @@ provider config).
 
 from __future__ import annotations
 
+import json
+
 import pulumi
 import pulumi_aws as aws
 import pulumi_cloudflare as cloudflare
@@ -169,6 +171,36 @@ webhook = lambda_service.create(
     },
     timeout_seconds=15,
     memory_mb=512,
+    # Encrypt env vars (DD_API_KEY in particular) at rest so a reader
+    # with `lambda:GetFunctionConfiguration` alone can't recover the
+    # plaintext API key. Closes #60. Webhook role granted kms:Decrypt
+    # via the additional inline policy below.
+    env_vars_kms_key_arn=grug_tokens_cmk.arn,
+)
+
+# Webhook role gains kms:Decrypt on the grug-tokens CMK — required so
+# the Lambda runtime can unwrap encrypted env vars at cold start
+# BEFORE the DD extension or our handler boots. Scoped via
+# `kms:ViaService = lambda` so this perm can't be reused for other
+# KMS-protected resources. Closes #60.
+aws.iam.RolePolicy(
+    "grug-webhook-envvar-kms-policy",
+    role=webhook.role.id,
+    policy=grug_tokens_cmk.arn.apply(
+        lambda arn: json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "kms:Decrypt",
+                "Resource": arn,
+                "Condition": {
+                    "StringEquals": {
+                        "kms:ViaService": "lambda.us-east-1.amazonaws.com",
+                    },
+                },
+            }],
+        }),
+    ),
 )
 
 # Cloudflare DNS — webhook.grug.lol → Lambda Function URL host
@@ -241,6 +273,11 @@ api_lambda = lambda_service.create(
     cors_allow_methods=["GET", "POST", "PUT", "DELETE"],
     cors_allow_headers=["content-type", "authorization"],
     cors_allow_credentials=True,
+    # Encrypt env vars at rest — api role already has kms:Decrypt on
+    # this CMK via kms_cmk.grant_use_to_role below (envelope-encrypted
+    # OAuth tokens), so the additional Lambda-runtime decrypt at cold
+    # start is covered by the existing grant. Closes #60.
+    env_vars_kms_key_arn=grug_tokens_cmk.arn,
 )
 
 # Per IAM split (Slice 2 acceptance criterion): api Lambda CAN decrypt

--- a/infra/pulumi/components/lambda_service.py
+++ b/infra/pulumi/components/lambda_service.py
@@ -40,6 +40,7 @@ def create(
     cors_allow_methods: list[str] | None = None,
     cors_allow_headers: list[str] | None = None,
     cors_allow_credentials: bool = False,
+    env_vars_kms_key_arn: pulumi.Input[str] | None = None,
 ) -> LambdaService:
     log_group = aws.cloudwatch.LogGroup(
         f"{name}-logs",
@@ -143,6 +144,14 @@ def create(
         ecr_repo.repository_url, ":", image_tag,
     )
 
+    # When env_vars_kms_key_arn is set, Lambda encrypts ALL env vars
+    # with that CMK at rest. `aws lambda get-function-configuration`
+    # returns ciphertext blobs instead of plaintext, so a reader needs
+    # BOTH `lambda:GetFunctionConfiguration` AND `kms:Decrypt` on the
+    # CMK to recover values. Closes #60 — DD_API_KEY was previously
+    # plaintext-visible to anyone with default ReadOnlyAccess Lambda
+    # perms. Lambda runtime decrypts before extension boot, so DD ext
+    # still reads DD_API_KEY normally.
     function = aws.lambda_.Function(
         name,
         name=name,
@@ -153,6 +162,7 @@ def create(
         memory_size=memory_mb,
         architectures=["arm64"],
         layers=layers or [],
+        kms_key_arn=env_vars_kms_key_arn,
         environment=aws.lambda_.FunctionEnvironmentArgs(
             variables=env_vars,
         ),

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -111,7 +111,16 @@ def create(
                             # is set on the function. Without kms:Encrypt
                             # on the deployer role, UpdateFunctionConfig
                             # 403s. Closes #60.
+                            #
+                            # kms:CreateGrant — required by AWS docs
+                            # for "configuring a customer managed key on
+                            # a Lambda function". Lambda needs the grant
+                            # to encrypt/decrypt during invocations.
+                            # Greptile P1 PR #79 (defensive: pulumi up
+                            # works without it, but AWS docs are
+                            # explicit it should be present).
                             "kms:Encrypt",
+                            "kms:CreateGrant",
                             "kms:DescribeKey",
                         ],
                         # NOTE: tightening to specific resource ARNs is a

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -106,6 +106,13 @@ def create(
                             "cloudwatch:*",
                             "sts:GetCallerIdentity",
                             "kms:Decrypt",
+                            # Lambda eagerly encrypts env vars on the
+                            # CALLING principal's behalf when kms_key_arn
+                            # is set on the function. Without kms:Encrypt
+                            # on the deployer role, UpdateFunctionConfig
+                            # 403s. Closes #60.
+                            "kms:Encrypt",
+                            "kms:DescribeKey",
                         ],
                         # NOTE: tightening to specific resource ARNs is a
                         # follow-up. Slice 1 prioritizes "deploy works".


### PR DESCRIPTION
Closes #60.

## Why

Codex Slice 1 P1 partial: PR #48 wrapped DD_API_KEY in `pulumi.Output.secret()` (encrypts Pulumi state at rest) but the Lambda env var is still plaintext-visible to any caller with default `lambda:GetFunctionConfiguration` (e.g. AWS-managed ReadOnlyAccess). KMS-encrypted env vars require both `GetFunctionConfiguration` AND `kms:Decrypt` on the CMK.

## Fix

`aws.lambda_.Function.kms_key_arn` set to the existing `grug-tokens` CMK on both webhook + api Lambdas. Lambda runtime decrypts at cold start BEFORE the DD extension boots, so DD APM still works.

api role already has kms:Decrypt via existing envelope-encryption grant. webhook role gets a new narrow inline policy: `kms:Decrypt` on grug_tokens_cmk.arn with `Condition: kms:ViaService=lambda.us-east-1.amazonaws.com` (scoped — perm can't leak to other KMS-protected paths).

## Acceptance criteria

- [x] Both Lambdas encrypt env vars with grug-tokens CMK
- [x] Webhook role narrowly grants kms:Decrypt (Lambda-via-service only)
- [x] api role unchanged (existing grant sufficient)
- [x] No code in lambda handlers needs changes (Lambda runtime handles unwrap)

## Test plan

- [ ] CI green (pulumi up succeeds)
- [ ] Post-deploy: `aws lambda get-function-configuration --function-name grug-webhook --query 'Environment.Variables.DD_API_KEY'` returns ciphertext-looking blob, NOT plaintext
- [ ] Post-deploy: DD APM dashboard shows traces from grug-webhook + grug-api (decrypt path works)
- [ ] Post-deploy: cold-start p99 monitor unchanged (KMS unwrap is ~10-30ms, well under 3s threshold)

## Out of scope

- Migrating SSM → Secrets Manager for DD_API_KEY (issue OOS — $0.40/mo cost)
- Encrypting non-secret env vars separately (CMK encrypts ALL env vars when `kms_key_arn` is set; safe and free)

**Size:** S