### PR TITLE
chore(quality): code-reviewer cleanup — unused imports + invariant tests

### DIFF
--- a/services/api/personas/tpm/persona.py
+++ b/services/api/personas/tpm/persona.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Literal
 
 from github_app_auth import with_install_token_retry
 from github_checks_client import CheckConclusion, CheckRunResult, post_check_run

--- a/services/api/tests/test_oauth_routes.py
+++ b/services/api/tests/test_oauth_routes.py
@@ -112,3 +112,47 @@ def test_logout_returns_204_and_clears_cookie(_oauth_mod):
     assert "grug_session=" in set_cookie
     # delete_cookie sets max-age=0 OR expires in the past
     assert "Max-Age=0" in set_cookie or "max-age=0" in set_cookie or "expires=" in set_cookie.lower()
+
+
+# ── TestClient end-to-end tests cover FastAPI router wiring ──
+# code-reviewer flagged that direct-handler-call tests bypass the
+# router (a typo'd @router.get path would still pass). At least one
+# happy-path TestClient call per route catches that drift.
+
+def test_logout_via_test_client(_oauth_mod):
+    """Real router round-trip — catches @router.post path typos +
+    middleware regressions."""
+    from fastapi.testclient import TestClient
+    from main import app
+    client = TestClient(app)
+    r = client.post("/api/v1/auth/logout")
+    assert r.status_code == 204
+    # cookie cleared via Set-Cookie header (TestClient strips on ack)
+    assert any(
+        c.lower().startswith("grug_session=")
+        for c in r.headers.get_list("set-cookie")
+    )
+
+
+def test_me_anonymous_via_test_client(_oauth_mod):
+    """Real router round-trip — anonymous /me returns the documented shape."""
+    from fastapi.testclient import TestClient
+    from main import app
+    client = TestClient(app)
+    r = client.get("/api/v1/me")
+    assert r.status_code == 200
+    assert r.json() == {"authenticated": False}
+
+
+def test_login_via_test_client(_oauth_mod):
+    """Real router round-trip — login redirects + sets cookie."""
+    from fastapi.testclient import TestClient
+    from main import app
+    client = TestClient(app)
+    r = client.get("/api/v1/auth/github/login", follow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["location"].startswith("https://github.com/login/oauth/authorize?")
+    assert any(
+        c.startswith("grug_oauth_state=")
+        for c in r.headers.get_list("set-cookie")
+    )

--- a/services/webhook/personas/tpm/persona.py
+++ b/services/webhook/personas/tpm/persona.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Literal
 
 from github_app_auth import with_install_token_retry
 from github_checks_client import CheckConclusion, CheckRunResult, post_check_run

--- a/services/webhook/tests/test_health.py
+++ b/services/webhook/tests/test_health.py
@@ -38,12 +38,29 @@ def test_no_healthz_endpoint() -> None:
     assert r.status_code == 404
 
 
-def test_livez_does_no_io():
+def test_livez_does_no_io(monkeypatch):
     """Liveness must be cheap — no DDB, KMS, or HTTPX call. If it ever
-    starts depending on downstream, move it to /readyz semantics."""
-    import inspect
-    import main as webhook_main
-    src = inspect.getsource(webhook_main.livez)
-    forbidden = ("get_item", "decrypt", "httpx.", "_table.", "boto3.")
-    assert not any(token in src for token in forbidden), \
-        f"livez must not do IO; found one of {forbidden} in source"
+    starts depending on downstream, move it to /readyz semantics.
+
+    Runtime sentinel: patch every potential IO surface with a noisy
+    mock that records calls. After hitting /livez, assert zero calls
+    to ANY of them. Catches more than the prior source-string scan
+    (helper functions, renamed variables, future deps)."""
+    from unittest.mock import MagicMock
+    import boto3
+    import httpx
+
+    boto3_client_calls: list = []
+    boto3_resource_calls: list = []
+    httpx_calls: list = []
+
+    monkeypatch.setattr(boto3, "client", MagicMock(side_effect=lambda *a, **k: boto3_client_calls.append((a, k)) or MagicMock()))
+    monkeypatch.setattr(boto3, "resource", MagicMock(side_effect=lambda *a, **k: boto3_resource_calls.append((a, k)) or MagicMock()))
+    for verb in ("get", "post", "put", "delete", "patch"):
+        monkeypatch.setattr(httpx, verb, MagicMock(side_effect=lambda *a, **k: httpx_calls.append((verb, a, k)) or MagicMock()))
+
+    r = client.get("/livez")
+    assert r.status_code == 200
+    assert boto3_client_calls == [], "livez triggered boto3.client()"
+    assert boto3_resource_calls == [], "livez triggered boto3.resource()"
+    assert httpx_calls == [], f"livez triggered httpx call: {httpx_calls}"


### PR DESCRIPTION
## Why

code-reviewer agent ran post-PR-#113 and surfaced 3 findings: 2 unused-import nits (#1) + 1 weaker test (#2 substring-match) + 1 router-bypass gap (#3). All low-risk cleanup.

## Changes

| Finding | File | Change |
|---|---|---|
| 1 | services/{api,webhook}/personas/tpm/persona.py | Drop `from typing import Any, Literal` (leftover from pre-#111 shape) |
| 2 | services/webhook/tests/test_health.py | livez_does_no_io: replace source-string scan with runtime patch sentinel (catches helper IO + renamed deps + future libs) |
| 3 | services/api/tests/test_oauth_routes.py | Add 3 TestClient round-trip tests for logout, me, login (catches FastAPI router-path typos that direct-handler tests bypass) |

## Acceptance criteria

- [x] No unused imports in either persona.py
- [x] livez no-io test uses runtime sentinel (boto3.client/resource + httpx 5 verbs)
- [x] OAuth routes have at least one TestClient happy-path each
- [x] Mirrored-files drift-lint stays clean

## Test plan

- [ ] CI green

## Out of scope

- AST-level checks for livez (overkill — runtime sentinel is good enough)
- Full TestClient migration of all OAuth tests (router-binding catch is the value-add; direct tests still cover branch logic without TestClient overhead)

**Size:** XS