### PR TITLE
chore(#71): force Node 24 + bump aws-creds to v6 (Node24 native)

### DIFF
--- a/.github/workflows/grug.pr-gate.yml
+++ b/.github/workflows/grug.pr-gate.yml
@@ -19,6 +19,10 @@ permissions:
   pull-requests: write
   issues: write
 
+# Force JS actions to Node 24. See iac.deploy.yml. Closes #71.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   grug:
     name: Grug · self check

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -37,6 +37,12 @@ permissions:
   contents: read
   id-token: write   # Required for OIDC AWS auth
 
+# Force every JS-action to run on Node 24 instead of Node 20 (deprecated
+# 2026-09-16; default-on 2026-06-02). Bridges until each pinned action
+# ships a Node24-native release. Closes #71.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 concurrency:
   group: iac-deploy-${{ github.ref }}
   cancel-in-progress: false
@@ -50,7 +56,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 02. Configure AWS via OIDC
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
           aws-region: us-east-1

--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -27,6 +27,10 @@ permissions:
   contents: read
   id-token: write
 
+# Force JS actions to Node 24. See iac.deploy.yml. Closes #71.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-and-deploy:
     runs-on: [self-hosted, Linux, X64, srv-unraid-gha]
@@ -43,7 +47,7 @@ jobs:
           node-version: '20'
 
       - name: 03. Configure AWS via OIDC
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
           aws-region: us-east-1


### PR DESCRIPTION
Closes #71.

## Why

GH Actions deprecation: "Node.js 20 actions are deprecated. Will be forced to Node 24 by default 2026-06-02; Node 20 removed 2026-09-16". 5 pinned actions still on Node 20.

## Two-part bridge

1. **Workflow env: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`** on all 3 workflows. Forces every JS-action to run on Node 24 immediately. Bridges until each action ships native release.
2. **aws-actions/configure-aws-credentials v4.3.1 → v6.1.0** (Node24-native).

## Acceptance criteria

- [x] FORCE_JS_ACTIONS env on iac.deploy, web.deploy, grug.pr-gate
- [x] aws-creds bumped to v6.1.0 + SHA-pinned
- [x] No drift-lint regression
- [x] Node 24 ready before 2026-06-02 cutoff

## Test plan

- [ ] CI green
- [ ] Run logs no longer show 'Node.js 20 actions are deprecated' warning
- [ ] aws-creds OIDC step still resolves role correctly

## Out of scope

- Bumping checkout/setup-node/setup-python/docker-buildx/qemu/pulumi to native Node24 — bridge env handles them. Bump as upstreams release.

**Size:** XS