### PR TITLE
fix(admin): record github_user_id (not login) on allowlisted_by audit field

### DIFF
--- a/services/api/admin.py
+++ b/services/api/admin.py
@@ -171,7 +171,10 @@ def patch_user(
         if payload.allowlisted and not before["allowlisted"]:
             update_parts.append("allowlisted_at = :at, allowlisted_by = :by")
             expr_vals[":at"] = now
-            expr_vals[":by"] = actor.login
+            # Record the immutable github_user_id, not the (mutable) login.
+            # GitHub usernames can be renamed; the audit trail must survive
+            # a username change.
+            expr_vals[":by"] = actor.github_user_id
     if payload.role is not None:
         # `role` is a DDB reserved word — must alias.
         update_parts.append("#r = :r")

--- a/services/api/tests/test_admin.py
+++ b/services/api/tests/test_admin.py
@@ -106,7 +106,9 @@ def test_patch_user_flips_allowlist(_ddb):
     assert out["before"]["allowlisted"] is False
     assert out["after"]["allowlisted"] is True
     assert out["changed"] is True
-    assert out["user"]["allowlisted_by"] == "admin"
+    # allowlisted_by records the immutable github_user_id, not login.
+    # _admin_user() in this fixture is github_user_id="100".
+    assert out["user"]["allowlisted_by"] == "100"
 
 
 def test_patch_user_404_unknown(_ddb):


### PR DESCRIPTION
## Why

GitHub usernames are mutable — a user can rename their account at any time, and audit trails referencing the old login become orphaned. The `allowlisted_by` audit field on USER# rows must reference the immutable `github_user_id`, not the (mutable) `login`. The pre-existing `test_patch_user_first_allowlist_writes_audit_trail` already asserted the correct behavior — production code was wrong.

**Size:** XS

## What changed

- `services/api/admin.py:174`: `expr_vals[":by"] = actor.github_user_id` (was `actor.login`).
- `services/api/tests/test_admin.py:109`: corrected an inverse assertion in `test_patch_user_flips_allowlist` that was inadvertently testing the old (wrong) behavior. The other test in the file (`test_patch_user_first_allowlist_writes_audit_trail`) already asserted the correct shape and was failing on `main` until this fix.

## Acceptance criteria

- [x] `allowlisted_by` records `github_user_id` not `login`
- [x] Both `test_patch_user_first_allowlist_writes_audit_trail` + `test_patch_user_flips_allowlist` pass
- [x] No other audit-field references depend on the old (login) shape

## Test plan

- [x] `pytest -q services/api/tests/test_admin.py` → 12/12 pass
- [x] Grep `allowlisted_by` across services/ — no other code path reads from this field except the read-projection (`_user_to_admin_view`) which echoes whatever is stored.

## Out of scope

- Backfilling existing rows in DDB whose `allowlisted_by` is a login. There are 0 production rows with `allowlisted` flipped (Evan + GF are both seeded admin/lifetime, allowlisted=true at table init time per locked PRD #21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)