### PR TITLE
perf(#70): CI buildx local cache + DD_GIT_* runtime env

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -118,11 +118,16 @@ jobs:
           # DD_GIT_* env vars now set on the Lambda Function (in
           # __main__.py) instead of via --build-arg, so commit-SHA
           # changes don't bust every layer.
+          set -euo pipefail
           mkdir -p /tmp/buildx-cache-grug
           for service in webhook api; do
             REPO="$ECR/grug-$service"
             CACHE_DIR="/tmp/buildx-cache-grug/$service"
             mkdir -p "$CACHE_DIR"
+            # Atomic swap path: write new layers to -new, then promote
+            # ONLY if buildx exits 0 (set -e + && guard). A partial /
+            # corrupted dest never overwrites the working cache. Greptile
+            # P2 PR #81.
             docker buildx build \
               --platform linux/arm64 \
               --provenance=false \
@@ -133,10 +138,9 @@ jobs:
               --tag "$REPO:$IMAGE_TAG" \
               --tag "$REPO:latest" \
               --push \
-              "services/$service"
-            # Atomic swap so a failed build doesn't poison the cache
-            rm -rf "$CACHE_DIR"
-            mv "$CACHE_DIR-new" "$CACHE_DIR"
+              "services/$service" \
+            && rm -rf "$CACHE_DIR" \
+            && mv "$CACHE_DIR-new" "$CACHE_DIR"
           done
           echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
@@ -146,9 +150,13 @@ jobs:
           command: up
           stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
           work-dir: infra/pulumi
+          # full_commit_sha = 40-char SHA used for DD source-code linking
+          # (image_tag is 8-char short SHA; DD source UI requires full).
+          # Greptile P1 PR #81.
           config-map: |
             webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
             api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }
+            full_commit_sha:   { value: "${{ github.sha }}" }
 
       - name: 11. Deploy CF Workers (host-rewrite proxies)
         run: bash infra/cloudflare/deploy.sh

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -110,19 +110,33 @@ jobs:
           # attestations. Force Docker manifest schema 2 + disable
           # attestations so the manifest is a single arm64 image, not a
           # provenance-wrapped manifest list.
+          #
+          # Closes #70: --cache-from + --cache-to type=local on the
+          # self-hosted runner's filesystem persists buildx layers
+          # between runs. Skips re-pulling python:3.13-arm64 base
+          # (~90s × 2 services) on warm-cache deploys.
+          # DD_GIT_* env vars now set on the Lambda Function (in
+          # __main__.py) instead of via --build-arg, so commit-SHA
+          # changes don't bust every layer.
+          mkdir -p /tmp/buildx-cache-grug
           for service in webhook api; do
             REPO="$ECR/grug-$service"
+            CACHE_DIR="/tmp/buildx-cache-grug/$service"
+            mkdir -p "$CACHE_DIR"
             docker buildx build \
               --platform linux/arm64 \
               --provenance=false \
               --sbom=false \
               --file services/$service/Dockerfile.lambda \
-              --build-arg DD_GIT_REPOSITORY_URL=https://github.com/${{ github.repository }} \
-              --build-arg DD_GIT_COMMIT_SHA=${{ github.sha }} \
+              --cache-from "type=local,src=$CACHE_DIR" \
+              --cache-to "type=local,dest=$CACHE_DIR-new,mode=max" \
               --tag "$REPO:$IMAGE_TAG" \
               --tag "$REPO:latest" \
               --push \
               "services/$service"
+            # Atomic swap so a failed build doesn't poison the cache
+            rm -rf "$CACHE_DIR"
+            mv "$CACHE_DIR-new" "$CACHE_DIR"
           done
           echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -128,6 +128,10 @@ webhook_ecr = ecr_repo.create(
 # is live, CF DNS resolves. CI's first build replaces the image tag
 # with the real SHA, second `pulumi up` swaps imageUri.
 webhook_image_tag = config.get("webhook_image_tag") or "bootstrap"
+# Full 40-char commit SHA — separate from image_tag (8-char short)
+# because DD source-code linking requires the full SHA. Greptile P1
+# PR #81. CI passes via config; bootstrap deploys fall back to short.
+_full_commit_sha = config.get("full_commit_sha") or webhook_image_tag
 webhook = lambda_service.create(
     name="grug-webhook",
     ecr_repo=webhook_ecr,
@@ -163,7 +167,7 @@ webhook = lambda_service.create(
         # instead of --build-arg so commit SHA churn doesn't bust
         # buildx layer cache (which made every deploy a cold rebuild).
         "DD_GIT_REPOSITORY_URL": "https://github.com/githumps/grug",
-        "DD_GIT_COMMIT_SHA": webhook_image_tag,
+        "DD_GIT_COMMIT_SHA": _full_commit_sha,
         "DD_TRACE_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
         # Disable noisy ASGI integration that collapses every FastAPI
@@ -234,7 +238,7 @@ api_lambda = lambda_service.create(
         # See webhook above — DD_GIT_* moved from build-arg to runtime
         # env var so layer cache survives commit-SHA churn. Closes #70.
         "DD_GIT_REPOSITORY_URL": "https://github.com/githumps/grug",
-        "DD_GIT_COMMIT_SHA": api_image_tag,
+        "DD_GIT_COMMIT_SHA": _full_commit_sha,
         "DD_TRACE_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
         "DD_PATCH_MODULES": "asgi:false",

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -159,6 +159,11 @@ webhook = lambda_service.create(
         "DD_ENV": env,
         "DD_SERVICE": "grug-webhook",
         "DD_VERSION": webhook_image_tag,
+        # Closes #70 — set DD source-code link via runtime env vars
+        # instead of --build-arg so commit SHA churn doesn't bust
+        # buildx layer cache (which made every deploy a cold rebuild).
+        "DD_GIT_REPOSITORY_URL": "https://github.com/githumps/grug",
+        "DD_GIT_COMMIT_SHA": webhook_image_tag,
         "DD_TRACE_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
         # Disable noisy ASGI integration that collapses every FastAPI
@@ -226,6 +231,10 @@ api_lambda = lambda_service.create(
         "DD_ENV": env,
         "DD_SERVICE": "grug-api",
         "DD_VERSION": api_image_tag,
+        # See webhook above — DD_GIT_* moved from build-arg to runtime
+        # env var so layer cache survives commit-SHA churn. Closes #70.
+        "DD_GIT_REPOSITORY_URL": "https://github.com/githumps/grug",
+        "DD_GIT_COMMIT_SHA": api_image_tag,
         "DD_TRACE_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
         "DD_PATCH_MODULES": "asgi:false",


### PR DESCRIPTION
Closes #70.

## Why

iac.deploy.yml currently 4-7min per run because every commit busts buildx layer cache:
1. `--build-arg DD_GIT_COMMIT_SHA=${{ github.sha }}` changes per commit → invalidates that ENV layer + everything beneath
2. No buildx `--cache-from` / `--cache-to` → no layer reuse run-to-run

## Fix

1. **buildx local cache**: `--cache-from type=local,src=/tmp/buildx-cache-grug/<svc>` + `--cache-to type=local,dest=...-new,mode=max` then atomic swap. Self-hosted runner persists this dir between runs.
2. **Drop DD_GIT_* build-args**: ARGs only baked into image as ENV defaults. Setting them as Lambda env vars in Pulumi achieves same DD APM source-link without commit-SHA layer churn.

## Acceptance criteria

- [x] buildx --cache-from + --cache-to wired
- [x] Atomic cache swap (rm + mv) avoids poisoning on failed builds
- [x] DD_GIT_* moved to Lambda env vars (DD APM still gets source-link)
- [x] Per-service cache dirs (webhook + api don't cross-pollute)

## Test plan

- [ ] CI green
- [ ] First run = cold (creates cache dir, full 4-7min)
- [ ] Second run after merge = warm (~2-3min, layers from cache)
- [ ] DD APM trace shows DD_GIT_REPOSITORY_URL + DD_GIT_COMMIT_SHA correctly populated

## Out of scope

- uv cache (self-hosted runner persists ~/.cache/uv natively)
- Pulumi plugin cache (~/.pulumi/plugins persists natively)
- ECR layer push dedup (buildx already deduplicates content-addressable layers)

**Size:** S