### PR TITLE
fix(test): remove stale _session_secret monkeypatch from oauth fixture

### DIFF
--- a/services/api/tests/test_oauth_routes.py
+++ b/services/api/tests/test_oauth_routes.py
@@ -19,8 +19,10 @@ def _oauth_mod(monkeypatch):
     monkeypatch.setenv("GITHUB_APP_CLIENT_SECRET_SSM", "/grug/test-client-secret")
     monkeypatch.setenv("GRUG_DOMAIN", "grug.lol")
     import auth.github_oauth as mod
+    # State CSRF + session cookie signing both use `_state_secret` —
+    # no separate `_session_secret` function exists. The session HMAC
+    # binds gh_id (Codex P1 fix in Slice 7) but uses the same key.
     monkeypatch.setattr(mod, "_state_secret", lambda: "test-secret-v1")
-    monkeypatch.setattr(mod, "_session_secret", lambda: "test-session-v1")
     monkeypatch.setattr(mod, "_client_id", lambda: "Iv1.testclientid")
     monkeypatch.setattr(mod, "_client_secret", lambda: "test-client-secret")
     return mod


### PR DESCRIPTION
## Why

\`tests/test_oauth_routes.py\` fixture patches \`mod._session_secret\` which doesn't exist. State CSRF + session-cookie HMAC both sign with \`_state_secret()\` — there is no separate \`_session_secret()\` function. The patch raised \`AttributeError\` at fixture setup, so all 11 tests in the file were erroring (not failing) with zero meaningful coverage of the OAuth route paths.

**Size:** XS

## What changed

- \`services/api/tests/test_oauth_routes.py:23\`: removed the stale \`monkeypatch.setattr(mod, \"_session_secret\", ...)\` line. Added a 2-line comment noting both signing paths use the single \`_state_secret\`.

## Acceptance criteria

- [x] All 11 tests pass (was 11 errors)
- [x] No production code changed
- [x] Tests still cover: login redirect, state cookie attrs, state HMAC round-trip, /me anon/invalid/valid, logout, TestClient OAuth flow

## Test plan

- [x] \`pytest -q services/api/tests/test_oauth_routes.py\` → 11/11 pass

## Out of scope

- The 1 pre-existing \`test_admin\` failure was fixed in #122; this PR completes the cleanup of the suite issues uncovered during the 2026-05-04 autonomous loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)