### PR TITLE
fix(webhook): use Request.body() for raw bytes — JSON content-type was 422ing

### DIFF
--- a/services/webhook/main.py
+++ b/services/webhook/main.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import logging
 import os
 
-from fastapi import Body, FastAPI, Header, HTTPException, status
+from fastapi import FastAPI, Header, HTTPException, Request, status
 
 from hmac_verify import verify_signature
 from observability import configure_logging
@@ -51,20 +51,25 @@ def readyz() -> dict[str, str]:
 
 
 @app.post("/webhook/github")
-def receive_github_webhook(
-    body: bytes = Body(...),
+async def receive_github_webhook(
+    request: Request,
     x_github_event: str = Header(default=""),
     x_github_delivery: str = Header(default=""),
     x_hub_signature_256: str = Header(default=""),
 ) -> dict[str, str]:
-    # Handler is `def`, not `async def`. Every downstream call (DDB
-    # boto3, httpx GitHub posts, KMS) is sync I/O — running them on
-    # the asyncio event loop blocks every other coroutine in the
-    # process. FastAPI runs sync `def` handlers in a threadpool via
-    # Starlette's run_in_threadpool, so concurrent invocations don't
-    # starve each other. Mangum supports both signatures.
-    # Body injected via `bytes = Body(...)` (raw body, no JSON parse)
-    # because HMAC verify needs the exact wire bytes. Closes #68.
+    # Handler is async because reading raw body via Starlette's Request
+    # requires `await request.body()`. Earlier sync version used
+    # `body: bytes = Body(...)` but FastAPI 0.115 / Pydantic-v2
+    # JSON-decodes the body BEFORE bytes-validation when the
+    # Content-Type is application/json (GitHub's default), then 422s
+    # on the parsed dict not being bytes — so HMAC verify never runs.
+    # Using `Request` keeps the wire bytes intact for HMAC verify.
+    #
+    # Lambda concurrency is per-container (one in-flight request per
+    # warm container). Sync boto3 / httpx calls below don't starve
+    # other coroutines because there are none. Closes #68 (the
+    # original spirit) and the pre-Slice-11 422 regression.
+    body = await request.body()
 
     secret = get_webhook_secret()
     if not verify_signature(secret, body, x_hub_signature_256):


### PR DESCRIPTION
## Why

PR #76 dropped \`async def\` on \`receive_github_webhook\` and switched body to FastAPI's \`body: bytes = Body(...)\` injection. In FastAPI 0.115 + Pydantic-v2, this path JSON-decodes the body BEFORE the bytes-shape validation when \`Content-Type: application/json\` (GitHub's default) — the parsed dict fails bytes validation, returning **422 to GitHub before HMAC verify even runs**.

**Production-blocking for Slice 11 (#32)** — first real GitHub webhook would 422. Production hasn't been hit because the App is not yet installed on any consumer repo.

**Size:** S

## What changed

\`services/webhook/main.py\`:

- Import \`Request\` instead of \`Body\`.
- \`receive_github_webhook\` becomes \`async def\`.
- Body via \`await request.body()\` (raw wire bytes; HMAC verify gets the exact payload GitHub signed).
- Updated the rationale comment: handler must be async to await body, but Lambda's per-container concurrency means no other coroutines to starve, so sync boto3/httpx calls below remain fine.

## Acceptance criteria

- [x] Handler returns 401 for unsigned + bad-signature requests
- [x] Handler returns 400 for HMAC-passing non-JSON body
- [x] Handler returns 200 for HMAC-passing JSON body + dispatches to persona
- [x] No regression in any other webhook test
- [x] HMAC verify still runs on raw wire bytes (not re-serialized JSON)

## Test plan

- [x] \`pytest -q tests/test_main_webhook_receiver.py\` → 4/4 pass (was 4 fail on main)
- [x] \`pytest -q tests/\` (full webhook suite) → **151/151** (was 147 + 4 fail)
- [x] \`python -m py_compile main.py\` → OK

## How was this missed?

PR #76 description was \"drop async def — sync end-to-end\" but had no end-to-end test against an HMAC-signed JSON body — pr-test-analyzer HIGH gap #2 was filed for this gap (PR #99 added the tests but they sat as 4 pre-existing failures because nobody ran the suite end-to-end after PR #76 merged).

## Out of scope

- Changing the Lambda concurrency model — current per-container 1-in-flight pattern is fine.
- Re-introducing run_in_threadpool wrapping — sync downstream calls remain inline since Lambda doesn't expose multi-coroutine concurrency anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)