### PR TITLE
feat(#2): /grug recheck slash command via issue_comment

### DIFF
--- a/docs/HITL_PREREQUISITES.md
+++ b/docs/HITL_PREREQUISITES.md
@@ -17,7 +17,7 @@ URL: <https://github.com/settings/apps/new>
 | Repository permissions — Contents | **Read** |
 | Repository permissions — Metadata | **Read** *(default, required)* |
 | Repository permissions — Checks | **Read & write** |
-| Subscribe to events | `pull_request`, `pull_request_review` |
+| Subscribe to events | `pull_request`, `pull_request_review`, `issue_comment` *(closes #2 — `/grug recheck` slash command)* |
 | Where can this app be installed? | **Any account** |
 
 After creating:

--- a/services/webhook/dispatcher.py
+++ b/services/webhook/dispatcher.py
@@ -38,6 +38,8 @@ def dispatch(event_name: str, payload: dict[str, Any]) -> dict[str, str]:
         return _handle_pull_request(payload)
     if event_name == "pull_request_review":
         return {"status": "no_op", "reason": "no persona for pull_request_review yet"}
+    if event_name == "issue_comment":
+        return _handle_issue_comment(payload)
     return {"status": "no_op", "reason": f"no handler for event {event_name}"}
 
 
@@ -167,5 +169,154 @@ def _handle_pull_request(payload: dict[str, Any]) -> dict[str, str]:
     return {
         "status": "dispatched",
         "persona": "tpm",
+        "result": "pass" if result.passed else "fail",
+    }
+
+
+# Closes #2 — `/grug recheck` slash command. PR comments containing
+# the trigger phrase re-fire DoR check without requiring an empty commit.
+# Trigger surface is `issue_comment` event (PR comments arrive there too,
+# distinguished by `issue.pull_request` truthy). Author-or-collaborator
+# auth check stops drive-by spam.
+import re as _re  # noqa: E402
+
+_RECHECK_PAT = _re.compile(r"^\s*/grug\s+recheck\b", _re.IGNORECASE | _re.MULTILINE)
+# Author-only roles that satisfy the auth gate. PR author is implicit
+# (sender.login == pr.user.login). Collaborator perms come from
+# `permission` field on `GET /repos/{o}/{r}/collaborators/{u}/permission`.
+_AUTHORIZED_ROLES = {"admin", "maintain", "write"}
+
+
+def _handle_issue_comment(payload: dict[str, Any]) -> dict[str, str]:
+    action = payload.get("action", "")
+    if action != "created":
+        return {"status": "no_op", "reason": f"issue_comment action={action} not gated"}
+
+    issue = payload.get("issue") or {}
+    if not issue.get("pull_request"):
+        return {"status": "no_op", "reason": "issue_comment on non-PR"}
+
+    comment = payload.get("comment") or {}
+    body = comment.get("body") or ""
+    if not _RECHECK_PAT.search(body):
+        return {"status": "no_op", "reason": "no /grug recheck trigger"}
+
+    repo = payload.get("repository") or {}
+    installation = payload.get("installation") or {}
+    sender = payload.get("sender") or {}
+
+    installation_id = installation.get("id")
+    owner = (repo.get("owner") or {}).get("login") or repo.get("full_name", "").split("/")[0]
+    repo_name = repo.get("name")
+    pr_number = issue.get("number")
+    sender_login = sender.get("login", "")
+    pr_author_login = (issue.get("user") or {}).get("login", "")
+
+    if not all([installation_id, owner, repo_name, pr_number]):
+        log.warning(
+            "issue_comment_payload_incomplete",
+            extra={
+                "installation_id": installation_id, "owner": owner,
+                "repo_name": repo_name, "pr_number": pr_number,
+            },
+        )
+        return {"status": "skip", "reason": "incomplete_payload"}
+
+    if not is_install_allowlisted(int(installation_id)):
+        return {"status": "no_op", "reason": "installer not allowlisted"}
+
+    repo_id = repo.get("id")
+    if repo_id is not None and not is_persona_enabled(
+        int(installation_id), int(repo_id), "tpm",
+    ):
+        return {"status": "no_op", "reason": "tpm disabled for this repo"}
+
+    # Author OR write+ collaborator only — public-listed App means random
+    # commenters can't spam re-evaluations. Lazy imports keep cold-start
+    # cheap when only PR events fire.
+    from github_app_auth import with_install_token_retry  # type: ignore
+    from personas.tpm.persona import evaluate_pull_request  # type: ignore
+    import httpx  # type: ignore
+
+    if sender_login != pr_author_login:
+        def _check_perm(token: str) -> str:
+            r = httpx.get(
+                f"https://api.github.com/repos/{owner}/{repo_name}"
+                f"/collaborators/{sender_login}/permission",
+                headers={
+                    "Authorization": f"token {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                timeout=10,
+            )
+            r.raise_for_status()
+            return (r.json() or {}).get("permission", "")
+
+        try:
+            perm = with_install_token_retry(int(installation_id), _check_perm)
+        except httpx.HTTPStatusError as e:
+            log.warning(
+                "recheck_perm_lookup_failed",
+                extra={"sender": sender_login, "status": e.response.status_code},
+            )
+            return {"status": "skip", "reason": "perm_lookup_failed"}
+
+        if perm not in _AUTHORIZED_ROLES:
+            log.info(
+                "recheck_unauthorized",
+                extra={
+                    "sender": sender_login, "perm": perm, "owner": owner,
+                    "repo": repo_name, "pr_number": pr_number,
+                },
+            )
+            return {"status": "no_op", "reason": "sender lacks write perm"}
+
+    # Re-fetch PR to get current head_sha + body (issue payload only has
+    # the issue mirror, not the PR head). One API call per recheck.
+    def _fetch_pr(token: str) -> dict[str, Any]:
+        r = httpx.get(
+            f"https://api.github.com/repos/{owner}/{repo_name}/pulls/{pr_number}",
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=10,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    try:
+        pr = with_install_token_retry(int(installation_id), _fetch_pr)
+    except httpx.HTTPStatusError as e:
+        log.warning(
+            "recheck_pr_fetch_failed",
+            extra={"pr_number": pr_number, "status": e.response.status_code},
+        )
+        return {"status": "skip", "reason": "pr_fetch_failed"}
+
+    head_sha = ((pr.get("head") or {}).get("sha")) or ""
+    pr_body = pr.get("body") or ""
+    if not head_sha:
+        return {"status": "skip", "reason": "pr_has_no_head_sha"}
+
+    result = evaluate_pull_request(
+        installation_id=int(installation_id),
+        owner=owner,
+        repo=repo_name,
+        head_sha=head_sha,
+        pr_body=pr_body,
+        pr_number=int(pr_number),
+    )
+    log.info(
+        "recheck_dispatched",
+        extra={
+            "owner": owner, "repo": repo_name, "pr_number": pr_number,
+            "sender": sender_login, "result": "pass" if result.passed else "fail",
+        },
+    )
+    return {
+        "status": "dispatched",
+        "persona": "tpm",
+        "trigger": "recheck",
         "result": "pass" if result.passed else "fail",
     }

--- a/services/webhook/tests/test_recheck_slash.py
+++ b/services/webhook/tests/test_recheck_slash.py
@@ -1,0 +1,185 @@
+"""Tests for #2 — `/grug recheck` slash command via issue_comment.
+
+Covers:
+- Trigger pattern matches case-insensitively + with surrounding whitespace
+- Non-PR comments no_op
+- Non-trigger comments no_op
+- PR author always authorized
+- Non-author with admin/maintain/write authorized
+- Non-author with read/triage/none REJECTED
+- Non-allowlisted install no_op
+- Per-repo TPM disable no_op
+- Successful path re-fetches PR + dispatches to TPM persona
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import dispatcher as d
+
+
+def _comment_payload(
+    *,
+    body: str,
+    is_pr: bool = True,
+    sender_login: str = "evan",
+    pr_author: str = "evan",
+    install_id: int = 1,
+    repo_id: int = 100,
+):
+    return {
+        "action": "created",
+        "issue": {
+            "number": 42,
+            "user": {"login": pr_author},
+            "pull_request": {"url": "..."} if is_pr else None,
+        },
+        "comment": {"body": body},
+        "repository": {
+            "id": repo_id, "name": "myrepo",
+            "owner": {"login": "myorg"}, "full_name": "myorg/myrepo",
+        },
+        "installation": {"id": install_id},
+        "sender": {"login": sender_login},
+    }
+
+
+@pytest.fixture
+def _no_install_lookups(monkeypatch):
+    """Skip allowlist + persona toggle DDB calls."""
+    monkeypatch.setattr(d, "is_install_allowlisted", lambda _id: True)
+    monkeypatch.setattr(d, "is_persona_enabled", lambda *_: True)
+
+
+def test_recheck_pattern_matches_case_insensitive():
+    assert d._RECHECK_PAT.search("/grug recheck")
+    assert d._RECHECK_PAT.search("/Grug Recheck")
+    assert d._RECHECK_PAT.search("  /grug   recheck please  ")
+
+
+def test_recheck_pattern_rejects_other_commands():
+    assert not d._RECHECK_PAT.search("/grug status")
+    assert not d._RECHECK_PAT.search("grug recheck")  # missing /
+    assert not d._RECHECK_PAT.search("nope")
+
+
+def test_no_trigger_text_no_ops(_no_install_lookups):
+    payload = _comment_payload(body="lgtm")
+    out = d.dispatch("issue_comment", payload)
+    assert out["status"] == "no_op"
+    assert "no /grug recheck trigger" in out["reason"]
+
+
+def test_non_pr_issue_comment_no_ops(_no_install_lookups):
+    payload = _comment_payload(body="/grug recheck", is_pr=False)
+    out = d.dispatch("issue_comment", payload)
+    assert out["status"] == "no_op"
+    assert "non-PR" in out["reason"]
+
+
+def test_non_created_action_no_ops(_no_install_lookups):
+    payload = _comment_payload(body="/grug recheck")
+    payload["action"] = "edited"
+    out = d.dispatch("issue_comment", payload)
+    assert out["status"] == "no_op"
+    assert "issue_comment action=edited" in out["reason"]
+
+
+def test_pr_author_authorized_path_dispatches(_no_install_lookups):
+    payload = _comment_payload(body="/grug recheck", sender_login="evan", pr_author="evan")
+    fake_pr = {"head": {"sha": "abc123"}, "body": "## Why\nbecause closes #1\n## Acceptance criteria\n- [x] one\n- [x] two\n- [x] three\n## Out of scope\nnone\n\n**Size:** S"}
+
+    class _Result:
+        passed = True
+
+    with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
+        with patch("httpx.get") as get_mock, \
+             patch("personas.tpm.persona.evaluate_pull_request", return_value=_Result()) as eval_mock:
+            get_mock.return_value.raise_for_status = lambda: None
+            get_mock.return_value.json.return_value = fake_pr
+            out = d.dispatch("issue_comment", payload)
+
+    assert out["status"] == "dispatched"
+    assert out["trigger"] == "recheck"
+    assert out["result"] == "pass"
+    eval_mock.assert_called_once()
+    kwargs = eval_mock.call_args.kwargs
+    assert kwargs["head_sha"] == "abc123"
+    assert kwargs["pr_number"] == 42
+
+
+def test_non_author_with_write_perm_authorized(_no_install_lookups):
+    payload = _comment_payload(body="/grug recheck", sender_login="bob", pr_author="evan")
+    fake_pr = {"head": {"sha": "def456"}, "body": ""}
+
+    class _Result:
+        passed = False
+
+    perm_responses = [
+        # First call: permission lookup
+        {"raise_for_status": None, "json": {"permission": "write"}},
+        # Second call: PR fetch
+        {"raise_for_status": None, "json": fake_pr},
+    ]
+    call_idx = [0]
+
+    def _httpx_get(*args, **kwargs):
+        resp = perm_responses[call_idx[0]]
+        call_idx[0] += 1
+
+        class _R:
+            def raise_for_status(self_inner):
+                pass
+
+            def json(self_inner):
+                return resp["json"]
+        return _R()
+
+    with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
+        with patch("httpx.get", side_effect=_httpx_get), \
+             patch("personas.tpm.persona.evaluate_pull_request", return_value=_Result()):
+            out = d.dispatch("issue_comment", payload)
+
+    assert out["status"] == "dispatched"
+    assert out["result"] == "fail"
+
+
+def test_non_author_with_read_perm_rejected(_no_install_lookups):
+    payload = _comment_payload(body="/grug recheck", sender_login="random", pr_author="evan")
+
+    def _httpx_get(*args, **kwargs):
+        class _R:
+            def raise_for_status(self_inner):
+                pass
+
+            def json(self_inner):
+                return {"permission": "read"}
+        return _R()
+
+    with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
+        with patch("httpx.get", side_effect=_httpx_get):
+            out = d.dispatch("issue_comment", payload)
+
+    assert out["status"] == "no_op"
+    assert "lacks write perm" in out["reason"]
+
+
+def test_non_allowlisted_install_no_ops(monkeypatch):
+    monkeypatch.setattr(d, "is_install_allowlisted", lambda _id: False)
+    monkeypatch.setattr(d, "is_persona_enabled", lambda *_: True)
+    payload = _comment_payload(body="/grug recheck")
+    out = d.dispatch("issue_comment", payload)
+    assert out["status"] == "no_op"
+    assert "not allowlisted" in out["reason"]
+
+
+def test_tpm_disabled_per_repo_no_ops(monkeypatch):
+    monkeypatch.setattr(d, "is_install_allowlisted", lambda _id: True)
+    monkeypatch.setattr(d, "is_persona_enabled", lambda *_: False)
+    payload = _comment_payload(body="/grug recheck")
+    out = d.dispatch("issue_comment", payload)
+    assert out["status"] == "no_op"
+    assert "tpm disabled" in out["reason"]


### PR DESCRIPTION
Closes #2.

## Why

Currently grug only re-runs DoR on PR push (synchronize). Operators editing PR description to fix flagged issues need an empty commit to retrigger. `/grug recheck` PR comment fixes that — no commit needed.

## How

`dispatcher._handle_issue_comment` filters `issue_comment` events for:
- action=created
- issue.pull_request truthy (PR comments arrive as issue events)
- body matches `/grug recheck` regex (case-insensitive)
- install allowlisted (Slice 5 gate)
- TPM enabled per repo (Slice 7 gate)
- sender is PR author OR has write+ perm via /repos/.../collaborators/{u}/permission

Then re-fetches PR (issue payload lacks head_sha) and dispatches to evaluate_pull_request. Sticky comment patches in place — no duplicate.

## Acceptance criteria

- [x] /grug recheck triggers re-evaluation
- [x] Case-insensitive matching
- [x] PR author always authorized
- [x] Non-author needs admin/maintain/write
- [x] Read/triage/none REJECTED
- [x] Sticky comment patches in place (handled by existing post_check_run impl)
- [x] 9 unit tests cover all branches
- [x] HITL doc updated: App settings need `issue_comment` event

## HITL prereq (post-merge)

Add `issue_comment` to webhook events on the GitHub App settings:
- https://github.com/settings/apps/grug-boss/permissions
- Subscribe to events → check `Issue comment`
- Save changes (will need user re-acceptance per install)

## Test plan

- [ ] CI green (9 new pytest tests)
- [ ] Post-deploy + App-settings update: comment `/grug recheck` on a test PR → check-run re-posts
- [ ] Comment from random user → no_op + log entry

## Out of scope

- Reaction-driven UX (👍/👀/🚀/😕 on the trigger comment) — issue called this v1 out-of-scope
- Other slash commands (/grug split-this, /grug status) — separate tickets

**Size:** S