### PR TITLE
test(webhook): health endpoint tests + no-io invariant

### DIFF
--- a/services/webhook/tests/test_health.py
+++ b/services/webhook/tests/test_health.py
@@ -1,0 +1,49 @@
+"""Health-endpoint tests for grug-webhook.
+
+Per `feedback_health_endpoint_standard` memory: /livez (alive) +
+/readyz (ready), NOT /healthz. Mirrors services/api/tests/test_health.py
+for parity.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+
+client = TestClient(app)
+
+
+def test_livez_returns_200_with_status_ok() -> None:
+    r = client.get("/livez")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["service"] == "grug-webhook"
+
+
+def test_readyz_returns_200_with_status_ready() -> None:
+    r = client.get("/readyz")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ready"
+    assert body["service"] == "grug-webhook"
+
+
+def test_no_healthz_endpoint() -> None:
+    """Memory feedback_health_endpoint_standard: /healthz is K8s-deprecated.
+    grug-webhook ships /livez + /readyz instead."""
+    r = client.get("/healthz")
+    assert r.status_code == 404
+
+
+def test_livez_does_no_io():
+    """Liveness must be cheap — no DDB, KMS, or HTTPX call. If it ever
+    starts depending on downstream, move it to /readyz semantics."""
+    import inspect
+    import main as webhook_main
+    src = inspect.getsource(webhook_main.livez)
+    forbidden = ("get_item", "decrypt", "httpx.", "_table.", "boto3.")
+    assert not any(token in src for token in forbidden), \
+        f"livez must not do IO; found one of {forbidden} in source"


### PR DESCRIPTION
## Why

services/webhook/main.py has /livez + /readyz handlers but only services/api/tests/test_health.py covered the api-side mirror. Webhook-side health was untested. Live-deployed smoke (Makefile target) catches breakage post-deploy; this catches at PR time.

## Acceptance criteria

- [x] /livez 200 + status=ok + service=grug-webhook
- [x] /readyz 200 + status=ready + service=grug-webhook
- [x] /healthz 404 (per feedback_health_endpoint_standard)
- [x] **livez_does_no_io**: source-level guard rejects future DDB/KMS/HTTPX calls in /livez handler — keeps Lambda liveness probes cheap

## Test plan

- [ ] CI green (4 new pytest tests)

## Out of scope

- /webhook/github route already covered in test_main_webhook_receiver.py (PR #110)

**Size:** XS