### PR TITLE
fix(ci): pulumi up retry on IAM eventual-consistency failure

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -145,7 +145,9 @@ jobs:
           echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: 10. Pulumi up
+        id: pulumi_up_first
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
+        continue-on-error: true
         with:
           command: up
           stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
@@ -153,6 +155,31 @@ jobs:
           # full_commit_sha = 40-char SHA used for DD source-code linking
           # (image_tag is 8-char short SHA; DD source UI requires full).
           # Greptile P1 PR #81.
+          config-map: |
+            webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
+            api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }
+            full_commit_sha:   { value: "${{ github.sha }}" }
+
+      # IAM eventual consistency: when pulumi up adds new RolePolicy
+      # statements (e.g. kms:Encrypt for env-var encryption) AND in the
+      # same plan tries to use those perms (Lambda UpdateFunctionConfig),
+      # AWS auth checks may still see the old policy for 10-30s after
+      # the RolePolicy update returns success. The first run's IAM update
+      # propagates by the time the retry kicks off. Closes #60 deploy
+      # flakiness on env-var-encrypt-touching diffs.
+      - name: 10b. Wait for IAM propagation if pulumi-up failed
+        if: steps.pulumi_up_first.outcome == 'failure'
+        run: |
+          echo "::warning::pulumi up #1 failed — sleeping 45s for IAM consistency, retrying"
+          sleep 45
+
+      - name: 10c. Pulumi up (retry on IAM-consistency failure)
+        if: steps.pulumi_up_first.outcome == 'failure'
+        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
+        with:
+          command: up
+          stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
+          work-dir: infra/pulumi
           config-map: |
             webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
             api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }


### PR DESCRIPTION
## Why

Three back-to-back deploys (PR #79 + main pulumi-ups) failed with:
> AccessDeniedException: User ... is not authorized to perform: kms:Encrypt on resource ...

Caused by IAM eventual consistency: when pulumi up adds new RolePolicy statements (e.g. `kms:Encrypt` on the deployer role for Lambda env-var encryption) AND in the same plan uses those perms (UpdateFunctionConfiguration), AWS auth checks may still see the OLD policy for 10-30s after RolePolicy update returns success.

## Fix

Two-step pulumi up with sleep:
1. `10. Pulumi up` with `continue-on-error: true`
2. `10b. Sleep 45s` only if step 10 failed
3. `10c. Pulumi up` retry only if step 10 failed

Workflow only fails if BOTH attempts fail.

## Acceptance criteria

- [x] continue-on-error gates retry to actual failures
- [x] Conditional steps avoid noise when first attempt succeeds
- [x] Same config-map passed to both attempts
- [x] Sleep is 45s — covers 10-30s typical IAM propagation + buffer

## Test plan

- [ ] CI green
- [ ] Manual: trigger iac.deploy.yml against main, observe 2-attempt pattern only when needed
- [ ] Future PRs that add IAM Statements + use perms in same plan deploy on retry

## Out of scope

- Adding pulumi-time `Sleep` resource between RolePolicy and Lambda Function (heavier; new provider dep). Workflow retry is the cheaper bridge.

**Size:** XS

Closes deploy flakiness from #60.