### PR TITLE
fix(security): silent-failure-hunter P1+P2 batch (5 surfaces)

### DIFF
--- a/services/api/adapters/user_store.py
+++ b/services/api/adapters/user_store.py
@@ -12,6 +12,7 @@ EncryptionContext bound (anti-row-transplant defense).
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from dataclasses import dataclass
@@ -20,6 +21,8 @@ from typing import Any
 
 import boto3
 from botocore.exceptions import ClientError
+
+log = logging.getLogger("grug.api.adapters.user_store")
 
 _TABLE_NAME = os.environ.get("GRUG_DDB_TABLE", "grug-main")
 
@@ -66,10 +69,26 @@ def get_user(github_user_id: str) -> User | None:
     """
     from crypto.kms_envelope import decrypt_for_user  # lazy import
 
-    resp = _table.get_item(
-        Key={"PK": _user_pk(github_user_id), "SK": "META"},
-        ConsistentRead=True,
-    )
+    try:
+        resp = _table.get_item(
+            Key={"PK": _user_pk(github_user_id), "SK": "META"},
+            ConsistentRead=True,
+        )
+    except ClientError as e:
+        # Distinguish DDB throttle/transient/IAM from a legitimate miss
+        # (resp.get("Item") absent). Without this, a transient
+        # ProvisionedThroughputExceededException would surface as a
+        # generic 500 with no DDB context — and worse, get_current_user
+        # would return None, spuriously logging the user out.
+        # silent-failure-hunter P1 #2.
+        log.error(
+            "user_store_get_item_failed",
+            extra={
+                "github_user_id": github_user_id,
+                "code": e.response.get("Error", {}).get("Code", "unknown"),
+            },
+        )
+        raise
     item = resp.get("Item")
     if not item:
         return None

--- a/services/api/auth/github_oauth.py
+++ b/services/api/auth/github_oauth.py
@@ -224,8 +224,18 @@ def callback(
         )
         raise HTTPException(status_code=502, detail="oauth_upstream_failed") from e
     gh_user = user_resp.json()
-    gh_id = str(gh_user["id"])
-    login_name = gh_user["login"]
+    # Defensive: GH can return {} or partial body if the access_token
+    # was revoked between the token-exchange call and this user-info
+    # call. KeyError → 500 with no log. silent-failure-hunter P2 #5.
+    raw_id = gh_user.get("id")
+    login_name = gh_user.get("login")
+    if not raw_id or not login_name:
+        log.warning(
+            "oauth_user_payload_missing_fields",
+            extra={"keys": list(gh_user.keys())},
+        )
+        raise HTTPException(status_code=502, detail="oauth_user_malformed")
+    gh_id = str(raw_id)
 
     user = upsert_oauth_user(
         github_user_id=gh_id,

--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -65,17 +65,28 @@ def list_installations(user: User = Depends(require_authenticated)) -> dict[str,
     """Installs owned by the current user (admin sees only own here too;
     cross-user listing is admin-only and lives at /api/v1/admin/users)."""
     items = list_user_installations(user.github_user_id)
-    return {
-        "installations": [
-            {
-                "install_id": int(it["PK"].split("#", 1)[1]),
-                "account_login": it.get("account_login", ""),
-                "account_type": it.get("account_type", "User"),
-                "installed_at": it.get("installed_at", ""),
-            }
-            for it in items
-        ],
-    }
+    out: list[dict[str, Any]] = []
+    for it in items:
+        # Defensive: GSI1 row with corrupt/missing PK shouldn't 500
+        # the whole list endpoint. Skip + log so we surface the
+        # corruption without breaking the user's dashboard.
+        # silent-failure-hunter P2 #6.
+        pk = it.get("PK", "")
+        try:
+            install_id = int(pk.split("#", 1)[1])
+        except (IndexError, ValueError):
+            log.error(
+                "list_installations_corrupt_pk",
+                extra={"pk": pk, "user": user.login},
+            )
+            continue
+        out.append({
+            "install_id": install_id,
+            "account_login": it.get("account_login", ""),
+            "account_type": it.get("account_type", "User"),
+            "installed_at": it.get("installed_at", ""),
+        })
+    return {"installations": out}
 
 
 @router.get("/installations/{install_id}/repos")
@@ -110,7 +121,20 @@ def list_install_repos(
                 )
                 resp.raise_for_status()
                 body = resp.json()
-                for r in body.get("repositories", []):
+                if "repositories" not in body:
+                    # GH returned 200 but malformed payload — distinguish
+                    # from "0 repos" so the caller doesn't show an empty
+                    # dashboard for what's really upstream broken.
+                    # silent-failure-hunter P1 #3.
+                    log.error(
+                        "gh_install_repos_malformed",
+                        extra={"install_id": install_id, "page": page},
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="gh_upstream_malformed",
+                    )
+                for r in body["repositories"]:
                     cfg = get_repo_config(install_id, r["id"])
                     out.append({
                         "repo_id": r["id"],
@@ -119,7 +143,7 @@ def list_install_repos(
                         "default_branch": r.get("default_branch", "main"),
                         "config": cfg,
                     })
-                if len(body.get("repositories", [])) < 100:
+                if len(body["repositories"]) < 100:
                     break
                 page += 1
                 if page > 10:  # 1000 repos is plenty for v1
@@ -170,10 +194,20 @@ def update_repo_config(
                 )
                 resp.raise_for_status()
                 body_json = resp.json()
-                for r in body_json.get("repositories", []):
+                if "repositories" not in body_json:
+                    log.error(
+                        "gh_install_repos_malformed",
+                        extra={"install_id": install_id, "page": page,
+                               "context": "update_repo_config"},
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="gh_upstream_malformed",
+                    )
+                for r in body_json["repositories"]:
                     if r["id"] == repo_id:
                         return True, r["full_name"]
-                if len(body_json.get("repositories", [])) < 100:
+                if len(body_json["repositories"]) < 100:
                     return False, ""
                 page += 1
                 # No page cap — single-repo membership lookup must scan

--- a/services/webhook/main.py
+++ b/services/webhook/main.py
@@ -100,8 +100,16 @@ def receive_github_webhook(
     try:
         payload = _json.loads(body)
     except _json.JSONDecodeError:
-        log.warning("webhook_body_not_json", extra={"delivery_id": x_github_delivery})
-        return {"status": "skip", "reason": "body_not_json"}
+        # Body already passed HMAC verify — non-JSON here is GitHub
+        # bug, our own header-stripping middleware, or attack payload
+        # that got past sig verify (shouldn't happen). 400 stops GH
+        # retries while bumping severity above the 200 'skip' bucket
+        # so DD alerts fire. silent-failure-hunter P1 #1.
+        log.error(
+            "webhook_body_not_json_after_hmac_pass",
+            extra={"delivery_id": x_github_delivery, "body_len": len(body)},
+        )
+        raise HTTPException(status_code=400, detail="body_not_json")
 
     outcome = dispatch(x_github_event, payload)
     log.info(


### PR DESCRIPTION
## Why

silent-failure-hunter agent audited last 25 PRs and found 5 actionable findings: 3 P1 + 2 P2. Bundled — all are 'surface the real failure instead of masking as success/empty'.

## Fixes

| File | Fix | Type |
|---|---|---|
| services/webhook/main.py | JSON-decode after HMAC pass: log error + 400 not 200 'skip' | P1 #1 |
| services/api/adapters/user_store.py | DDB ClientError catch + re-raise (was masking throttle as None → spurious logout) | P1 #2 |
| services/api/installations.py | Malformed GH 'repositories' key: 502 not silent empty list | P1 #3 |
| services/api/auth/github_oauth.py | Missing gh_user.id/login: 502 not KeyError 500 | P2 #5 |
| services/api/installations.py | Corrupt PK in GSI1 row: skip+log not 500 entire endpoint | P2 #6 |

## Acceptance criteria

- [x] webhook 400 (not 200) on post-HMAC JSON decode failure
- [x] user_store DDB ClientError logged + re-raised (not masked)
- [x] installations.py distinguishes empty-list from missing-key payload
- [x] OAuth callback handles partial GH user payload (revoked-mid-flow case)
- [x] list_installations resilient to one corrupt GSI1 row

## Test plan

- [ ] CI green (existing tests should still pass — refactors are append-only)

## Out of scope

- silent-failure-hunter P2 #4 (install_store.get_repo_config ClientError) — deferred
- P3 #7 (dispatcher log context) — deferred
- P3 #8 (kms_envelope overbroad except) — deferred

**Size:** S