### PR TITLE
chore(#46): better error message for missing CF Pages:Edit perm

### DIFF
--- a/infra/cloudflare/pages-bootstrap.sh
+++ b/infra/cloudflare/pages-bootstrap.sh
@@ -29,6 +29,46 @@ api() {
     curl -sS -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" "$@"
 }
 
+# Detect "missing Pages:Edit token perm" error 10000 + provide actionable
+# guidance (closes a tail of #46). CF returns the same generic auth error
+# for every Pages-API call when the token lacks Account → Cloudflare
+# Pages: Edit perm.
+explain_if_pages_perm_missing() {
+    local resp="$1"
+    if echo "$resp" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    errs = d.get('errors') or []
+    for e in errs:
+        # 10000 = generic 'unauthorized'; 10001 = expired; pages-specific perms
+        # surface as 10000 + message containing 'Cloudflare Pages'
+        if e.get('code') == 10000 or 'Cloudflare Pages' in e.get('message',''):
+            sys.exit(0)
+    sys.exit(1)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null; then
+        cat <<'EOF'
+
+  ✗ Cloudflare API rejected the request — looks like a token-perm issue.
+
+  The /grug/cloudflare-api-token must have:
+    - Zone → DNS → Edit
+    - Account → Workers Scripts → Edit
+    - Account → Workers Routes → Edit
+    - Account → Cloudflare Pages → Edit  ← easy to miss
+
+  Fix:
+    1. https://dash.cloudflare.com/profile/api-tokens
+    2. Edit the grug.lol token → Add 'Account → Cloudflare Pages: Edit'
+    3. Save → re-run this script (idempotent).
+
+  See docs/HITL_PREREQUISITES.md / issue #46 for context.
+EOF
+    fi
+}
+
 # 1. Ensure project exists.
 project_resp=$(api "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/pages/projects/$PROJECT")
 if echo "$project_resp" | python3 -c "import json,sys; d=json.load(sys.stdin); sys.exit(0 if d.get('success') else 1)" 2>/dev/null; then
@@ -39,7 +79,9 @@ else
         "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/pages/projects" \
         -d "{\"name\":\"$PROJECT\",\"production_branch\":\"$PROD_BRANCH\"}")
     if ! echo "$create_resp" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('success') else 1)" 2>/dev/null; then
-        echo "  ✗ Project create FAILED:"; echo "$create_resp" | python3 -m json.tool; exit 1
+        echo "  ✗ Project create FAILED:"; echo "$create_resp" | python3 -m json.tool
+        explain_if_pages_perm_missing "$create_resp"
+        exit 1
     fi
     echo "  ✓ Project created"
 fi
@@ -61,7 +103,9 @@ else
         "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/pages/projects/$PROJECT/domains" \
         -d "{\"name\":\"$APEX\"}")
     if ! echo "$bind_resp" | python3 -c "import json,sys; sys.exit(0 if json.load(sys.stdin).get('success') else 1)" 2>/dev/null; then
-        echo "  ✗ Domain bind FAILED:"; echo "$bind_resp" | python3 -m json.tool; exit 1
+        echo "  ✗ Domain bind FAILED:"; echo "$bind_resp" | python3 -m json.tool
+        explain_if_pages_perm_missing "$bind_resp"
+        exit 1
     fi
     echo "  ✓ Apex bound (CF will auto-create the DNS record; allow ~30s for verification)"
 fi


### PR DESCRIPTION
Refs #46.

## Why

Pages-bootstrap script currently dumps raw CF API error JSON when the token lacks 'Account → Cloudflare Pages: Edit'. Generic CF auth error code 10000 is opaque — easy to chase wrong things.

## Acceptance criteria

- [x] Detect CF API error code 10000 in response
- [x] Print actionable guidance: token UI URL + exact perm checkbox
- [x] Apply to both project-create + domain-bind error paths
- [x] No regression on success path (no false-positive perm warnings)

## Test plan

- [ ] CI bash -n syntax check passes
- [ ] Manual: re-run `bash infra/cloudflare/pages-bootstrap.sh` against the existing token (currently missing Pages:Edit) → see new guidance block
- [ ] Manual: re-run after adding Pages:Edit → success path no-ops cleanly

## Out of scope

- Auto-applying the missing perm (CF API doesn't allow token-self-update)
- Other CF API permissions audits (only Pages:Edit is the v1 gap)

#46 itself stays open until the user actually adds the perm in CF UI (HITL). This PR just makes the failure self-explanatory.

**Size:** XS