### PR TITLE
fix: mirror TpmEvaluation into api persona.py + clarify drift-lint allowlist

### DIFF
--- a/services/api/personas/tpm/persona.py
+++ b/services/api/personas/tpm/persona.py
@@ -3,12 +3,31 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 from github_app_auth import with_install_token_retry
-from github_checks_client import CheckRunResult, post_check_run
+from github_checks_client import CheckConclusion, CheckRunResult, post_check_run
 from personas.tpm.dor_checks import CheckResult, run_all
 
+
+@dataclass(frozen=True)
+class TpmEvaluation:
+    """Persona-level rollup of dor_checks results.
+
+    Distinct from CheckResult (per-check name + passed + detail) so
+    callers don't have to know the magic name='overall' string. The
+    `conclusion` field aligns with github_checks_client's
+    CheckConclusion vocabulary so the GH POST shape stays explicit.
+    Closes #104.
+    """
+    passed: bool
+    results: tuple[CheckResult, ...]
+    conclusion: CheckConclusion
+
+# Logger uses the `grug.api.*` namespace; webhook-side copy uses
+# `grug.webhook.*`. The single-line divergence is intentional + the
+# only reason this file isn't in MIRRORED_FILES (drift-lint).
 log = logging.getLogger("grug.api.persona.tpm")
 
 _CHECK_NAME = "Grug — Definition of Ready"
@@ -38,17 +57,12 @@ def evaluate_pull_request(
     head_sha: str,
     pr_body: str,
     pr_number: int,
-) -> CheckResult:
-    """Run TPM checks on the PR body + post check-run. Returns overall result."""
+) -> TpmEvaluation:
+    """Run TPM checks on the PR body + post check-run. Returns rollup."""
     results = run_all(pr_body)
     failed = [r for r in results if not r.passed]
-    overall = CheckResult(
-        name="overall",
-        passed=not failed,
-        detail=("all pass" if not failed else f"{len(failed)} blocking"),
-    )
     title, summary = _summary(results)
-    conclusion = "success" if not failed else "failure"
+    conclusion: CheckConclusion = "success" if not failed else "failure"
 
     # Retry once on 401 — handles tokens revoked out-of-band (App
     # reinstall, perm change, secret rotation). Codex post-review #50.
@@ -75,8 +89,12 @@ def evaluate_pull_request(
             "repo": f"{owner}/{repo}",
             "pr_number": pr_number,
             "head_sha": head_sha[:8],
-            "passed": overall.passed,
+            "passed": not failed,
             "failed_checks": [r.name for r in failed],
         },
     )
-    return overall
+    return TpmEvaluation(
+        passed=not failed,
+        results=tuple(results),
+        conclusion=conclusion,
+    )

--- a/services/webhook/personas/tpm/persona.py
+++ b/services/webhook/personas/tpm/persona.py
@@ -25,10 +25,9 @@ class TpmEvaluation:
     results: tuple[CheckResult, ...]
     conclusion: CheckConclusion
 
-# Logger uses the `grug.webhook.*` namespace because this file is the
-# webhook-side copy (mirrored from services/api/personas/tpm/persona.py).
-# Greptile P2 on PR #40 — earlier `grug.api.persona.tpm` would route DD
-# logs/queries to the wrong service.
+# Logger uses the `grug.webhook.*` namespace; api-side copy uses
+# `grug.api.*`. The single-line divergence is intentional + the
+# only reason this file isn't in MIRRORED_FILES (drift-lint).
 log = logging.getLogger("grug.webhook.persona.tpm")
 
 _CHECK_NAME = "Grug — Definition of Ready"


### PR DESCRIPTION
## Why

PR #111 added TpmEvaluation to services/webhook/personas/tpm/persona.py but missed the api-side mirror. persona.py is intentionally allowlisted-OUT of drift-lint (logger-name diverges between sides), so the divergence didn't fail CI. The api Lambda was running stale persona.py until this PR.

## Fix

- Copy webhook persona.py → api persona.py
- Swap ONLY the log = ... line (grug.webhook → grug.api)
- Replace ambiguous 'mirrored from services/api' comment on both sides with explicit 'allowlisted-OUT of drift-lint because logger name diverges' note so future maintainers don't accidentally re-converge

## Acceptance criteria

- [x] api persona.py has TpmEvaluation
- [x] api persona.py uses grug.api.persona.tpm logger
- [x] webhook persona.py uses grug.webhook.persona.tpm logger
- [x] Diff between the two files = exactly the logger name + comment block
- [x] Both py_compile pass

## Test plan

- [ ] CI green
- [ ] Manual: `diff services/api/personas/tpm/persona.py services/webhook/personas/tpm/persona.py` shows logger-only diff

## Out of scope

- Adding persona.py to drift-lint MIRRORED_FILES (would force perfect byte equality and require more elaborate logger-name workaround) — defer to v1.5 #77 shared-package extraction

**Size:** XS