### PR TITLE
chore(#63): workflow step naming + concurrency hygiene

### DIFF
--- a/.github/workflows/grug.pr-gate.yml
+++ b/.github/workflows/grug.pr-gate.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     types: [opened, edited, synchronize, ready_for_review]
 
+# Cancel older runs on same PR — newer push obsoletes prior gating
+# attempt. Closes #63.
+concurrency:
+  group: grug-pr-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -46,15 +46,16 @@ jobs:
     runs-on: [self-hosted, Linux, X64, srv-unraid-gha]
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: 01. Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Configure AWS via OIDC
+      - name: 02. Configure AWS via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
           aws-region: us-east-1
 
-      - name: Set stack
+      - name: 03. Resolve stack name
         id: stack
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -70,7 +71,7 @@ jobs:
       # at deploy time using OIDC role's ssm:GetParameter on /shared/*.
       # Mask the value so it never leaks into job logs even if a step
       # echoes it accidentally.
-      - name: Fetch Pulumi access token from SSM
+      - name: 04. Fetch Pulumi access token from SSM
         run: |
           TOKEN=$(aws ssm get-parameter --name /shared/pulumi-access-token \
             --with-decryption --query 'Parameter.Value' --output text)
@@ -80,26 +81,26 @@ jobs:
       # Runner has system Python 3.14 + uv (installed at /usr/local/bin/uv
       # via the runner-tooling bootstrap). Pyproject requires >=3.11 so
       # 3.14 satisfies. actions/setup-python lacks Ubuntu 26.04 prebuilds.
-      - name: Verify Python + uv
+      - name: 05. Verify Python + uv
         run: |
           python3 --version
           uv --version
 
-      - name: Set up QEMU (arm64 cross-build emulation on x86 runners)
+      - name: 06. Setup QEMU (arm64 cross-build emulation on x86)
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           platforms: arm64
 
-      - name: Set up Docker Buildx
+      - name: 07. Setup Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
-      - name: Login to ECR
+      - name: 08. Login to ECR
         run: |
           aws ecr get-login-password --region us-east-1 | \
             docker login --username AWS --password-stdin \
             ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
 
-      - name: Build + push webhook + api images
+      - name: 09. Build + push webhook + api images
         id: build
         run: |
           IMAGE_TAG="${GITHUB_SHA::8}"
@@ -125,7 +126,8 @@ jobs:
           done
           echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
-      - uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
+      - name: 10. Pulumi up
+        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
         with:
           command: up
           stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
@@ -134,7 +136,7 @@ jobs:
             webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
             api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }
 
-      - name: Deploy CF Workers (host-rewrite proxies)
+      - name: 11. Deploy CF Workers (host-rewrite proxies)
         run: bash infra/cloudflare/deploy.sh
         env:
           PULUMI_CWD: infra/pulumi

--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -19,7 +19,9 @@ on:
 
 concurrency:
   group: web-deploy-${{ github.ref }}
-  cancel-in-progress: true
+  # Deploys serialize, never cancel — partially-deployed Cloudflare
+  # Pages state is worse than queued runs. Closes #63.
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -30,21 +32,23 @@ jobs:
     runs-on: [self-hosted, Linux, X64, srv-unraid-gha]
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: 01. Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - name: 02. Setup Node 20
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
 
-      - name: Configure AWS via OIDC
+      - name: 03. Configure AWS via OIDC
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
           aws-region: us-east-1
 
-      - name: Resolve secrets from SSM
+      - name: 04. Resolve secrets from SSM
         id: secrets
         env:
           AWS_REGION: us-east-1
@@ -65,19 +69,19 @@ jobs:
           echo "CLOUDFLARE_API_TOKEN=$CF_API_TOKEN" >> "$GITHUB_ENV"
           echo "CLOUDFLARE_ACCOUNT_ID=$CF_ACCOUNT_ID" >> "$GITHUB_ENV"
 
-      - name: Install deps
+      - name: 05. Install deps
         working-directory: web
         run: npm ci --no-audit --no-fund
 
-      - name: Type check
+      - name: 06. Type check
         working-directory: web
         run: npm run typecheck
 
-      - name: Build
+      - name: 07. Build
         working-directory: web
         run: npm run build
 
-      - name: Deploy to Cloudflare Pages
+      - name: 08. Deploy to Cloudflare Pages
         working-directory: web
         env:
           CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Closes #63.

## Why

Workflow runs page noisy: unnamed/inconsistent steps make it slow to find failure points. PR-gating workflow lacked concurrency block (two pushes could race).

## What

- Every step now has `name:` in `NN. <Imperative Action>` format
- Numbering reflects position (visual ordering in run UI)
- grug.pr-gate.yml: new concurrency block, cancel-in-progress: true
- web.deploy.yml: concurrency was cancel-in-progress: true → false (deploys serialize, never cancel mid-CF-Pages-deploy)
- iac.deploy.yml: cancel-in-progress already false (correct)

## Acceptance criteria

- [x] All workflow steps in scope have `name:` field
- [x] Step names use 01..NN imperative-voice prefix
- [x] grug.pr-gate.yml has concurrency block
- [x] Deploy workflows cancel-in-progress: false; PR-gating: true

## Test plan

- [ ] CI green
- [ ] Visual: GH Actions run UI shows numbered steps in iac.deploy.yml + web.deploy.yml + grug.pr-gate.yml
- [ ] Trigger 2 quick pushes to same PR branch → older grug.pr-gate run cancels

## Out of scope

- _reusable.grug-pr-gate.yml + _reusable.grug-pulse.yml (called by consumer repos; renaming would breaking-change them)
- drift-lint.yml (just landed, single 1-step job, low value to renumber)

**Size:** XS