### PR TITLE
fix(deploy): grant kms:GenerateDataKey to gha-deploy role

### DIFF
--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -122,6 +122,15 @@ def create(
                             "kms:Encrypt",
                             "kms:CreateGrant",
                             "kms:DescribeKey",
+                            # Lambda's UpdateFunctionConfiguration on a
+                            # CMK-protected function performs an upfront
+                            # GenerateDataKey check using the calling
+                            # principal's perms. Verified mid-loop on
+                            # run 25310220972 (failed step 10, succeeded
+                            # step 10c after IAM-retry sleep). Adding
+                            # defensively so cold-account first deploys
+                            # don't repeat the chicken-egg.
+                            "kms:GenerateDataKey",
                         ],
                         # NOTE: tightening to specific resource ARNs is a
                         # follow-up. Slice 1 prioritizes "deploy works".


### PR DESCRIPTION
## Why

PR #79 added kms:Encrypt + CreateGrant + DescribeKey for Lambda env-var KMS encryption. Lambda's UpdateFunctionConfiguration on a CMK-protected function ALSO performs an upfront kms:GenerateDataKey check on the calling principal's perms.

Verified live on run 25310220972: step 10 failed 'is not authorized to perform: kms:GenerateDataKey'. Step 10c retry succeeded after the 45s sleep let IAM eventual consistency catch up (RolePolicy was updated in parallel during step 10).

Adding defensively so cold-account first deploys don't repeat the chicken-egg.

## Acceptance criteria

- [x] kms:GenerateDataKey added to oidc_role.py policy
- [x] Comment explains the verification trace + run ID
- [x] Resource scope unchanged ('*' — same as Encrypt/Decrypt grants)

## Test plan

- [ ] CI green
- [ ] Next pulumi up sees no 'kms:GenerateDataKey denied' in step 10

## Out of scope

- Tightening Resource: '*' to specific CMK ARN — separate hardening pass

**Size:** XS