### PR TITLE
fix(security): handle httpx transport errors in OAuth + dispatcher

### DIFF
--- a/services/api/auth/github_oauth.py
+++ b/services/api/auth/github_oauth.py
@@ -164,24 +164,44 @@ def callback(
     state: str = Query(...),
     grug_oauth_state: str = Cookie(default=""),
 ) -> RedirectResponse:
-    """OAuth callback — exchange code → user-token + upsert DDB."""
+    """OAuth callback — exchange code → user-token + upsert DDB.
+
+    Handler is `def`, NOT `async def` — every downstream call is sync
+    httpx + sync boto3 KMS + sync DDB. FastAPI runs sync defs in a
+    threadpool so concurrent requests don't starve each other. Don't
+    flip this to `async def` without converting the httpx + boto3
+    paths to their async equivalents (re-eval at v1.5 if fan-out
+    behavior lands). See main.py:60-67 + RUNBOOK 'Sync-vs-async
+    route handlers'. Closes async-blocker-hunter F-03.
+    """
     # CSRF
     if not state or state != grug_oauth_state or not _verify_state(state):
         raise HTTPException(status_code=400, detail="invalid_state")
 
-    # Exchange code → user-access-token
-    token_resp = httpx.post(
-        _GH_TOKEN_URL,
-        data={
-            "client_id": _client_id(),
-            "client_secret": _client_secret(),
-            "code": code,
-            "redirect_uri": f"https://api.{_DOMAIN}/api/v1/auth/github/callback",
-        },
-        headers={"Accept": "application/json"},
-        timeout=10,
-    )
-    token_resp.raise_for_status()
+    # Exchange code → user-access-token. Catch BOTH HTTPStatusError
+    # (4xx/5xx from GitHub) AND RequestError (transport: timeout, DNS,
+    # connection-reset). Without the RequestError catch, a transient
+    # network blip surfaces as a 500 with no actionable log line —
+    # async-blocker-hunter F-02.
+    try:
+        token_resp = httpx.post(
+            _GH_TOKEN_URL,
+            data={
+                "client_id": _client_id(),
+                "client_secret": _client_secret(),
+                "code": code,
+                "redirect_uri": f"https://api.{_DOMAIN}/api/v1/auth/github/callback",
+            },
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        token_resp.raise_for_status()
+    except (httpx.HTTPStatusError, httpx.RequestError) as e:
+        log.warning(
+            "oauth_token_endpoint_failed",
+            extra={"err": str(e), "kind": type(e).__name__},
+        )
+        raise HTTPException(status_code=502, detail="oauth_upstream_failed") from e
     token_payload = token_resp.json()
     access_token = token_payload.get("access_token")
     refresh_token = token_payload.get("refresh_token")
@@ -189,13 +209,20 @@ def callback(
         log.warning("oauth_token_missing", extra={"err": token_payload.get("error")})
         raise HTTPException(status_code=400, detail="oauth_token_exchange_failed")
 
-    # Identity
-    user_resp = httpx.get(
-        _GH_USER_URL,
-        headers={"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json"},
-        timeout=10,
-    )
-    user_resp.raise_for_status()
+    # Identity — same transport-error wrap. F-02.
+    try:
+        user_resp = httpx.get(
+            _GH_USER_URL,
+            headers={"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json"},
+            timeout=10,
+        )
+        user_resp.raise_for_status()
+    except (httpx.HTTPStatusError, httpx.RequestError) as e:
+        log.warning(
+            "oauth_user_endpoint_failed",
+            extra={"err": str(e), "kind": type(e).__name__},
+        )
+        raise HTTPException(status_code=502, detail="oauth_upstream_failed") from e
     gh_user = user_resp.json()
     gh_id = str(gh_user["id"])
     login_name = gh_user["login"]

--- a/services/webhook/dispatcher.py
+++ b/services/webhook/dispatcher.py
@@ -260,6 +260,11 @@ def _handle_issue_comment(payload: dict[str, Any]) -> dict[str, str]:
             r.raise_for_status()
             return (r.json() or {}).get("permission", "")
 
+        # Catch BOTH HTTPStatusError (4xx/5xx from GH) AND RequestError
+        # (transport: timeout, DNS, connection-reset). Earlier code only
+        # caught HTTPStatusError; transport blips surfaced as webhook
+        # 500 → GitHub retries the delivery → duplicate work.
+        # async-blocker-hunter F-01.
         try:
             perm = with_install_token_retry(int(installation_id), _check_perm)
         except httpx.HTTPStatusError as e:
@@ -268,6 +273,12 @@ def _handle_issue_comment(payload: dict[str, Any]) -> dict[str, str]:
                 extra={"sender": sender_login, "status": e.response.status_code},
             )
             return {"status": "skip", "reason": "perm_lookup_failed"}
+        except httpx.RequestError as e:
+            log.warning(
+                "recheck_perm_lookup_transport_failed",
+                extra={"sender": sender_login, "kind": type(e).__name__},
+            )
+            return {"status": "skip", "reason": "perm_lookup_transport_failed"}
 
         if perm not in _AUTHORIZED_ROLES:
             log.info(
@@ -302,6 +313,14 @@ def _handle_issue_comment(payload: dict[str, Any]) -> dict[str, str]:
             extra={"pr_number": pr_number, "status": e.response.status_code},
         )
         return {"status": "skip", "reason": "pr_fetch_failed"}
+    except httpx.RequestError as e:
+        # Transport-level failure (timeout, DNS, connection-reset).
+        # Same rationale as the perm-lookup catch above. F-01.
+        log.warning(
+            "recheck_pr_fetch_transport_failed",
+            extra={"pr_number": pr_number, "kind": type(e).__name__},
+        )
+        return {"status": "skip", "reason": "pr_fetch_transport_failed"}
 
     head_sha = ((pr.get("head") or {}).get("sha")) or ""
     pr_body = pr.get("body") or ""

--- a/services/webhook/tests/test_recheck_slash.py
+++ b/services/webhook/tests/test_recheck_slash.py
@@ -183,3 +183,35 @@ def test_tpm_disabled_per_repo_no_ops(monkeypatch):
     out = d.dispatch("issue_comment", payload)
     assert out["status"] == "no_op"
     assert "tpm disabled" in out["reason"]
+
+
+def test_perm_lookup_transport_error_returns_skip(_no_install_lookups):
+    """async-blocker-hunter F-01: transport error during perm lookup
+    must return skip + log, not 500."""
+    payload = _comment_payload(body="/grug recheck", sender_login="bob", pr_author="evan")
+
+    def _raise_transport(*args, **kwargs):
+        raise httpx.ConnectError("DNS failure")
+
+    with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
+        with patch("httpx.get", side_effect=_raise_transport):
+            out = d.dispatch("issue_comment", payload)
+
+    assert out["status"] == "skip"
+    assert "transport" in out["reason"]
+
+
+def test_pr_fetch_transport_error_returns_skip(_no_install_lookups):
+    """async-blocker-hunter F-01: transport error during PR re-fetch
+    must return skip + log, not 500."""
+    payload = _comment_payload(body="/grug recheck", sender_login="evan", pr_author="evan")
+
+    def _raise_timeout(*args, **kwargs):
+        raise httpx.ReadTimeout("github.com slow")
+
+    with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
+        with patch("httpx.get", side_effect=_raise_timeout):
+            out = d.dispatch("issue_comment", payload)
+
+    assert out["status"] == "skip"
+    assert "transport" in out["reason"]


### PR DESCRIPTION
## Why

async-blocker-hunter agent caught 3 P1 issues post-PR-#86/#97:

- **F-01:** dispatcher._handle_issue_comment caught httpx.HTTPStatusError but NOT RequestError. Transport blips (timeout, DNS, connection-reset) → webhook 500 → GitHub retries delivery → duplicate dispatch.
- **F-02:** github_oauth.callback raised bare .raise_for_status() with no transport-error wrap. Network blip → FastAPI 500 with no oauth-specific log.
- **F-03:** callback() is intentionally sync (matches PR #68 webhook). No comment block explaining why; future contributor may 'fix' by adding async def.

## Acceptance criteria

- [x] dispatcher: perm-lookup catches both HTTPStatusError + RequestError
- [x] dispatcher: PR-fetch catches both HTTPStatusError + RequestError
- [x] dispatcher: distinct log + reason for transport vs status errors
- [x] OAuth callback: try/except around BOTH httpx.post + httpx.get
- [x] OAuth callback: transport error → 502 oauth_upstream_failed (chained from e)
- [x] OAuth callback: comment block matches main.py:60-67 sync rationale
- [x] 2 new dispatcher tests cover ConnectError + ReadTimeout

## Test plan

- [ ] CI green (2 new tests; 9 existing pass)

## Out of scope

- Module-level httpx.Client reuse (F-04, perf optimization)
- Real httpx.MockTransport fixture (F-01 closing test gap; deferred)

**Size:** S