### PR TITLE
chore(web): drop dead lint script — eslint not installed

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,6 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
Part of #21 (PRD #21 grug repo hygiene cleanup).

## Why

\`web/package.json\` declared a \`lint\` script invoking eslint, but eslint is not in \`devDependencies\` and no CI workflow runs it. \`npm run lint\` returns \`sh: eslint: command not found\`. Per CLAUDE.md \"do not add abstractions beyond what the task requires\" + the cleanup patterns, drop the dead script. Build + typecheck remain.

**Size:** XS

## What changed

\`web/package.json\`: removed the 1 \`lint\` script line.

## Acceptance criteria

- [x] \`npm run build\` still succeeds (verified locally — 262 KB bundle)
- [x] \`npm run typecheck\` still succeeds
- [x] No CI workflow references \`npm run lint\` (verified — none found in \`.github/workflows/\`)

## Test plan

- [x] Local \`npm run build\` → \`✓ built in 2.48s\`
- [x] Local \`npm run typecheck\` → silent (clean)
- [x] grep for \`npm run lint\` across repo → no hits

## Out of scope

- Re-introducing eslint properly. If we want lint, install + configure as a separate PR (would also wire up to web.deploy.yml as a quality gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
