### PR TITLE
test(#105): httpx.MockTransport fixture for real transport-error coverage

### DIFF
--- a/services/webhook/tests/conftest.py
+++ b/services/webhook/tests/conftest.py
@@ -1,0 +1,91 @@
+"""pytest config for services/webhook/ tests.
+
+Adds the parent directory to sys.path so tests can `from hmac_verify
+import ...` without a package install (handler files live alongside the
+tests folder, not under a package).
+
+Also exposes `mock_transport_client` + `raise_status_error` helpers
+that build a real `httpx.Client` whose request handler is driven by
+`httpx.MockTransport`. Closes the mock-vs-real gap from
+async-blocker-hunter F-01 (issue #105): direct construction of
+`httpx.HTTPStatusError(...)` keeps tests green even if the production
+`except` clause silently narrows to a sub-class. With MockTransport,
+the exception comes from real httpx machinery.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _build_handler(
+    *,
+    status_codes: list[int] | None = None,
+    raise_exc: BaseException | None = None,
+    json_bodies: list[Any] | None = None,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Build a MockTransport handler that returns / raises in sequence."""
+
+    seq_status = list(status_codes or [])
+    seq_json = list(json_bodies or [])
+    idx = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if raise_exc is not None:
+            raise raise_exc
+        i = idx["n"]
+        idx["n"] += 1
+        status = seq_status[i] if i < len(seq_status) else (seq_status[-1] if seq_status else 200)
+        body = seq_json[i] if i < len(seq_json) else (seq_json[-1] if seq_json else {})
+        return httpx.Response(status, json=body)
+
+    return handler
+
+
+@pytest.fixture
+def mock_transport_client() -> Iterator[Callable[..., httpx.Client]]:
+    """Factory fixture: build a real httpx.Client backed by MockTransport.
+
+    Usage:
+
+        client = mock_transport_client(status_codes=[401, 200],
+                                       json_bodies=[{}, {"ok": True}])
+        resp = client.get("https://api.github.com/foo")
+        # First call returns 401, second returns 200.
+
+        client = mock_transport_client(raise_exc=httpx.ConnectError("boom"))
+        # Every call raises ConnectError from real httpx machinery.
+
+    Pass the returned client into a `monkeypatch.setattr(httpx, "get",
+    client.get)` (or post) to redirect a production module-level call.
+    """
+    created: list[httpx.Client] = []
+
+    def factory(
+        *,
+        status_codes: list[int] | None = None,
+        raise_exc: BaseException | None = None,
+        json_bodies: list[Any] | None = None,
+    ) -> httpx.Client:
+        transport = httpx.MockTransport(
+            _build_handler(
+                status_codes=status_codes,
+                raise_exc=raise_exc,
+                json_bodies=json_bodies,
+            ),
+        )
+        client = httpx.Client(transport=transport)
+        created.append(client)
+        return client
+
+    yield factory
+    for c in created:
+        c.close()

--- a/services/webhook/tests/test_github_checks_client.py
+++ b/services/webhook/tests/test_github_checks_client.py
@@ -106,26 +106,22 @@ def test_post_check_run_includes_external_id_when_provided():
     assert body["external_id"] == "trace-id-7"
 
 
-def test_post_check_run_401_propagates_for_retry_helper():
+def test_post_check_run_401_propagates_for_retry_helper(mock_transport_client):
     """post_check_run does NOT swallow 401 — the with_install_token_retry
     wrapper at the call site is responsible for invalidating the cache
-    + retrying. Closes #50."""
+    + retrying. Closes #50.
+
+    Real-transport-backed (issue #105): exception comes from
+    `resp.raise_for_status()` on a real `httpx.Response(401)`, not from
+    a hand-built `HTTPStatusError`.
+    """
     result = CheckRunResult(
         name="dor", head_sha="abc", status="completed",
         conclusion="success", title="x", summary="y",
     )
+    client = mock_transport_client(status_codes=[401])
 
-    def _raise_401():
-        raise httpx.HTTPStatusError(
-            "401",
-            request=httpx.Request("POST", "https://api.github.com/..."),
-            response=httpx.Response(401),
-        )
-
-    bad = _ok_response()
-    bad.raise_for_status = _raise_401
-
-    with patch("httpx.post", return_value=bad):
+    with patch("httpx.post", side_effect=lambda *a, **kw: client.post(*a, **kw)):
         with pytest.raises(httpx.HTTPStatusError) as exc:
             post_check_run("stale-tok", "o", "r", result)
     assert exc.value.response.status_code == 401
@@ -150,23 +146,31 @@ def test_check_run_result_rejects_in_progress_with_conclusion():
         )
 
 
-def test_post_check_run_500_propagates_unwrapped():
+def test_post_check_run_500_propagates_unwrapped(mock_transport_client):
+    """Real-transport-backed (issue #105) — 500 raised via raise_for_status."""
     result = CheckRunResult(
         name="dor", head_sha="abc", status="completed",
         conclusion="success", title="x", summary="y",
     )
+    client = mock_transport_client(status_codes=[500])
 
-    def _raise_500():
-        raise httpx.HTTPStatusError(
-            "500",
-            request=httpx.Request("POST", "https://api.github.com/..."),
-            response=httpx.Response(500),
-        )
-
-    bad = _ok_response()
-    bad.raise_for_status = _raise_500
-
-    with patch("httpx.post", return_value=bad):
+    with patch("httpx.post", side_effect=lambda *a, **kw: client.post(*a, **kw)):
         with pytest.raises(httpx.HTTPStatusError) as exc:
             post_check_run("tok", "o", "r", result)
     assert exc.value.response.status_code == 500
+
+
+def test_post_check_run_connect_error_propagates(mock_transport_client):
+    """Transport-level ConnectError must propagate (not get caught by an
+    httpx.HTTPStatusError-only handler). Closes mock-vs-real gap from
+    issue #105 / async-blocker-hunter F-01.
+    """
+    result = CheckRunResult(
+        name="dor", head_sha="abc", status="completed",
+        conclusion="success", title="x", summary="y",
+    )
+    client = mock_transport_client(raise_exc=httpx.ConnectError("dns down"))
+
+    with patch("httpx.post", side_effect=lambda *a, **kw: client.post(*a, **kw)):
+        with pytest.raises(httpx.ConnectError):
+            post_check_run("tok", "o", "r", result)

--- a/services/webhook/tests/test_install_token_retry.py
+++ b/services/webhook/tests/test_install_token_retry.py
@@ -32,38 +32,41 @@ def _stub_token(monkeypatch: pytest.MonkeyPatch):
     return counter
 
 
-def test_retry_on_401_invalidates_and_refetches(_stub_token):
+def test_retry_on_401_invalidates_and_refetches(_stub_token, mock_transport_client):
+    """First call: 401 from real httpx machinery. Second call: 200.
+
+    Closes mock-vs-real gap from async-blocker-hunter F-01 (issue #105) —
+    direct construction of `httpx.HTTPStatusError(...)` keeps tests green
+    even if production `except` clause narrows to a sub-class. With
+    MockTransport, the exception comes from `resp.raise_for_status()`.
+    """
+    client = mock_transport_client(status_codes=[401, 200], json_bodies=[{}, {"ok": True}])
     calls: list[str] = []
 
     def fn(token: str) -> str:
         calls.append(token)
-        if len(calls) == 1:
-            raise httpx.HTTPStatusError(
-                "401",
-                request=httpx.Request("GET", "https://api.github.com/repos"),
-                response=httpx.Response(401),
-            )
-        return "ok"
+        resp = client.get("https://api.github.com/repos")
+        resp.raise_for_status()
+        return resp.json()["ok"]
 
     result = gh_auth.with_install_token_retry(123, fn)
 
-    assert result == "ok"
+    assert result is True
     assert len(calls) == 2, "fn must be called twice (once + retry)"
     assert calls[0] == "token-1-refresh=False", "first call uses cached token"
     assert calls[1] == "token-2-refresh=True", \
         "retry must force_refresh — otherwise cache returns same bad token"
 
 
-def test_non_401_status_propagates_without_retry(_stub_token):
+def test_non_401_status_propagates_without_retry(_stub_token, mock_transport_client):
+    client = mock_transport_client(status_codes=[500])
     calls: list[str] = []
 
     def fn(token: str) -> str:
         calls.append(token)
-        raise httpx.HTTPStatusError(
-            "500",
-            request=httpx.Request("GET", "https://api.github.com/repos"),
-            response=httpx.Response(500),
-        )
+        resp = client.get("https://api.github.com/repos")
+        resp.raise_for_status()
+        return None
 
     with pytest.raises(httpx.HTTPStatusError) as ei:
         gh_auth.with_install_token_retry(123, fn)

--- a/services/webhook/tests/test_recheck_slash.py
+++ b/services/webhook/tests/test_recheck_slash.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 import dispatcher as d
@@ -185,32 +186,36 @@ def test_tpm_disabled_per_repo_no_ops(monkeypatch):
     assert "tpm disabled" in out["reason"]
 
 
-def test_perm_lookup_transport_error_returns_skip(_no_install_lookups):
+def test_perm_lookup_transport_error_returns_skip(_no_install_lookups, mock_transport_client):
     """async-blocker-hunter F-01: transport error during perm lookup
-    must return skip + log, not 500."""
-    payload = _comment_payload(body="/grug recheck", sender_login="bob", pr_author="evan")
+    must return skip + log, not 500.
 
-    def _raise_transport(*args, **kwargs):
-        raise httpx.ConnectError("DNS failure")
+    Real-transport-backed (issue #105): ConnectError comes from
+    httpx.MockTransport handler raising.
+    """
+    payload = _comment_payload(body="/grug recheck", sender_login="bob", pr_author="evan")
+    client = mock_transport_client(raise_exc=httpx.ConnectError("DNS failure"))
 
     with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
-        with patch("httpx.get", side_effect=_raise_transport):
+        with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
             out = d.dispatch("issue_comment", payload)
 
     assert out["status"] == "skip"
     assert "transport" in out["reason"]
 
 
-def test_pr_fetch_transport_error_returns_skip(_no_install_lookups):
+def test_pr_fetch_transport_error_returns_skip(_no_install_lookups, mock_transport_client):
     """async-blocker-hunter F-01: transport error during PR re-fetch
-    must return skip + log, not 500."""
-    payload = _comment_payload(body="/grug recheck", sender_login="evan", pr_author="evan")
+    must return skip + log, not 500.
 
-    def _raise_timeout(*args, **kwargs):
-        raise httpx.ReadTimeout("github.com slow")
+    Real-transport-backed (issue #105): ReadTimeout comes from
+    httpx.MockTransport handler raising.
+    """
+    payload = _comment_payload(body="/grug recheck", sender_login="evan", pr_author="evan")
+    client = mock_transport_client(raise_exc=httpx.ReadTimeout("github.com slow"))
 
     with patch("github_app_auth.with_install_token_retry", side_effect=lambda _i, fn: fn("tok")):
-        with patch("httpx.get", side_effect=_raise_timeout):
+        with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
             out = d.dispatch("issue_comment", payload)
 
     assert out["status"] == "skip"


### PR DESCRIPTION
Closes #105.

## Why

async-blocker-hunter F-01 caught: existing tests construct `httpx.HTTPStatusError(...)` directly. If a future narrowing of the production `except` clause from `RequestError` to a sub-class slips in, tests stay green even though the exception type wouldn't be caught at runtime. Replace direct construction with `httpx.MockTransport`-backed real `httpx.Client` so the exception comes from real httpx machinery.

**Size:** S

## What changed

- `services/webhook/tests/conftest.py` (new): `mock_transport_client` factory fixture. Cleans up created clients on teardown.
- `test_install_token_retry.py`: 401-then-200 retry path + 500-no-retry path use real `httpx.Client` with `MockTransport` instead of hand-raising.
- `test_github_checks_client.py`: 401 + 500 paths converted; added `test_post_check_run_connect_error_propagates` covering transport-level error.
- `test_recheck_slash.py`: perm-lookup-transport-error + pr-fetch-transport-error tests use real `ConnectError` / `ReadTimeout` from a MockTransport handler.

## Acceptance criteria

- [x] `services/webhook/tests/conftest.py` exposes parametrized fixture
- [x] `test_recheck_slash` + `test_github_checks_client` + `test_install_token_retry` use it for transport-error paths
- [x] Removes hand-built `httpx.HTTPStatusError(...)` from those tests
- [x] CI run-time impact <1s (147 tests in 2.6s; identical to baseline)

## Test plan

- [x] `pytest -q tests/test_install_token_retry.py tests/test_github_checks_client.py tests/test_recheck_slash.py` → 25/25 pass
- [x] `pytest -q tests/` (full suite) → 147 pass, 4 pre-existing failures in `test_main_webhook_receiver.py` (verified on `main` via stash)
- [x] `python -m py_compile` on all 4 modified files

## Out of scope

- Fix the 4 pre-existing `test_main_webhook_receiver.py` failures (separate cleanup ticket; pre-dates this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)