### PR TITLE
test(webhook): github_app_auth JWT + install-token cache coverage

### DIFF
--- a/services/webhook/tests/test_github_app_auth.py
+++ b/services/webhook/tests/test_github_app_auth.py
@@ -1,0 +1,181 @@
+"""Tests for github_app_auth — JWT signing + install-token exchange.
+
+Coverage gap: with_install_token_retry was tested in
+test_install_token_retry, but the underlying get_app_jwt + cache logic
+in get_install_token had no direct coverage. Forging an RS256 token
+needs a real RSA key — uses cryptography to mint one per test.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch, MagicMock
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+@pytest.fixture
+def _rsa_pem() -> tuple[str, str]:
+    """Mint a fresh RSA keypair per test (PEM strings)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return private_pem, public_pem
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Each test sees a fresh cache (module-scope state would leak)."""
+    import github_app_auth as gh
+    from ports.token_cache import InMemoryTokenCache
+    original = gh._cache
+    gh._cache = InMemoryTokenCache()
+    yield
+    gh._cache = original
+
+
+@pytest.fixture
+def _stub_secrets(monkeypatch, _rsa_pem):
+    private_pem, public_pem = _rsa_pem
+    import github_app_auth as gh
+    monkeypatch.setattr(gh, "_app_id", lambda: "12345")
+    monkeypatch.setattr(gh, "_app_private_key", lambda: private_pem)
+    return private_pem, public_pem
+
+
+def test_get_app_jwt_cache_miss_signs_rs256(_stub_secrets):
+    """First call signs a fresh JWT with iat (60s back) + exp + iss claims."""
+    import github_app_auth as gh
+    private_pem, public_pem = _stub_secrets
+    token = gh.get_app_jwt()
+    decoded = jwt.decode(
+        token, public_pem, algorithms=["RS256"],
+        options={"verify_aud": False},
+    )
+    assert decoded["iss"] == "12345"
+    now = int(time.time())
+    # iat is 60s back (clock skew compensation per GH docs)
+    assert decoded["iat"] <= now - 50
+    assert decoded["iat"] >= now - 70
+    # exp is ~9min ahead
+    assert decoded["exp"] >= now + 8 * 60
+    assert decoded["exp"] <= now + 10 * 60
+
+
+def test_get_app_jwt_cache_hit_skips_resign(_stub_secrets, monkeypatch):
+    """Second call within TTL returns cached value — does NOT re-sign."""
+    import github_app_auth as gh
+    t1 = gh.get_app_jwt()
+    encode_called = []
+    real_encode = jwt.encode
+
+    def trap(*args, **kwargs):
+        encode_called.append(1)
+        return real_encode(*args, **kwargs)
+
+    monkeypatch.setattr(jwt, "encode", trap)
+    t2 = gh.get_app_jwt()
+    assert t2 == t1
+    assert encode_called == [], "should NOT re-sign within TTL window"
+
+
+def test_get_install_token_cache_hit_skips_http(_stub_secrets):
+    """Repeat call within 55min returns cached, no HTTP."""
+    import github_app_auth as gh
+    fake = MagicMock()
+    fake.raise_for_status = MagicMock()
+    fake.json = MagicMock(return_value={"token": "TOKEN-XYZ"})
+
+    with patch("httpx.post", return_value=fake) as mock_post:
+        t1 = gh.get_install_token(123)
+        t2 = gh.get_install_token(123)
+
+    assert t1 == t2 == "TOKEN-XYZ"
+    assert mock_post.call_count == 1
+
+
+def test_get_install_token_force_refresh_invalidates_then_refetches(_stub_secrets):
+    """force_refresh=True drops the cached entry + hits HTTP again."""
+    import github_app_auth as gh
+    responses = []
+    for tok in ("TOK-1", "TOK-2"):
+        r = MagicMock()
+        r.raise_for_status = MagicMock()
+        r.json = MagicMock(return_value={"token": tok})
+        responses.append(r)
+
+    call_idx = [0]
+
+    def _post(*args, **kwargs):
+        r = responses[call_idx[0]]
+        call_idx[0] += 1
+        return r
+
+    with patch("httpx.post", side_effect=_post):
+        t1 = gh.get_install_token(123)
+        t2 = gh.get_install_token(123, force_refresh=True)
+
+    assert t1 == "TOK-1"
+    assert t2 == "TOK-2"
+
+
+def test_get_install_token_url_uses_installation_id(_stub_secrets):
+    import github_app_auth as gh
+    fake = MagicMock()
+    fake.raise_for_status = MagicMock()
+    fake.json = MagicMock(return_value={"token": "x"})
+
+    with patch("httpx.post", return_value=fake) as mock_post:
+        gh.get_install_token(99999)
+
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://api.github.com/app/installations/99999/access_tokens"
+
+
+def test_get_install_token_uses_bearer_app_jwt(_stub_secrets):
+    """Authorization header must be 'Bearer <App JWT>' — not 'token <...>'."""
+    import github_app_auth as gh
+    fake = MagicMock()
+    fake.raise_for_status = MagicMock()
+    fake.json = MagicMock(return_value={"token": "x"})
+
+    with patch("httpx.post", return_value=fake) as mock_post:
+        gh.get_install_token(1)
+
+    auth = mock_post.call_args.kwargs["headers"]["Authorization"]
+    assert auth.startswith("Bearer ")
+    # Decode the JWT to confirm it's our App JWT (not the install token)
+    import jwt as _jwt
+    private_pem, public_pem = _stub_secrets
+    decoded = _jwt.decode(
+        auth.removeprefix("Bearer "), public_pem,
+        algorithms=["RS256"], options={"verify_aud": False},
+    )
+    assert decoded["iss"] == "12345"
+
+
+def test_get_install_token_propagates_401(_stub_secrets):
+    """401 propagates so with_install_token_retry can catch + refresh."""
+    import github_app_auth as gh
+    bad = MagicMock()
+    bad.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError(
+        "401",
+        request=httpx.Request("POST", "https://api.github.com/x"),
+        response=httpx.Response(401),
+    ))
+
+    with patch("httpx.post", return_value=bad):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            gh.get_install_token(1)
+    assert exc.value.response.status_code == 401


### PR DESCRIPTION
## Why

PR #50 added 401-retry coverage via test_install_token_retry, but the underlying get_app_jwt + get_install_token cache logic (TTL, force_refresh, JWT claims, Authorization header) had no direct tests. JWT bugs would silently authenticate as the wrong App. Cache bugs would either burn rate-limit (no cache) or 401 forever (no force_refresh).

## Acceptance criteria

- [x] get_app_jwt signs RS256 with iat (60s back) + exp (~9min) + iss=App ID
- [x] get_app_jwt returns cached value within TTL — does NOT re-sign
- [x] get_install_token cache hit avoids HTTP
- [x] get_install_token force_refresh=True drops cache + re-fetches
- [x] URL path uses installation_id correctly
- [x] Authorization header is 'Bearer <App JWT>' (decoded back + iss verified)
- [x] 401 propagates (lets with_install_token_retry handle invalidate+refresh)

## Test plan

- [ ] CI green (7 new pytest tests, fresh RSA keypair per test via cryptography)

## Out of scope

- with_install_token_retry already covered (test_install_token_retry)
- _app_id / _app_private_key SSM fetch (covered by test_secrets_loader)

**Size:** S