### PR TITLE
fix(secrets): env-derive logger name so api copy stops mis-attributing (#140)

### DIFF
--- a/services/api/secrets_loader.py
+++ b/services/api/secrets_loader.py
@@ -17,7 +17,7 @@ from functools import lru_cache
 
 import boto3
 
-log = logging.getLogger("grug.webhook.secrets")
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.secrets")
 _ssm = boto3.client("ssm")
 
 

--- a/services/webhook/secrets_loader.py
+++ b/services/webhook/secrets_loader.py
@@ -17,7 +17,7 @@ from functools import lru_cache
 
 import boto3
 
-log = logging.getLogger("grug.webhook.secrets")
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.secrets")
 _ssm = boto3.client("ssm")
 
 


### PR DESCRIPTION
## Why

`services/api/secrets_loader.py:20` hardcoded `logging.getLogger(\"grug.webhook.secrets\")` — accurate for the webhook Lambda but cross-attributing the api Lambda's SSM-fetch logs to the wrong service namespace. This is exactly the [class of bug ADR-0001](https://github.com/githumps/grug/pull/143) (just-landed parent of the docs-discipline stack) was authored to make load-bearing: a copy-paste literal that legitimately differs per service but lives as a hardcoded value in one half of a mirror pair.

ADR-0001 calls out the resolution shape: *\"Legitimate per-service divergence is rare and named (e.g. logger namespace, env-var names). When it exists, it's a parameter or env read, not a hardcoded literal in one copy.\"*

This PR follows that guidance. Both `secrets_loader.py` files are now byte-identical and read the service name from the `DD_SERVICE` env var that Pulumi already sets on each Lambda (`infra/pulumi/__main__.py:171` webhook + `:292` api). Result:

```
DD_SERVICE=grug-webhook → logger name  grug-webhook.secrets
DD_SERVICE=grug-api     → logger name  grug-api.secrets
(unset, local dev)      → logger name  grug.secrets
```

Codex peer-review confirmed Pulumi sets `DD_SERVICE` on both Lambdas — the fallback `grug` never fires in deployed environments.

## Acceptance criteria

- [x] api Lambda's SSM-fetch logs route to `grug-api.secrets` (not `grug.webhook.secrets`)
- [x] webhook Lambda's logs still route to `grug-webhook.secrets`
- [x] Both `secrets_loader.py` files remain byte-identical post-fix (verified `diff` returns empty)
- [x] No test anchors on the old logger name (`grep` confirms)
- [x] No DD log filter / monitor / processing rule keyed on `grug.webhook.secrets` as a literal — only DD `service:` tag matters (Codex confirmed)
- [x] Smoke-tested all three env permutations locally

## Out of scope

- The other 5 mirrored files (`observability.py`, `github_checks_client.py`, `install_store.py`, `ports/token_cache.py`, `personas/tpm/dor_checks.py`) — Codex confirmed no other copy-paste-namespace-bugs exist in this set
- Adding the `MIRRORED-from` headers (issue #138)
- Building the CI mirror-pair gate that would have caught this structurally (issue #139)
- Verifying the deployed Lambda logs carry the new namespace post-merge (will validate against DD after deploy)

Size: XS

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)