### PR TITLE
fix(#88): replace IAM-retry workflow hack with pulumiverse_time.Sleep

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -150,10 +150,13 @@ jobs:
           done
           echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
+      # IAM eventual consistency now modeled in IaC via a
+      # `pulumiverse_time.Sleep` resource that gates KMS-using Lambda
+      # ops on the deploy-role policy having propagated. Local + CI
+      # share the same waiter. Closes #88. Previously this step had
+      # `continue-on-error: true` + a 45s sleep + retry (steps 10b/10c).
       - name: 10. Pulumi up
-        id: pulumi_up_first
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
-        continue-on-error: true
         with:
           command: up
           stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
@@ -161,31 +164,6 @@ jobs:
           # full_commit_sha = 40-char SHA used for DD source-code linking
           # (image_tag is 8-char short SHA; DD source UI requires full).
           # Greptile P1 PR #81.
-          config-map: |
-            webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
-            api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }
-            full_commit_sha:   { value: "${{ github.sha }}" }
-
-      # IAM eventual consistency: when pulumi up adds new RolePolicy
-      # statements (e.g. kms:Encrypt for env-var encryption) AND in the
-      # same plan tries to use those perms (Lambda UpdateFunctionConfig),
-      # AWS auth checks may still see the old policy for 10-30s after
-      # the RolePolicy update returns success. The first run's IAM update
-      # propagates by the time the retry kicks off. Closes #60 deploy
-      # flakiness on env-var-encrypt-touching diffs.
-      - name: 10b. Wait for IAM propagation if pulumi-up failed
-        if: steps.pulumi_up_first.outcome == 'failure'
-        run: |
-          echo "::warning::pulumi up #1 failed — sleeping 45s for IAM consistency, retrying"
-          sleep 45
-
-      - name: 10c. Pulumi up (retry on IAM-consistency failure)
-        if: steps.pulumi_up_first.outcome == 'failure'
-        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
-        with:
-          command: up
-          stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
-          work-dir: infra/pulumi
           config-map: |
             webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
             api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -92,7 +92,7 @@ _dd_extension_version = config.get("dd_extension_version") or "65"
 
 # OIDC trust for GitHub Actions deploys from githumps/grug. Per
 # `feedback_prefer_ssm_over_1p` — no long-lived AWS creds in the repo.
-gha_deploy_role = oidc_role.create(
+_deploy_role_bundle = oidc_role.create(
     name="grug-gha-deploy",
     repo="githumps/grug",
     # `main` and SaaS-conversion feature branches (epic-grug-saas).
@@ -105,6 +105,11 @@ gha_deploy_role = oidc_role.create(
     branches=["main", "feat/*", "fix/*", "hotfix/*"],
     tags_pattern="v*",
 )
+gha_deploy_role = _deploy_role_bundle.role
+# Sleep waiter that gates KMS-using Lambda Function ops on the deploy
+# role's IAM policy having propagated. Closes #88 — replaces workflow-
+# layer retry hack with in-IaC dependency edge.
+_iam_propagation_wait = _deploy_role_bundle.iam_propagation_wait
 
 # Slice 2 (#23) — DDB single-table + KMS CMK + api Lambda
 grug_main_table = ddb_table.create("grug-main")
@@ -185,6 +190,10 @@ webhook = lambda_service.create(
     # plaintext API key. Closes #60. Webhook role granted kms:Decrypt
     # via the additional inline policy below.
     env_vars_kms_key_arn=grug_tokens_cmk.arn,
+    # Wait 45s after deploy-role policy update so AWS auth-checks see
+    # `kms:Encrypt` + `kms:GenerateDataKey` before this Function update
+    # runs. Closes #88.
+    iam_propagation_wait=_iam_propagation_wait,
 )
 
 # Webhook role gains kms:Decrypt on the grug-tokens CMK — required so
@@ -294,6 +303,8 @@ api_lambda = lambda_service.create(
     # OAuth tokens), so the additional Lambda-runtime decrypt at cold
     # start is covered by the existing grant. Closes #60.
     env_vars_kms_key_arn=grug_tokens_cmk.arn,
+    # See webhook above. Closes #88.
+    iam_propagation_wait=_iam_propagation_wait,
 )
 
 # Per IAM split (Slice 2 acceptance criterion): api Lambda CAN decrypt

--- a/infra/pulumi/components/lambda_service.py
+++ b/infra/pulumi/components/lambda_service.py
@@ -41,6 +41,7 @@ def create(
     cors_allow_headers: list[str] | None = None,
     cors_allow_credentials: bool = False,
     env_vars_kms_key_arn: pulumi.Input[str] | None = None,
+    iam_propagation_wait: pulumi.Resource | None = None,
 ) -> LambdaService:
     log_group = aws.cloudwatch.LogGroup(
         f"{name}-logs",
@@ -152,6 +153,16 @@ def create(
     # plaintext-visible to anyone with default ReadOnlyAccess Lambda
     # perms. Lambda runtime decrypts before extension boot, so DD ext
     # still reads DD_API_KEY normally.
+    # `iam_propagation_wait` (issue #88) defers Lambda create/update
+    # until the GHA deploy role's RolePolicy has propagated through
+    # AWS IAM (10-30s typical). Without this, an in-same-plan addition
+    # of `kms:Encrypt` + `kms:GenerateDataKey` to the deploy role +
+    # Lambda kms_key_arn-touching update collides on AWS auth-check.
+    function_opts = (
+        pulumi.ResourceOptions(depends_on=[iam_propagation_wait])
+        if iam_propagation_wait is not None
+        else None
+    )
     function = aws.lambda_.Function(
         name,
         name=name,
@@ -178,6 +189,7 @@ def create(
             "env": env_vars["GRUG_ENV"],
             "team": "grug",
         },
+        opts=function_opts,
     )
 
     # Lambda Function URL CORS — preflight handled by AWS *before* the

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -5,14 +5,25 @@ secrets. GHA assumes this role via OIDC each deploy.
 
 Trust is scoped to a specific repo + ref pattern (branches + tags) so a
 fork or PR from a different repo can't assume the role.
+
+IAM eventual-consistency: when this role's RolePolicy is updated AND in
+the same `pulumi up` run a Lambda is configured to use the new perms
+(e.g. kms_key_arn requires kms:Encrypt + kms:GenerateDataKey on the
+caller), AWS auth checks may still see the old policy for 10-30s. Closes
+issue #88 — replaces the workflow-layer retry hack with an in-IaC
+`pulumiverse_time.Sleep` whose triggers re-fire on policy content
+change. Local + CI pulumi-up share the same waiter.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+from dataclasses import dataclass
 
 import pulumi
 import pulumi_aws as aws
+import pulumiverse_time as ptime
 
 
 def _ensure_oidc_provider() -> str:
@@ -35,12 +46,21 @@ def _ensure_oidc_provider() -> str:
     )
 
 
+@dataclass
+class DeployRole:
+    """Bundle returned by `create()` so the composition root can wire the
+    `iam_propagation_wait` resource into Lambda Function `depends_on`."""
+
+    role: aws.iam.Role
+    iam_propagation_wait: ptime.Sleep
+
+
 def create(
     name: str,
     repo: str,
     branches: list[str],
     tags_pattern: str | None = None,
-) -> aws.iam.Role:
+) -> DeployRole:
     provider_arn = _ensure_oidc_provider()
 
     sub_patterns = [f"repo:{repo}:ref:refs/heads/{b}" for b in branches]
@@ -87,10 +107,7 @@ def create(
     # SSM read explicitly includes `/shared/*` so CI can fetch the
     # cross-repo Pulumi access token (per githumps/infrastructure#164
     # SSM convention — `/shared/<token>` is the cross-cutting namespace).
-    aws.iam.RolePolicy(
-        f"{name}-policy",
-        role=role.id,
-        policy=json.dumps(
+    deploy_policy_doc = json.dumps(
             {
                 "Version": "2012-10-17",
                 "Statement": [
@@ -138,6 +155,28 @@ def create(
                     },
                 ],
             },
-        ),
+        )
+    deploy_policy = aws.iam.RolePolicy(
+        f"{name}-policy",
+        role=role.id,
+        policy=deploy_policy_doc,
     )
-    return role
+
+    # Hash the policy doc so a content change re-triggers the Sleep
+    # (which forces a 45s wait before any depends_on Lambda update).
+    # Per pulumiverse_time docs, `triggers` change → resource replace →
+    # `create_duration` re-fires.
+    policy_hash = hashlib.sha256(deploy_policy_doc.encode()).hexdigest()
+    iam_propagation_wait = ptime.Sleep(
+        f"{name}-iam-propagation",
+        create_duration="45s",
+        triggers={
+            "role_policy_id": deploy_policy.id,
+            # Content hash so policy edits (not just resource id) refresh
+            # the wait. Without this, in-place policy.update wouldn't
+            # cause the Sleep to refire.
+            "policy_sha256": policy_hash,
+        },
+    )
+
+    return DeployRole(role=role, iam_propagation_wait=iam_propagation_wait)

--- a/infra/pulumi/pyproject.toml
+++ b/infra/pulumi/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pulumi-aws>=6.50.0,<7.0.0",
     "pulumi-cloudflare>=5.0.0,<6.0.0",
     "pulumi-datadog>=5.0.0,<6.0.0",
+    "pulumiverse-time>=0.1.1",
 ]
 
 [tool.uv]


### PR DESCRIPTION
Closes #88.

## Why

PR #83 added a workflow-layer retry pattern: if `pulumi up` fails, sleep 45s + retry. Works for CI flakiness on IAM eventual-consistency (deploy role gains `kms:Encrypt` + `kms:GenerateDataKey` AND in same plan does Lambda update with `kms_key_arn` set → 10-30s window where AWS auth-check still sees old policy → 403). Local `pulumi up` users see the bare error with no auto-retry — drift between CI + local. Move the propagation wait into IaC so both surfaces share one waiter.

**Size:** S

## What changed

- `oidc_role.create()` returns `DeployRole(role, iam_propagation_wait)`.
- `iam_propagation_wait = pulumiverse_time.Sleep(create_duration="45s", triggers={role_policy_id, policy_sha256})`. The sha256 trigger refires the wait on policy content change, not just resource-id change.
- `lambda_service.create()` accepts `iam_propagation_wait` and applies it as `ResourceOptions(depends_on=[...])` on `aws.lambda_.Function`.
- `__main__.py` threads the Sleep through both webhook + api Lambda creates.
- `iac.deploy.yml`: deleted steps 10b (`sleep 45`) + 10c (retry pulumi up). Step 10 no longer needs `continue-on-error`.

## Acceptance criteria

- [x] Add pulumi-time to deps (via `uv add pulumiverse-time` → pyproject.toml)
- [x] Wrap RolePolicy → Lambda Function dependency edge with Sleep
- [x] Remove workflow steps 10b + 10c
- [ ] Local + CI pulumi up both succeed on cold deploy (verifies in CI run on this PR)

## Test plan

- [ ] `iac.preview` workflow runs clean on this PR
- [ ] `iac.deploy` runs clean on first merge to `main` after PR (acceptance proof — deploy succeeds without 10b/10c retry)
- [ ] No regression in webhook/api Lambda env-var encryption (verified by existing `services/{api,webhook}/tests/`)
- [ ] `python -m py_compile infra/pulumi/{__main__.py,components/oidc_role.py,components/lambda_service.py}` — done locally, OK

## Out of scope

- Tightening deploy role's `Resource: "*"` to specific ARNs (separate cleanup, was already deferred in #83).
- Removing `pulumiverse_time` package memo from PR description (this is a long-form companion to a small change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)