### PR TITLE
fix(observability): suppress DD Lambda phantom-service inferred spans

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -182,6 +182,18 @@ webhook = lambda_service.create(
         # `reference_dd_apm_asgi_resource_grouping`).
         "DD_PATCH_MODULES": "asgi:false",
         "DD_TRACE_ASGI_ENABLED": "false",
+        # Kill DD Lambda Extension's inferred-spans feature. Without
+        # this, the Extension synthesizes an `aws.lambda.url` root
+        # span per Function URL invocation tagged with the lambda-url
+        # FQDN as `service`, creating a phantom DD APM service entry
+        # like `<id>.lambda-url.us-east-1.on.aws` alongside the real
+        # `grug-webhook` / `grug-api` entries. Canonical kill-switch
+        # per https://docs.datadoghq.com/tracing/services/inferred_services/.
+        # Verified via DD spans 2026-05-07: 64 phantom spans/2h all
+        # carry `service:jikcel...lambda-url.us-east-1.on.aws` AND
+        # `base_service:grug-webhook` — same shape pasto-api faced
+        # before PR somatic-scripts#235 fixed it.
+        "DD_TRACE_MANAGED_SERVICES": "false",
     },
     timeout_seconds=15,
     memory_mb=512,
@@ -287,6 +299,18 @@ api_lambda = lambda_service.create(
         "DD_LOGS_INJECTION": "true",
         "DD_PATCH_MODULES": "asgi:false",
         "DD_TRACE_ASGI_ENABLED": "false",
+        # Kill DD Lambda Extension's inferred-spans feature. Without
+        # this, the Extension synthesizes an `aws.lambda.url` root
+        # span per Function URL invocation tagged with the lambda-url
+        # FQDN as `service`, creating a phantom DD APM service entry
+        # like `<id>.lambda-url.us-east-1.on.aws` alongside the real
+        # `grug-webhook` / `grug-api` entries. Canonical kill-switch
+        # per https://docs.datadoghq.com/tracing/services/inferred_services/.
+        # Verified via DD spans 2026-05-07: 64 phantom spans/2h all
+        # carry `service:jikcel...lambda-url.us-east-1.on.aws` AND
+        # `base_service:grug-webhook` — same shape pasto-api faced
+        # before PR somatic-scripts#235 fixed it.
+        "DD_TRACE_MANAGED_SERVICES": "false",
     },
     timeout_seconds=15,
     memory_mb=512,


### PR DESCRIPTION
Closes #132.

## Why

DD APM Service Catalog (per user screenshot 2026-05-07) shows a phantom service entry:
```
jikcel3mr5vp623ykiqo3p5v7m0zvtoq.lambda-url.us-east-1.on.aws
```

Verified via DD MCP `search_datadog_spans service:jikcel3mr5vp623ykiqo3p5v7m0zvtoq.lambda-url.us-east-1.on.aws` — **64 phantom spans / 2h**, all `operation_name: aws.lambda.url`, every span carrying:

- `service: jikcel...lambda-url.us-east-1.on.aws` (the synthesized service)
- `base_service: grug-webhook` (the real service)
- `function_arn: arn:aws:lambda:us-east-1:317164914846:function:grug-webhook`
- `resource_name: GET /livez` (matches the health-probe path)

Root cause is the DD Lambda Extension's inferred-spans feature: when invocations arrive via Function URL, the Extension synthesizes an `aws.lambda.url` root span tagged with the lambda-url FQDN as `service`. That creates a phantom DD APM service entry alongside the real `grug-webhook`.

Same shape and fix as somatic-scripts pasto-api / tempo-api (PRs githumps/somatic-scripts#235 and #383).

## Fix

Add `DD_TRACE_MANAGED_SERVICES=false` to the Lambda env vars. Per [DD docs on inferred services](https://docs.datadoghq.com/tracing/services/inferred_services/), this is the canonical kill-switch.

Applied to BOTH `grug-webhook` AND `grug-api` Lambdas:
- webhook is the one currently surfaced as a phantom
- api could exhibit the same shape if it later gets a Function URL or behind-LB invocation path

## Acceptance criteria

- [x] `DD_TRACE_MANAGED_SERVICES=false` on both grug Lambdas
- [x] Codex adversarial review (approve)
- [ ] Post-deploy: phantom `jikcel...lambda-url` entry stops receiving new spans (will age out)
- [ ] Verify via DD MCP `search_datadog_spans service:jikcel...` after deploy: span count returns to 0

## Out of scope

- Manual deletion of historical phantom entry from DD catalog UI — DD ages out unused services automatically
- ASGI / log-injection / managed-services env-var coverage on future grug Lambdas (this PR sets a precedent; new functions should follow the same shape)

## Estimate

Size: XS

🤖 Generated with [Claude Code](https://claude.com/claude-code)