### PR TITLE
feat(deploy): add post-deploy smoke test (api + webhook /livez + 401)

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -173,3 +173,42 @@ jobs:
         run: bash infra/cloudflare/deploy.sh
         env:
           PULUMI_CWD: infra/pulumi
+
+      # 12. Post-deploy smoke test: catches Lambda boot failures, async-
+      # handler regressions, container handler import errors, CF Worker
+      # mis-routes BEFORE the next webhook lands. Failure here is more
+      # actionable than waiting for the first real request to time out
+      # (or worse, silently 422 like the bug closed in #124).
+      #
+      # Each subcommand is `set -e`-fatal; one failure stops the run.
+      # Retries built in: webhook + api may cold-start on first invoke
+      # so each curl gets up to 30s + 3 retries with backoff.
+      - name: 12. Smoke test public endpoints
+        run: |
+          set -euo pipefail
+          DOMAIN_API="https://api.grug.lol"
+          DOMAIN_WH="https://webhook.grug.lol"
+
+          probe() {
+            local name="$1"
+            local url="$2"
+            local expected="$3"
+            shift 3
+            local actual
+            actual=$(curl -sS -o /dev/null -w "%{http_code}" \
+              --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
+              "$@" "$url")
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::$name expected $expected got $actual ($url)"
+              return 1
+            fi
+            echo "✓ $name ($actual)"
+          }
+
+          probe "api /livez"     "$DOMAIN_API/livez"     200
+          probe "webhook /livez" "$DOMAIN_WH/livez"      200
+          # Unsigned POST must 401 — proves HMAC verify gate runs (the
+          # #124 bug returned 422 here, blocking every real webhook).
+          probe "webhook unsigned POST" "$DOMAIN_WH/webhook/github" 401 \
+            -X POST -H "Content-Type: application/json" \
+            -H "X-GitHub-Event: ping" -d '{"zen":"smoke"}'


### PR DESCRIPTION
Part of #124 (post-deploy verification for the webhook handler async fix).

## Why

Prior to PR #124, the webhook handler had been silently broken since Slice 1 (PR #76 → \`body: bytes = Body(...)\` 422s on JSON content-type) and we wouldn't have noticed until the App was first installed on a real repo. iac.deploy succeeds on \`pulumi up\` but doesn't verify Lambda actually serves traffic. A 30-second smoke-test step catches this class of bug before it reaches GitHub.

**Size:** S

## What changed

\`.github/workflows/iac.deploy.yml\`: new step **\"12. Smoke test public endpoints\"** after CF Worker deploy. Three probes:

1. \`GET api.grug.lol/livez\` → 200 (api Lambda alive + CF Worker proxy)
2. \`GET webhook.grug.lol/livez\` → 200 (webhook Lambda alive)
3. \`POST webhook.grug.lol/webhook/github\` unsigned → **401** (HMAC gate actually runs; would have failed at 422 before #124)

Each curl: 30s timeout, 3 retries with 5s delay, --retry-all-errors so cold-start latency doesn't fail the run.

## Acceptance criteria

- [x] All 3 probes return expected status codes
- [x] Failure surfaces as workflow error (set -e + non-zero exit)
- [x] Cold-start tolerant (retries + timeout)
- [x] Verified locally against current prod state (200/200/401)

## Test plan

- [x] Local probe script: 200/200/401 against api.grug.lol + webhook.grug.lol
- [x] YAML syntax check (\`python3 -c \"import yaml; yaml.safe_load(...)\"\`)
- [ ] Next merge to main: confirm iac.deploy step 12 runs green
- [ ] Verify failure path by injecting a deliberate regression (out of scope here; future hardening could add this)

## Out of scope

- Adding a smoke probe for HMAC-signed POST (would require generating a real webhook secret HMAC at workflow time → adds complexity for marginal coverage; unsigned 401 already proves the handler runs).
- Datadog Synthetic uptime check (already exists per Slice 9 #30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
