### PR TITLE
docs(context): author CONTEXT.md domain glossary (#136)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,94 @@
+# CONTEXT.md — grug domain glossary
+
+The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifiers a contributor will encounter while reading code. New contributors should be able to read this file and use the terms correctly without grepping. Drift between this file and the code is a bug; fix the file in the same PR that renames a concept.
+
+> **Architecture decisions live in [`docs/adr/`](docs/adr/).** This file is the lexicon; the ADRs are the load-bearing choices.
+
+## Product surface
+
+| Term | Definition |
+|---|---|
+| **Grug** | The bot. A hosted GitHub App at `grug.lol` that gates pull requests against a set of process checks. Open-source AGPL-3.0; self-host path in [`docs/SELF_HOST.md`](docs/SELF_HOST.md). |
+| **Grug Boss** | Public-facing name of the GitHub App users install on their repos. Same product as Grug; "Grug Boss" is the GitHub Marketplace listing handle. |
+| **Persona** | A bounded behavior surface Grug applies per PR. v1 ships exactly one: **TPM** (static Definition-of-Ready check). v1.5+ roadmap (per PRD #21) adds `code-reviewer`, `release-manager`, `stuck-PR-pulse`, and the LLM scope-review half of TPM. Personas are per-repo togglable. |
+| **TPM persona** | Today's only persona. Static **Definition-of-Ready (DoR) check** that blocks merge if PR body is malformed. The companion **Scope review** half is wired as a `poolside_client.py` hook in `evaluate()` per the `__init__.py` docstring but is NOT shipped — see "Roadmap" rows. See [`services/{api,webhook}/personas/tpm/`](services/api/personas/tpm/). |
+| **Pulse (roadmap)** | Scheduled (non-PR-triggered) persona work, named `stuck-PR-pulse` in the future-persona list in `services/webhook/main.py`. Not implemented. Intent: weekly issue-grooming sweep against Grugboard. |
+
+## Process-gate concepts
+
+| Term | Definition |
+|---|---|
+| **Definition of Ready (DoR)** | The standard a PR description must meet before it can merge. Enforced as a set of `CheckResult`s combined into a single GitHub check-run named `Grug — Definition of Ready`. |
+| **DoR check** | Individual rule: `why`, `acceptance`, `estimate`, `scope-fence`, `issue-link`. Defined in [`services/{api,webhook}/personas/tpm/dor_checks.py`](services/api/personas/tpm/dor_checks.py) (mirrored — see ADR-0001). The five rule names are the prose label — there is no `DoRCheck` class; rules are functions returning `CheckResult`. |
+| **CheckResult** | Outcome of one `DoR check` against one PR body. Frozen dataclass — fields `name: str`, `passed: bool`, `detail: str`. Pass/fail only — no third "warn" state. |
+| **TpmEvaluation** | Aggregate result of running all `DoR check`s against one PR. Frozen dataclass returned by `evaluate_pull_request(...)` in `personas/tpm/persona.py`. Composes into a `CheckRunResult` for GitHub. |
+| **CheckRunResult** | Frozen dataclass that maps directly onto GitHub's Checks API `POST /repos/{owner}/{repo}/check-runs` payload. Carries the `status=completed` ↔ `conclusion` cross-field invariant — enforced in `__post_init__`. See [`services/{api,webhook}/github_checks_client.py`](services/api/github_checks_client.py). |
+| **`post_check_run` (publisher)** | Module-level function in `github_checks_client.py` that POSTs a `CheckRunResult` to GitHub. The acceptance-criteria spelling "CheckRunPublisher" is the *concept name* — the actual identifier is a function, not a class. |
+| **Scope review (roadmap)** | Advisory LLM pass over PR title + body. Wired as a `poolside_client.py` hook called from `evaluate_pull_request(...)` per the `personas/tpm/__init__.py` docstring, but **`poolside_client.py` does not exist in the repo today** — feature is roadmap-only. Intended behavior: flag title↔body mismatch, AC testability, scope-creep, XL inflation; posted as a comment, never blocking. |
+
+## Identity & authorization concepts
+
+| Term | Definition |
+|---|---|
+| **UserIdentity** | The GitHub user behind a session. Identifier: `github_user_id` (integer, stable across login renames). Definitions in `services/api/adapters/user_store.py`. |
+| **UserWithTokens** | `UserIdentity` plus an attached `oauth_*_blob` (KMS-envelope-encrypted access + refresh tokens). Used only by the api Lambda — webhook never needs it. |
+| **Installation** | A `Grug` install on one GitHub account or organization. Identified by `install_id` (GitHub-issued integer). Carries metadata: `account_login`, `account_type` (User/Organization), `installed_at`, `installed_by_user_id`. |
+| **RepoConfig** | Per-repo settings stored under an `Installation`. Today the schema has exactly one field: `tpm_enabled: bool` (default `True`). Storage shape in [`services/{api,webhook}/adapters/install_store.py`](services/api/adapters/install_store.py). When more personas ship, the field set grows (e.g. `code_reviewer_enabled`); the `_DEFAULT_PERSONA_CONFIG` dict is the source of truth. |
+| **AllowlistGate** | Defense-in-depth check: webhook handler refuses to act on any `Installation` whose `installed_by_user_id` is not in the `allowlist` set on the user's DDB row. Independent of GitHub App's public/private listing. Bypass guard for the hosted SaaS while ramp is closed. |
+| **AppJWT** | RSA-signed JWT identifying Grug as a GitHub App (10-min TTL). Generated from the App private key (loaded from SSM SecureString `/grug/github-app-private-key`). Used to exchange for installation tokens. |
+| **InstallToken** | Short-lived (~1h TTL) token returned by `POST /app/installations/{id}/access_tokens`. Lets Grug act on behalf of the installation against the GitHub API. Cached per-`Installation` in `TokenCache`. |
+| **TokenCache** | Get/put/invalidate store for `AppJWT` and `InstallToken`s. Today: single in-process implementation (`InMemoryTokenCache`) — see ADR-0001 + planned `DdbTokenCache` per PRD #21 Q17. |
+| **with_install_token_retry** | Helper that wraps a GitHub API call so that on 401 it invalidates the cached `InstallToken`, fetches a fresh one, and retries once. Lives alongside the AppJWT machinery; couples token rotation with call sites today (issue #142 may revisit). |
+
+## Persistence concepts
+
+| Term | Definition |
+|---|---|
+| **DynamoDB single-table layout** | Two key shapes co-existing in one DDB table: `PK=USER#<github_user_id> SK=META` (the `UserIdentity` row, optionally `UserWithTokens` + `allowlisted`) and `PK=INST#<install_id> SK=META` (the `Installation` row) plus `PK=INST#<install_id> SK=REPO#<repo_id>` (one `RepoConfig` per repo). Schema constants in [`services/{api,webhook}/adapters/install_store.py`](services/api/adapters/install_store.py). |
+| **KMS envelope** | Per-`UserIdentity` data-encryption-key generated via `kms:GenerateDataKey` and used (AES-GCM, 96-bit nonce) to encrypt OAuth refresh + access tokens. Wrapped DEK stored alongside the ciphertext. Only the api Lambda calls KMS at app-level; webhook never decrypts user tokens. Documented at [`infra/pulumi/components/kms_cmk.py`](infra/pulumi/components/kms_cmk.py). |
+| **CredentialBlobCorrupt** | Exception raised when an encrypted blob in DDB can't be decrypted (key-version drift, tampering, deliberate test fixture). Handler must idempotently clean up — see the "idempotency check after corruption-empty fallthrough" audit pattern. |
+| **UserStateCorrupt** | Same shape as `CredentialBlobCorrupt`, but for non-secret user state fields that fail invariant checks at read time. |
+
+## Cross-service primitives (mirrored)
+
+The following six modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
+
+| Module | Purpose |
+|---|---|
+| `observability.py` | DD-extension-aware logger + JSON formatter. Reads `DD_SERVICE`, `DD_ENV`, `GRUG_LOG_LEVEL`. |
+| `secrets_loader.py` | SSM SecureString reads at cold start (`GITHUB_APP_ID_SSM`, `GITHUB_APP_WEBHOOK_SECRET_SSM`, etc.). |
+| `github_checks_client.py` | Thin `httpx`-based wrapper over GitHub's Checks API; carries the `CheckRunResult` dataclass. |
+| `adapters/install_store.py` | DDB single-table CRUD for `Installation` + `RepoConfig` + `AllowlistGate` reads. |
+| `ports/token_cache.py` | `TokenCache` Protocol + `InMemoryTokenCache` impl. |
+| `personas/tpm/dor_checks.py` | The 5 `DoR check` rules + the `CheckResult` dataclass. |
+| `personas/tpm/persona.py` | `TpmEvaluation` dataclass + `evaluate_pull_request(...)` entry point. |
+
+## Infrastructure concepts
+
+| Term | Definition |
+|---|---|
+| **AWS Lambda image-mode** | Deploy shape: per-service Docker image pushed to ECR, Lambda function points at the digest. Both services use this. Container brings DD extension + `datadog_lambda` wrapper. |
+| **Lambda Function URL** | Public HTTPS endpoint AWS provisions for each Lambda. `AuthType=NONE` (we gate via app-layer HMAC + Cognito). Hosted at `api.grug.lol` / `webhook.grug.lol` via Cloudflare Worker proxy. |
+| **Cloudflare Worker proxy** | Per-service `<service>-host-rewrite` Worker that rewrites incoming `<service>.grug.lol` requests to the Lambda Function URL. Lets us use friendly domains + WAF in front of Lambda. |
+| **Pulumi stack** | One stack per environment. Today: `dev` only. Stack name and project structure under [`infra/pulumi/`](infra/pulumi/). |
+| **Grugboard** | GitHub Projects (v2) board at https://github.com/users/githumps/projects/1. Target of the future `Pulse (roadmap)` persona's label sync + issue reprefixing. |
+
+## Operational concepts
+
+| Term | Definition |
+|---|---|
+| **Cutover** | Migration path from a self-hosted to a hosted setup, or between Pulumi stacks. Runbook at [`docs/CUTOVER.md`](docs/CUTOVER.md). |
+| **HITL prerequisite** | A human-in-the-loop step that must precede automated work (e.g. App registration on github.com, SSM secret pre-load). Documented in [`docs/HITL_PREREQUISITES.md`](docs/HITL_PREREQUISITES.md). |
+| **Self-host** | Operator deploys Grug against their own AWS + Cloudflare account. Step-by-step in [`docs/SELF_HOST.md`](docs/SELF_HOST.md). AGPL-3.0 network-service compliance applies. |
+
+## Vocabulary debt (named for future cleanup)
+
+These terms exist in the codebase but are inconsistent or under-named. Resolving them is out of scope for the initial CONTEXT.md authoring; track in dedicated issues.
+
+- **`with_install_token_retry`** — verbose helper name; better as a method on a future `TokenedGitHubClient` adapter (deferred in issue #142).
+- **`_LazyTable`** — descriptor pattern in `install_store.py` that defers boto3 init. Anti-pattern; documented rationale; defer-replace per #142.
+- **No name for the SPA's session shape** — `web/src/` consumes the api Lambda's `/me` payload but the SPA's TS types don't have a corresponding `Session` or `Viewer` concept. Add when frontend changes touch session state.
+
+---
+
+*This file is alive. Add terms as the codebase grows. Renaming a concept = update CONTEXT.md in the same PR. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the mirror-discipline architecture decision.*

--- a/docs/adr/0001-mirror-with-rule-of-three-deferral.md
+++ b/docs/adr/0001-mirror-with-rule-of-three-deferral.md
@@ -1,0 +1,92 @@
+# ADR-0001 — Mirror service-internal modules; defer extraction until rule-of-three triggers
+
+## Status
+
+Accepted (2026-05-17)
+
+## Context
+
+`grug` ships as two AWS Lambda functions that share the same platform primitives:
+
+- **`services/webhook/`** — receives GitHub App events (PR opened/synchronized/reopened, etc.), runs the TPM persona's Definition-of-Ready static checks, posts a green/red check-run back to the PR.
+- **`services/api/`** — backs `grug.lol` (React SPA): GitHub OAuth sign-in, list/toggle installations, admin allowlist UI.
+
+Both Lambdas need the same building blocks:
+
+| File | Purpose |
+|---|---|
+| `observability.py` | DD-extension-aware logger setup (`DD_SERVICE`, `DD_ENV`, log level) |
+| `secrets_loader.py` | SSM SecureString reads at cold start (App ID, webhook secret) |
+| `github_checks_client.py` | Thin wrapper over `POST /repos/{owner}/{repo}/check-runs` |
+| `adapters/install_store.py` | Single-table DynamoDB schema (PK/SK layout, allowlist gate, install/repo-config CRUD) |
+| `ports/token_cache.py` | `InMemoryTokenCache` for App JWT + installation tokens |
+| `personas/tpm/dor_checks.py` | Static DoR rule definitions (why ≥30 words, acceptance, scope-fence, etc.) |
+
+These six modules currently exist as **byte-identical copies** under `services/api/` and `services/webhook/`. Total: ~245 LOC duplicated across the pair.
+
+A naive architecture-review pass reads "duplicate code → extract a shared module" and proposes a `services/_shared/` Python package. We considered this, then rejected it (for now) based on the constraints below.
+
+## Decision
+
+**Mirror these modules across `services/api/` and `services/webhook/`. Do NOT extract a shared package until a third Lambda materializes** (rule-of-three).
+
+The pre-existing comment in `services/api/Dockerfile.lambda:1-4` already captured this stance informally:
+
+> *"API Lambda container image — mirrors services/webhook/Dockerfile.lambda. Rule-of-three for extracting a shared grug-base image triggers once a 3rd Lambda lands (web UI ships static — probably never)."*
+
+This ADR promotes that comment to a first-class decision record so future architecture reviews (human or AI) don't re-derive it from grep.
+
+### Discipline that pairs with the deferral
+
+To keep the mirroring honest, three guardrails:
+
+1. **Each mirrored file carries a header**: `# MIRRORED from services/<other>/<file>.py — keep in sync. See ADR-0001.`
+2. **CI gate**: `scripts/check-mirrored-files.sh` extended to fail any PR that modifies one half of a mirror pair without also modifying the other (or explicitly justifies the divergence in the commit message).
+3. **Legitimate per-service divergence is rare and named** (e.g. logger namespace, env-var names). When it exists, it's a parameter or env read, not a hardcoded literal in one copy — and the CI gate's allowlist explicitly tolerates that file.
+
+### Rule-of-three trigger conditions
+
+The deferral lifts when either:
+
+- A **third Python consumer** lands. Most likely shape is a 3rd Lambda (scheduled job, analytics worker, persona-runner), but any Python deploy target that imports the same primitives counts (e.g. a CLI tool, a local dev REPL, a separate Step Functions task).
+- A **third persona** lands (per PRD #21 v1.5+ roadmap: code-reviewer, release-manager, stuck-PR-pulse). At that point three instances of the same persona shape provide enough signal to extract the right abstraction.
+
+The React SPA at `web/` does **not** count toward the rule-of-three — it ships as static assets through Cloudflare Pages and does not consume Python modules.
+
+## Consequences
+
+### Positive
+
+- **No premature abstraction lock-in.** v1 has one persona; the shape of a shared CheckDefinition / ResultPublisher / TokenedGitHubClient abstraction is currently guesswork. Sandi Metz: *"Duplication is far cheaper than the wrong abstraction."*
+- **No Dockerfile / Pulumi packaging churn.** Each Lambda's image-mode build (`COPY . .` from service dir) stays simple. Adding a sibling shared dir would require Dockerfile restructure + Pulumi packaging changes — non-trivial deploy-risk surface for a solo-maintainer project.
+- **Independent blast-radius.** Two physical Lambdas with separate IAM roles. A bug in shared code can't accidentally cross the api ↔ webhook permission boundary because there IS no shared code yet.
+- **Cold-start isolation.** Each Lambda imports only what it needs. A shared package would need careful import discipline to avoid bloating init time for the smaller of the two. (Not currently measured — listed as a defensive consideration, not a quantified benefit.)
+
+### Negative
+
+- **245 LOC duplicated.** Every cross-cutting change (e.g. new logger formatter, new SSM secret name convention) is two edits.
+- **Drift risk if discipline lapses.** A contributor edits one copy and forgets the other → behavior diverges silently. Mitigated by the CI gate + MIRRORED header (above), but mitigation is only as strong as the script's MIRRORED_FILES allowlist — a file omitted from that list can drift silently by design.
+- **Cross-attribution bugs from copy-paste.** `services/api/secrets_loader.py:20` currently hardcodes `logging.getLogger("grug.webhook.secrets")` — wrong namespace in the api copy. Tracked separately (see issue #140); fix it without re-architecting.
+- **Security-surface duplication.** Four of the six mirrored modules (`secrets_loader`, `install_store`, `token_cache`, `github_checks_client`) handle credentials, OAuth tokens, or external-API calls. A CVE in a vendor library, an SDK upgrade, or a security patch must be applied to TWO files in lockstep. The CI gate catches the lockstep failure mode, but it does NOT prioritize security-sensitive mirrors — a future improvement.
+
+### Reconsideration triggers
+
+Open the deferred re-evaluation issue (filed at PR-merge time) when:
+
+- A 3rd Python consumer (Lambda or otherwise) is committed to a milestone (not just brainstormed).
+- A 2nd persona ships and proves the shared-shape hypothesis (or contradicts it).
+- The CI mirror-gate fails ≥3 times in a quarter — signals the duplication tax exceeds the extraction cost.
+- Lambda cold-start time per service crosses a budget that shared init could amortize.
+- A **security-relevant change** to any mirrored module — CVE in a vendor SDK, auth-flow patch, secret-handling change, IAM-policy diff. Lockstep editing under time pressure is the most error-prone shape; one-off extraction may be cheaper than risking drift on a security fix.
+- A vendor library bump in one Lambda's `requirements.txt` for a module that imports from a mirrored file — divergence inside a mirror is the hardest failure to detect.
+
+Until then: mirror with discipline.
+
+## References
+
+- `services/api/Dockerfile.lambda:1-4` — pre-existing informal version of this decision
+- `services/api/secrets_loader.py:20` — cross-attribution bug born of copy-paste (issue #140)
+- `services/api/ports/token_cache.py` — comparable one-adapter Protocol; collapse decision (issue #141)
+- PRD #21 — v1.5+ roadmap (code-reviewer + release-manager + stuck-PR-pulse personas)
+- Sandi Metz, *Practical Object-Oriented Design* — "wrong abstraction" cost argument
+- somatic-scripts `services/pasto-api/` ↔ `services/tempo-api/` — sibling project applying the same mirror-with-discipline pattern at larger scale


### PR DESCRIPTION
## Why

The `improve-codebase-architecture` skill (and any future contributor or AI reviewer) needs a stable vocabulary to talk about this codebase without re-deriving terms from `grep`. Without `CONTEXT.md`, every architecture review re-litigates "what do we call the OAuth-token-encryption thing? what's the difference between `Installation` and `RepoConfig`?" — wasting tokens and inviting drift.

This PR ships the lexicon. Companion ADR ([PR #143 — parent in this stack](https://github.com/githumps/grug/pull/143)) ships the load-bearing decision about *why we mirror six modules across `services/api/` and `services/webhook/` instead of extracting them*. Together they let the skill answer "what is this" + "why does it look like that" without re-grilling.

Codex peer-review caught three HIGH issues in the first draft (invented `RepoConfig` fields, wrong `CheckResult` shape, `ScopeReview` presented as live when `poolside_client.py` doesn't exist). All three corrected against the actual code before push.

## Acceptance criteria

- [x] Each major domain concept has a one-paragraph definition + filename pointer
- [x] Concepts at minimum: Installation, RepoConfig, AllowlistGate, DoR check, TpmEvaluation, CheckResult, CheckRunResult, `post_check_run` (publisher concept), TokenCache (`InMemoryTokenCache` / planned `DdbTokenCache`), InstallToken, AppJWT, KMS envelope (api Lambda only) — all present
- [x] Roadmap features (Scope review / Poolside, Pulse) explicitly labeled rather than presented as live behavior
- [x] Cross-links to PRD #21 for v1.5+ persona scope (code-reviewer, release-manager, stuck-PR-pulse)
- [x] Cross-links to [ADR-0001](https://github.com/githumps/grug/pull/143) for the mirror-with-rule-of-three-deferral discipline
- [x] Every code identifier mentioned (`CheckResult`, `TpmEvaluation`, `InMemoryTokenCache`, `with_install_token_retry`, `_LazyTable`, `evaluate_pull_request`, `post_check_run`, etc.) verified to actually exist in the repo
- [x] No secrets / API keys / tokens (defense-in-depth grep)
- [x] Codex adversarial review pass — clean after corrections

## Out of scope

- Adding `MIRRORED-from` headers to the six mirror pairs (issue #138, depends on this PR landing)
- CI `scripts/check-mirrored-files.sh` mirror-pair gate (issue #139, depends on #138)
- Fixing `services/api/secrets_loader.py:20` cross-attribution logger bug (issue #140, independent)
- Collapsing the `TokenCache` Protocol (issue #141, independent)
- Renaming `with_install_token_retry` / replacing `_LazyTable` (deferred per issue #142)
- Fixing ADR-0001's "~245 LOC" claim (actual is 615 LOC across the six pairs; will be a follow-up commit on the parent branch before merging the stack)

## Stack

This PR is the second in a small docs-discipline stack:

```
main
  └─ chore/137-adr-0001    (PR #143 — ADR-0001)
       └─ chore/136-context-md  (this PR)
```

Size: S

Closes #136
Part of #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)