### PR TITLE
test(api+webhook): pr-test-analyzer 4 HIGH + 1 MED coverage gaps

### DIFF
--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -159,3 +159,48 @@ def test_patch_user_no_op_payload_returns_unchanged(_ddb):
     _seed_user("1", "alice", "user")
     out = _ddb.patch_user("1", UserPatchPayload(), actor=_admin_user())
     assert out["changed"] is False
+
+
+def test_patch_user_first_allowlist_writes_audit_trail(_ddb):
+    """First flip-to-allowlisted=True writes allowlisted_at +
+    allowlisted_by audit fields. Without these we can't show a
+    moderation log in admin UI."""
+    from admin import UserPatchPayload
+    _seed_user("1", "alice", "user", allowlisted=False)
+    actor = _admin_user("100", "admin")
+
+    out = _ddb.patch_user("1", UserPatchPayload(allowlisted=True), actor=actor)
+    assert out["changed"] is True
+    table = boto3.resource("dynamodb", region_name="us-east-1").Table("grug-main-test")
+    row = table.get_item(Key={"PK": "USER#1", "SK": "META"})["Item"]
+    assert row["allowlisted"] is True
+    assert row.get("allowlisted_at"), "allowlisted_at missing on first flip"
+    assert row.get("allowlisted_by") == "100", \
+        "allowlisted_by must record the actor's github_user_id"
+
+
+def test_scan_all_paginates_via_last_evaluated_key(_ddb, monkeypatch):
+    """_scan_all must follow LastEvaluatedKey across pages. Mock _table.scan
+    to return 2 pages then None, assert all items returned."""
+    from admin import _scan_all
+    page1 = {"Items": [{"PK": "USER#1", "SK": "META"}], "LastEvaluatedKey": {"PK": "USER#1"}}
+    page2 = {"Items": [{"PK": "USER#2", "SK": "META"}]}  # no LEK = last page
+
+    pages = [page1, page2]
+    call_idx = [0]
+
+    def fake_scan(**kwargs):
+        # First call has no ExclusiveStartKey; second does
+        if call_idx[0] == 0:
+            assert "ExclusiveStartKey" not in kwargs
+        else:
+            assert kwargs["ExclusiveStartKey"] == {"PK": "USER#1"}
+        resp = pages[call_idx[0]]
+        call_idx[0] += 1
+        return resp
+
+    import admin as adm
+    monkeypatch.setattr(adm._table, "scan", fake_scan)
+    items = _scan_all(pk_prefix="USER#")
+    assert len(items) == 2
+    assert call_idx[0] == 2

--- a/services/api/tests/test_installations_list_repos.py
+++ b/services/api/tests/test_installations_list_repos.py
@@ -1,0 +1,133 @@
+"""Coverage for installations.list_install_repos GET endpoint.
+
+PR #96/#107 covered list_installations + update_repo_config + the
+_ensure_can_access helper, but the GET-repos endpoint that hits GH +
+merges DDB per-repo config was uncovered. Closes pr-test-analyzer
+HIGH gap #1.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+import installations as inst
+from adapters.user_store import User
+
+
+def _user(user_id="100", role="user"):
+    return User(
+        github_user_id=user_id, login="evan", role=role, tier="free",
+        allowlisted=True, oauth_access_token="x", oauth_refresh_token=None,
+        created_at="",
+    )
+
+
+def _ok_resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=json_body)
+    return r
+
+
+def test_list_install_repos_unknown_install_404():
+    with patch("installations.get_installation", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            inst.list_install_repos(install_id=999, user=_user())
+    assert exc.value.status_code == 404
+
+
+def test_list_install_repos_stranger_403():
+    install = {"installed_by_user_id": "999"}
+    with patch("installations.get_installation", return_value=install):
+        with pytest.raises(HTTPException) as exc:
+            inst.list_install_repos(install_id=1, user=_user(user_id="100"))
+    assert exc.value.status_code == 403
+
+
+def test_list_install_repos_merges_ddb_config_per_row():
+    """Critical: the per-repo config (tpm_enabled toggle) must be
+    merged into each repo row. SPA renders the toggle from this."""
+    install = {"installed_by_user_id": "100"}
+
+    def _retry(install_id, fn):
+        return fn("tok")
+
+    repos_resp = _ok_resp({"repositories": [
+        {"id": 1, "full_name": "myorg/r1", "private": False, "default_branch": "main"},
+        {"id": 2, "full_name": "myorg/r2", "private": True, "default_branch": "develop"},
+    ]})
+
+    def _get_cfg(install_id, repo_id):
+        return {"tpm_enabled": False} if repo_id == 1 else {"tpm_enabled": True}
+
+    with patch("installations.get_installation", return_value=install):
+        with patch("installations.with_install_token_retry", side_effect=_retry):
+            with patch("installations.get_repo_config", side_effect=_get_cfg):
+                with patch("httpx.Client") as client_cls:
+                    client = client_cls.return_value.__enter__.return_value
+                    client.get.return_value = repos_resp
+                    out = inst.list_install_repos(
+                        install_id=1, user=_user(user_id="100"),
+                    )
+
+    assert len(out["repos"]) == 2
+    by_id = {r["repo_id"]: r for r in out["repos"]}
+    assert by_id[1]["config"] == {"tpm_enabled": False}
+    assert by_id[2]["config"] == {"tpm_enabled": True}
+    assert by_id[2]["private"] is True
+    assert by_id[2]["default_branch"] == "develop"
+
+
+def test_list_install_repos_malformed_payload_502():
+    """silent-failure-hunter P1 #3 regression: missing 'repositories' key
+    on the GET-repos endpoint must 502, not return empty list."""
+    install = {"installed_by_user_id": "100"}
+
+    def _retry(install_id, fn):
+        return fn("tok")
+
+    bad_resp = _ok_resp({"unexpected": "shape"})
+
+    with patch("installations.get_installation", return_value=install):
+        with patch("installations.with_install_token_retry", side_effect=_retry):
+            with patch("httpx.Client") as client_cls:
+                client = client_cls.return_value.__enter__.return_value
+                client.get.return_value = bad_resp
+                with pytest.raises(HTTPException) as exc:
+                    inst.list_install_repos(
+                        install_id=1, user=_user(user_id="100"),
+                    )
+
+    assert exc.value.status_code == 502
+
+
+def test_list_install_repos_pagination_cap_at_10_pages():
+    """Truncate at 1000 repos (10 × 100) + log warning. Larger orgs
+    silently lose visibility past page 10. Not a v1 concern but the
+    branch should not crash."""
+    install = {"installed_by_user_id": "100"}
+
+    full_page = _ok_resp({"repositories": [
+        {"id": i, "full_name": f"myorg/r{i}", "private": False, "default_branch": "main"}
+        for i in range(100)
+    ]})
+
+    def _retry(install_id, fn):
+        return fn("tok")
+
+    with patch("installations.get_installation", return_value=install):
+        with patch("installations.with_install_token_retry", side_effect=_retry):
+            with patch("installations.get_repo_config", return_value={"tpm_enabled": True}):
+                with patch("httpx.Client") as client_cls:
+                    client = client_cls.return_value.__enter__.return_value
+                    # Always return a full page → loop hits page>10 cap
+                    client.get.return_value = full_page
+                    out = inst.list_install_repos(
+                        install_id=1, user=_user(user_id="100"),
+                    )
+
+    # 10 pages × 100 repos = 1000 (cap). Loop breaks on page 11.
+    assert len(out["repos"]) == 1000

--- a/services/api/tests/test_installations_routes.py
+++ b/services/api/tests/test_installations_routes.py
@@ -125,3 +125,28 @@ def test_repo_config_payload_default_tpm_enabled_true(_mod):
 def test_repo_config_payload_explicit_false(_mod):
     p = _mod.RepoConfigPayload(tpm_enabled=False)
     assert p.tpm_enabled is False
+
+
+def test_list_installations_skips_corrupt_pk_rows(_mod):
+    """silent-failure-hunter P2 #6 regression: corrupt GSI1 row PK
+    must skip + log, not crash entire endpoint."""
+    table = boto3.resource("dynamodb", region_name="us-east-1").Table("grug-main-test")
+    # Good row + corrupt-PK row both indexed under GSI1PK=100
+    table.put_item(Item={
+        "PK": "INST#1001", "SK": "META",
+        "account_login": "good", "account_type": "User",
+        "installed_at": "2026-01-01T00:00:00Z",
+        "installed_by_user_id": "100",
+        "GSI1PK": "100", "GSI1SK": "INST#1001",
+    })
+    table.put_item(Item={
+        "PK": "garbage-no-hash",
+        "SK": "META",
+        "account_login": "corrupt", "account_type": "User",
+        "installed_by_user_id": "100",
+        "GSI1PK": "100", "GSI1SK": "INST#bad",
+    })
+    user = _user(user_id="100")
+    out = _mod.list_installations(user)
+    install_ids = sorted(i["install_id"] for i in out["installations"])
+    assert install_ids == [1001]  # corrupt row skipped, dashboard not blank

--- a/services/webhook/tests/test_main_webhook_receiver.py
+++ b/services/webhook/tests/test_main_webhook_receiver.py
@@ -1,0 +1,98 @@
+"""TestClient-driven tests for receive_github_webhook.
+
+PR #99 added the JSON-decode-after-HMAC 400 branch but had no test —
+pr-test-analyzer HIGH gap #2.
+
+Uses FastAPI TestClient + signs payloads with the real verify_signature
+HMAC primitive so the HMAC gate runs end-to-end without mocking it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+_WEBHOOK_SECRET = "test-webhook-secret-v1"
+
+
+def _sign(secret: str, body: bytes) -> str:
+    sig = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={sig}"
+
+
+@pytest.fixture
+def _client(monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_WEBHOOK_SECRET_SSM", "/grug/test-webhook-secret")
+    monkeypatch.setenv("GRUG_DDB_TABLE", "grug-main-test")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    import main as webhook_main
+    monkeypatch.setattr(webhook_main, "get_webhook_secret", lambda: _WEBHOOK_SECRET)
+    # Stub dispatcher so we don't need DDB/KMS for the webhook-receiver tests
+    import dispatcher
+    monkeypatch.setattr(
+        dispatcher, "dispatch",
+        lambda event, payload: {"status": "no_op", "reason": "stubbed"},
+    )
+    return TestClient(webhook_main.app)
+
+
+def test_unsigned_post_returns_401(_client):
+    r = _client.post(
+        "/webhook/github",
+        content=b'{"action":"opened"}',
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+    assert r.status_code == 401
+
+
+def test_bad_signature_returns_401(_client):
+    body = b'{"action":"opened"}'
+    r = _client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": "sha256=000000000000",
+        },
+    )
+    assert r.status_code == 401
+
+
+def test_signed_non_json_body_returns_400(_client):
+    """silent-failure-hunter P1 #1: body that passes HMAC but fails
+    JSON decode must 400 (not 200 'skip'), so DD alarms trigger."""
+    body = b"not json at all { broken"
+    r = _client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": _sign(_WEBHOOK_SECRET, body),
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["detail"] == "body_not_json"
+
+
+def test_signed_valid_json_dispatches(_client):
+    body = b'{"action":"opened","number":1}'
+    r = _client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "deadbeef-1234",
+            "X-Hub-Signature-256": _sign(_WEBHOOK_SECRET, body),
+        },
+    )
+    assert r.status_code == 200
+    body_json = r.json()
+    assert body_json["delivery_id"] == "deadbeef-1234"
+    assert body_json["status"] == "no_op"
+    assert body_json["reason"] == "stubbed"


### PR DESCRIPTION
## Why

pr-test-analyzer agent ran on the last 33-PR coverage push and found 4 HIGH + 1 MED gaps that the recent test work missed. Closing all in one PR — they're related (lookup-route + dispatch-route uncovered branches).

## Coverage closed

| Gap | File | Branch |
|---|---|---|
| HIGH #1 | api/installations.py:120-166 | list_install_repos GET (5 tests) |
| HIGH #2 | webhook/main.py:100-119 | receive_github_webhook real TestClient (4 tests) |
| HIGH #3 | api/installations.py:81-89 | list_installations corrupt-PK skip (1 test) |
| HIGH #4 | api/admin.py:64-94 | _scan_all LastEvaluatedKey pagination (1 test) |
| MED #5 | api/admin.py:139-149 | patch_user first-flip writes audit-trail fields (1 test) |

## Acceptance criteria

- [x] list_install_repos covered: auth, DDB merge, malformed payload 502, pagination cap
- [x] webhook receiver: HMAC unsigned/bad/signed-non-JSON-400/signed-valid all paths
- [x] silent-failure-hunter P1 #1 + P2 #6 regression tests in place
- [x] _scan_all pagination via mocked _table.scan
- [x] allowlisted_at + allowlisted_by audit fields verified in DDB

## Test plan

- [ ] CI green (12 new pytest tests)

## Out of scope

- LOW gaps (#9 + #10 from analyzer report) — defer
- MED #6 #7 #8 — exercised transitively, less critical

**Size:** S