### PR TITLE
ci(mirror): extend drift-lint to enforce MIRRORED headers + body lockstep (#139)

### DIFF
--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -1,76 +1,155 @@
 #!/usr/bin/env bash
-# Drift-detection lint for files that MUST stay byte-identical between
-# services/api/ and services/webhook/. Closes #66.
+# Drift-detection lint for files that MUST stay in lockstep between
+# services/api/ and services/webhook/. Closes #66; extended for #139.
 #
-# v1 trade-off (PRD #21): both Lambda services duplicate shared modules
-# instead of importing from a shared package. Until extraction lands,
-# this script catches accidental one-side edits at PR time.
+# v1 trade-off (PRD #21 + ADR-0001): both Lambda services duplicate
+# shared modules instead of importing from a shared package. Until
+# rule-of-three triggers extraction (ADR-0001), this script catches
+# accidental one-side edits at PR time.
 #
-# Files that intentionally differ (FastAPI app, lambda handler entrypoint,
-# logger name) are NOT in MIRRORED_FILES — they're allowlisted to diverge.
+# Two mirror modes:
 #
-# Add new mirrored files to MIRRORED_FILES below. Add intentionally-
-# diverging files NOWHERE — they're skipped by omission.
+#   MIRRORED_WITH_HEADER  — files carrying a `# MIRRORED — sibling at
+#                           services/<other>/<path>; ...` header on
+#                           line 1 (added by #138). Body (line 2+)
+#                           must be byte-identical; header must point
+#                           at the correct counterpart.
+#
+#   MIRRORED_BYTE_IDENTICAL — files fully byte-identical (typically
+#                             empty __init__.py or low-content). No
+#                             header required.
+#
+# Files that intentionally differ (FastAPI app, lambda handler entry
+# points, etc.) are NOT in either list — they're allowlisted to diverge
+# by omission.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-MIRRORED_FILES=(
-  "adapters/__init__.py"
+MIRRORED_WITH_HEADER=(
   "adapters/install_store.py"
-  "conftest.py"
-  "github_app_auth/__init__.py"
   "github_checks_client.py"
   "observability.py"
-  "personas/__init__.py"
-  "personas/tpm/__init__.py"
   "personas/tpm/dor_checks.py"
-  "ports/__init__.py"
   "ports/token_cache.py"
   "secrets_loader.py"
 )
 
-DIVERGED=()
+MIRRORED_BYTE_IDENTICAL=(
+  "adapters/__init__.py"
+  "conftest.py"
+  "github_app_auth/__init__.py"
+  "personas/__init__.py"
+  "personas/tpm/__init__.py"
+  "ports/__init__.py"
+)
+
+ADR_REF="docs/adr/0001-mirror-with-rule-of-three-deferral.md"
+
+BODY_DIVERGED=()
+HEADER_BAD=()
 MISSING=()
 
-for f in "${MIRRORED_FILES[@]}"; do
+# --- MIRRORED_WITH_HEADER: header check + body diff ---
+for f in "${MIRRORED_WITH_HEADER[@]}"; do
   api="services/api/$f"
   webhook="services/webhook/$f"
-  if [ ! -f "$api" ]; then
-    MISSING+=("$api")
-    continue
+  if [ ! -f "$api" ]; then MISSING+=("$api"); continue; fi
+  if [ ! -f "$webhook" ]; then MISSING+=("$webhook"); continue; fi
+
+  expected_api_header="# MIRRORED — sibling at services/webhook/$f; keep in lockstep. See $ADR_REF."
+  expected_webhook_header="# MIRRORED — sibling at services/api/$f; keep in lockstep. See $ADR_REF."
+  actual_api_header=$(head -n 1 "$api")
+  actual_webhook_header=$(head -n 1 "$webhook")
+
+  if [ "$actual_api_header" != "$expected_api_header" ]; then
+    HEADER_BAD+=("$api")
   fi
-  if [ ! -f "$webhook" ]; then
-    MISSING+=("$webhook")
-    continue
+  if [ "$actual_webhook_header" != "$expected_webhook_header" ]; then
+    HEADER_BAD+=("$webhook")
   fi
-  if ! diff -q "$api" "$webhook" >/dev/null 2>&1; then
-    DIVERGED+=("$f")
+
+  # Compare body (line 2+) — strip header before diff
+  if ! diff -q <(tail -n +2 "$api") <(tail -n +2 "$webhook") >/dev/null 2>&1; then
+    BODY_DIVERGED+=("$f")
   fi
 done
+
+# --- MIRRORED_BYTE_IDENTICAL: full byte equality ---
+for f in "${MIRRORED_BYTE_IDENTICAL[@]}"; do
+  api="services/api/$f"
+  webhook="services/webhook/$f"
+  if [ ! -f "$api" ]; then MISSING+=("$api"); continue; fi
+  if [ ! -f "$webhook" ]; then MISSING+=("$webhook"); continue; fi
+  if ! diff -q "$api" "$webhook" >/dev/null 2>&1; then
+    BODY_DIVERGED+=("$f")
+  fi
+done
+
+EXIT=0
 
 if [ ${#MISSING[@]} -gt 0 ]; then
   echo "ERROR: missing mirror files (one side absent):"
   for m in "${MISSING[@]}"; do echo "  - $m"; done
   echo
-  echo "Either remove from MIRRORED_FILES in scripts/check-mirrored-files.sh"
-  echo "OR create the missing copy."
-  exit 2
+  echo "Either remove from scripts/check-mirrored-files.sh OR create the missing copy."
+  EXIT=2
 fi
 
-if [ ${#DIVERGED[@]} -gt 0 ]; then
-  echo "ERROR: paired files diverged between services/api/ + services/webhook/:"
-  for d in "${DIVERGED[@]}"; do
+if [ ${#HEADER_BAD[@]} -gt 0 ]; then
+  echo "ERROR: MIRRORED header missing or wrong on line 1:"
+  for h in "${HEADER_BAD[@]}"; do
+    # Derive the relative path + expected sibling-side header for this exact file
+    case "$h" in
+      services/api/*)
+        rel="${h#services/api/}"
+        expected="# MIRRORED — sibling at services/webhook/$rel; keep in lockstep. See $ADR_REF."
+        ;;
+      services/webhook/*)
+        rel="${h#services/webhook/}"
+        expected="# MIRRORED — sibling at services/api/$rel; keep in lockstep. See $ADR_REF."
+        ;;
+      *)
+        expected="# MIRRORED — sibling at services/<other>/<path>; keep in lockstep. See $ADR_REF."
+        ;;
+    esac
     echo
-    echo "=== $d ==="
-    diff -u "services/api/$d" "services/webhook/$d" | head -50
+    echo "=== $h ==="
+    echo "  expected: $expected"
+    echo "  actual:   $(head -n 1 "$h")"
   done
   echo
-  echo "Both copies must stay byte-identical (PRD #21 v1 duplicate-file pattern)."
-  echo "Apply the same change to both. Until shared-package extraction lands,"
-  echo "this lint catches accidental one-side edits."
-  exit 1
+  echo "Mirror-discipline header is load-bearing — see ADR-0001."
+  EXIT=1
 fi
 
-echo "OK: ${#MIRRORED_FILES[@]} mirrored file pairs are byte-identical."
+if [ ${#BODY_DIVERGED[@]} -gt 0 ]; then
+  # Build a newline-joined string of files-with-header so we can grep WITHOUT
+  # piping (per memory feedback_pipefail_grep_q_sigpipe.md: `... | grep -q X`
+  # under `set -euo pipefail` trips SIGPIPE when grep matches early and exits).
+  with_header_list=$(printf '%s\n' "${MIRRORED_WITH_HEADER[@]}")
+
+  echo "ERROR: paired files diverged between services/api/ + services/webhook/:"
+  for d in "${BODY_DIVERGED[@]}"; do
+    echo
+    echo "=== $d ==="
+    if grep -Fxq -- "$d" <<<"$with_header_list"; then
+      diff -u <(tail -n +2 "services/api/$d") <(tail -n +2 "services/webhook/$d") | head -50
+    else
+      diff -u "services/api/$d" "services/webhook/$d" | head -50
+    fi
+  done
+  echo
+  echo "Both copies must stay in lockstep (PRD #21 + ADR-0001 mirror discipline)."
+  echo "Apply the same change to both. Until shared-package extraction lands,"
+  echo "this lint catches accidental one-side edits."
+  EXIT=1
+fi
+
+if [ "$EXIT" -eq 0 ]; then
+  total=$(( ${#MIRRORED_WITH_HEADER[@]} + ${#MIRRORED_BYTE_IDENTICAL[@]} ))
+  echo "OK: $total mirrored file pairs verified (${#MIRRORED_WITH_HEADER[@]} with header + ${#MIRRORED_BYTE_IDENTICAL[@]} byte-identical)."
+fi
+
+exit "$EXIT"


### PR DESCRIPTION
## Why

[ADR-0001](https://github.com/githumps/grug/pull/143) says: \"CI gate fails any PR that modifies one half of a mirror pair without also modifying the other.\" [PR #147](https://github.com/githumps/grug/pull/147) (#138, parent of this stack) added the human-readable `# MIRRORED — sibling at services/<other>/<path>;` header to 6 files.

This PR makes both mechanical. After #147 lands, the existing `scripts/check-mirrored-files.sh` would FAIL on every push because line 1 of the 6 header-bearing files legitimately differs between api/webhook. This PR extends the gate to:

1. **Header check** — line 1 must match the prescribed pattern with the correct counterpart sibling path.
2. **Body check** — line 2+ must be byte-identical (`tail -n +2 | diff`).

The 6 header-less mirror pairs (empty `__init__.py`, `conftest.py`, `github_app_auth/__init__.py`) still get full byte-equality enforcement.

## What changed

`scripts/check-mirrored-files.sh` rewrites:
- Splits mirror list into `MIRRORED_WITH_HEADER` + `MIRRORED_BYTE_IDENTICAL`
- Adds per-side expected-header generation so error output shows the exact string the file should have (not a generic placeholder) — Codex SEV-LOW
- Replaces `printf | grep -Fxq` with `grep -Fxq -- ... <<<var` here-string to avoid `pipefail` + SIGPIPE bug (per memory `feedback_pipefail_grep_q_sigpipe.md`) — Codex SEV-HIGH

CI invocation in `.github/workflows/drift-lint.yml` unchanged.

## Acceptance criteria

- [x] Clean tree → exit 0 (script verifies all 12 pairs)
- [x] Body drift (e.g. `echo \"# stray\" >> services/api/observability.py`) → exit 1 with body-diff message
- [x] Header drift (e.g. `sed 1s|webhook|wrongpath| services/api/secrets_loader.py`) → exit 1 with header-mismatch message including the exact expected header per side
- [x] Missing-file (e.g. `mv services/webhook/secrets_loader.py /tmp/`) → exit 2
- [x] No pipefail/SIGPIPE regression — `grep -Fxq` runs against a here-string variable, not a pipe (Codex peer-review SEV-HIGH)
- [x] Header-only drift caught BEFORE body diff (header check fires first)
- [x] Bash-only features (`<(...)`, here-string `<<<`) safe — workflow invokes `bash scripts/check-mirrored-files.sh` explicitly (Codex verified)
- [x] GNU vs BSD `tail -n +2` both compatible (Codex verified)
- [x] Existing CI workflow `.github/workflows/drift-lint.yml` triggers unchanged

## Out of scope

- Migrating to a Python-based lint (could re-evaluate later if bash becomes painful)
- Extracting any of the mirrored files into a `_shared/` package (ADR-0001 explicitly defers until rule-of-three)
- The remaining cross-attribution bug in `services/api/conftest.py` docstring (\"pytest config for services/webhook/ tests\") — separate fix similar to #140

## Stack

```
main
  └─ chore/137-adr-0001                  (PR #143 — ADR-0001)
       └─ chore/136-context-md           (PR #144 — CONTEXT.md)
            └─ chore/138-mirrored-from-headers  (PR #147 — headers)
                 └─ chore/139-ci-mirror-gate    (this PR)
```

Size: S

Closes #139
Part of #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)