### PR TITLE
feat(#104): TpmEvaluation distinct type for persona rollup

### DIFF
--- a/services/webhook/personas/tpm/persona.py
+++ b/services/webhook/personas/tpm/persona.py
@@ -3,11 +3,27 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from github_app_auth import with_install_token_retry
-from github_checks_client import CheckRunResult, post_check_run
+from github_checks_client import CheckConclusion, CheckRunResult, post_check_run
 from personas.tpm.dor_checks import CheckResult, run_all
+
+
+@dataclass(frozen=True)
+class TpmEvaluation:
+    """Persona-level rollup of dor_checks results.
+
+    Distinct from CheckResult (per-check name + passed + detail) so
+    callers don't have to know the magic name='overall' string. The
+    `conclusion` field aligns with github_checks_client's
+    CheckConclusion vocabulary so the GH POST shape stays explicit.
+    Closes #104.
+    """
+    passed: bool
+    results: tuple[CheckResult, ...]
+    conclusion: CheckConclusion
 
 # Logger uses the `grug.webhook.*` namespace because this file is the
 # webhook-side copy (mirrored from services/api/personas/tpm/persona.py).
@@ -42,17 +58,12 @@ def evaluate_pull_request(
     head_sha: str,
     pr_body: str,
     pr_number: int,
-) -> CheckResult:
-    """Run TPM checks on the PR body + post check-run. Returns overall result."""
+) -> TpmEvaluation:
+    """Run TPM checks on the PR body + post check-run. Returns rollup."""
     results = run_all(pr_body)
     failed = [r for r in results if not r.passed]
-    overall = CheckResult(
-        name="overall",
-        passed=not failed,
-        detail=("all pass" if not failed else f"{len(failed)} blocking"),
-    )
     title, summary = _summary(results)
-    conclusion = "success" if not failed else "failure"
+    conclusion: CheckConclusion = "success" if not failed else "failure"
 
     # Retry once on 401 — handles tokens revoked out-of-band (App
     # reinstall, perm change, secret rotation). Codex post-review #50.
@@ -79,8 +90,12 @@ def evaluate_pull_request(
             "repo": f"{owner}/{repo}",
             "pr_number": pr_number,
             "head_sha": head_sha[:8],
-            "passed": overall.passed,
+            "passed": not failed,
             "failed_checks": [r.name for r in failed],
         },
     )
-    return overall
+    return TpmEvaluation(
+        passed=not failed,
+        results=tuple(results),
+        conclusion=conclusion,
+    )

--- a/services/webhook/tests/test_persona_evaluate.py
+++ b/services/webhook/tests/test_persona_evaluate.py
@@ -87,7 +87,9 @@ def test_evaluate_pull_request_passes_on_good_body():
             )
 
     assert overall.passed is True
-    assert overall.detail == "all pass"
+    assert overall.conclusion == "success"
+    assert len(overall.results) == 5  # 5 dor checks
+    assert all(r.passed for r in overall.results)
     assert captured["status"] == "completed"
     assert captured["conclusion"] == "success"
     assert captured["external_id"] == f"grug-tpm:myorg/myrepo#42:{'abc123def456' + '0' * 28}"
@@ -114,7 +116,8 @@ def test_evaluate_pull_request_fails_on_empty_body():
             )
 
     assert overall.passed is False
-    assert "blocking" in overall.detail
+    assert overall.conclusion == "failure"
+    assert any(not r.passed for r in overall.results)
     assert captured["conclusion"] == "failure"
     assert "❌" in captured["title"]
 
@@ -138,6 +141,30 @@ def test_evaluate_pull_request_uses_grug_check_name():
     # Branch protection ruleset relies on this exact string. Drift = silent
     # cutover regression.
     assert captured["name"] == "Grug — Definition of Ready"
+
+
+def test_tpm_evaluation_is_frozen():
+    """TpmEvaluation is frozen so callers can't mutate the rollup."""
+    from dataclasses import FrozenInstanceError
+    e = persona.TpmEvaluation(
+        passed=True,
+        results=(CheckResult("why", True, "ok"),),
+        conclusion="success",
+    )
+    with pytest.raises(FrozenInstanceError):
+        e.passed = False  # type: ignore[misc]
+
+
+def test_tpm_evaluation_results_is_tuple():
+    """results is a tuple (immutable) — caller can iterate but not append."""
+    e = persona.TpmEvaluation(
+        passed=True,
+        results=(CheckResult("why", True, "ok"),),
+        conclusion="success",
+    )
+    assert isinstance(e.results, tuple)
+    with pytest.raises(AttributeError):
+        e.results.append(CheckResult("x", False, "y"))  # type: ignore[attr-defined]
 
 
 def test_evaluate_pull_request_external_id_format():


### PR DESCRIPTION
Closes #104.

## Why

type-design-analyzer audit (this session) flagged that evaluate_pull_request returned CheckResult(name='overall', ...) — overloading the per-check type with a magic-string name. Every caller had to know the 'overall' convention.

## Fix

```python
@dataclass(frozen=True)
class TpmEvaluation:
    passed: bool
    results: tuple[CheckResult, ...]
    conclusion: CheckConclusion  # aligns with github_checks_client
```

Caller compatibility: dispatcher reads .passed (works on both old + new). Tests updated to assert .conclusion + .results instead of the discarded .detail.

## Acceptance criteria

- [x] New TpmEvaluation dataclass (frozen=True) in persona.py
- [x] evaluate_pull_request returns TpmEvaluation
- [x] dispatcher callers unchanged (read .passed)
- [x] CheckConclusion type alias from github_checks_client (single vocabulary)
- [x] 2 new tests: frozen invariant + tuple-results immutability

## Test plan

- [ ] CI green (existing 7 + 2 new = 9 persona-evaluate tests)
- [ ] dispatcher tests still pass (no caller change)

## Out of scope

- CheckResult Literal['why',...] tightening on the name field — separate refactor

**Size:** XS