### PR TITLE
refactor(token-cache): re-apply #146 — recover Protocol collapse (lost in cascade)

### DIFF
--- a/services/api/ports/token_cache.py
+++ b/services/api/ports/token_cache.py
@@ -1,3 +1,4 @@
+# MIRRORED — sibling at services/webhook/ports/token_cache.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
 """In-memory token cache for App JWTs + install tokens.
 
 Module-scope dict cache, lifetime = warm Lambda container. Per PRD #21

--- a/services/api/ports/token_cache.py
+++ b/services/api/ports/token_cache.py
@@ -1,19 +1,23 @@
-# MIRRORED — sibling at services/webhook/ports/token_cache.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
-"""TokenCache port — swappable cache for App JWTs + install tokens.
+"""In-memory token cache for App JWTs + install tokens.
 
-v1 = InMemoryTokenCache (module-scope dict in warm Lambda container).
-v2 = DdbTokenCache (cross-container shared) — same Protocol, swap via env.
+Module-scope dict cache, lifetime = warm Lambda container. Per PRD #21
+Q17: cold start re-signs JWT (~10ms) + re-fetches install token (~150ms).
+Acceptable for v1; revisit if cold start dominates p99.
 
-Per PRD #21 Q17: cold start re-signs JWT (~10ms) + re-fetches install
-token (~150ms) per warm container. Acceptable for v1; revisit if cold
-start dominates p99.
+A `TokenCache` Protocol previously lived here as a hypothetical seam for
+a future `DdbTokenCache`. Removed per githumps/grug#141 — one adapter
+makes the Protocol speculative. Re-introduce when a second concrete
+implementation is committed to a milestone (rule-of-three; see ADR-0001).
+
+Callers MUST invalidate on 401 — GitHub can revoke tokens before TTL
+expiry (App reinstall, perm change, secret rotation). Without invalidate,
+a warm Lambda keeps reusing the bad token until TTL. Codex post-review #50.
 """
 
 from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Protocol
 
 
 @dataclass(frozen=True)
@@ -32,22 +36,6 @@ class CachedToken:
 
     def is_fresh(self, skew_seconds: float = 30) -> bool:
         return time.time() < self.expires_at_unix - skew_seconds
-
-
-class TokenCache(Protocol):
-    """Get/put/invalidate for short-lived auth tokens.
-
-    Callers MUST invalidate on 401 — GitHub can revoke tokens before
-    TTL expiry (App reinstall, perm change, secret rotation). Without
-    invalidate, a warm Lambda keeps reusing the bad token until TTL.
-    Codex post-review #50.
-    """
-
-    def get(self, key: str) -> CachedToken | None: ...
-
-    def put(self, key: str, token: str, ttl_seconds: float) -> None: ...
-
-    def invalidate(self, key: str) -> None: ...
 
 
 class InMemoryTokenCache:

--- a/services/webhook/ports/token_cache.py
+++ b/services/webhook/ports/token_cache.py
@@ -1,19 +1,23 @@
-# MIRRORED — sibling at services/api/ports/token_cache.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
-"""TokenCache port — swappable cache for App JWTs + install tokens.
+"""In-memory token cache for App JWTs + install tokens.
 
-v1 = InMemoryTokenCache (module-scope dict in warm Lambda container).
-v2 = DdbTokenCache (cross-container shared) — same Protocol, swap via env.
+Module-scope dict cache, lifetime = warm Lambda container. Per PRD #21
+Q17: cold start re-signs JWT (~10ms) + re-fetches install token (~150ms).
+Acceptable for v1; revisit if cold start dominates p99.
 
-Per PRD #21 Q17: cold start re-signs JWT (~10ms) + re-fetches install
-token (~150ms) per warm container. Acceptable for v1; revisit if cold
-start dominates p99.
+A `TokenCache` Protocol previously lived here as a hypothetical seam for
+a future `DdbTokenCache`. Removed per githumps/grug#141 — one adapter
+makes the Protocol speculative. Re-introduce when a second concrete
+implementation is committed to a milestone (rule-of-three; see ADR-0001).
+
+Callers MUST invalidate on 401 — GitHub can revoke tokens before TTL
+expiry (App reinstall, perm change, secret rotation). Without invalidate,
+a warm Lambda keeps reusing the bad token until TTL. Codex post-review #50.
 """
 
 from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from typing import Protocol
 
 
 @dataclass(frozen=True)
@@ -32,22 +36,6 @@ class CachedToken:
 
     def is_fresh(self, skew_seconds: float = 30) -> bool:
         return time.time() < self.expires_at_unix - skew_seconds
-
-
-class TokenCache(Protocol):
-    """Get/put/invalidate for short-lived auth tokens.
-
-    Callers MUST invalidate on 401 — GitHub can revoke tokens before
-    TTL expiry (App reinstall, perm change, secret rotation). Without
-    invalidate, a warm Lambda keeps reusing the bad token until TTL.
-    Codex post-review #50.
-    """
-
-    def get(self, key: str) -> CachedToken | None: ...
-
-    def put(self, key: str, token: str, ttl_seconds: float) -> None: ...
-
-    def invalidate(self, key: str) -> None: ...
 
 
 class InMemoryTokenCache:

--- a/services/webhook/ports/token_cache.py
+++ b/services/webhook/ports/token_cache.py
@@ -1,3 +1,4 @@
+# MIRRORED — sibling at services/api/ports/token_cache.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
 """In-memory token cache for App JWTs + install tokens.
 
 Module-scope dict cache, lifetime = warm Lambda container. Per PRD #21


### PR DESCRIPTION
## Why

Recovers the `TokenCache` Protocol-collapse refactor from #146 that was lost during the stack-merge cascade earlier today. When #146 hit a conflict against the freshly-merged stack (#143/#144/#147 had landed the MIRRORED-from headers), the conflict was wrongly resolved by taking main's version — which discarded the entire refactor body. This PR re-cherry-picks the original refactor commit (1155bb1) onto current main.

Substance unchanged from #146 — see its description for the architectural argument (one-adapter = hypothetical seam; PRD #21 Q17 deferred DdbTokenCache indefinitely so the Protocol was speculative).

Part of #141

## Acceptance criteria

- [x] `class TokenCache(Protocol)` removed from both `services/{api,webhook}/ports/token_cache.py`
- [x] `TokenCache` removed from `services/{api,webhook}/github_app_auth/__init__.py` imports
- [x] `_cache: TokenCache` annotation removed — `_cache = InMemoryTokenCache()` type is inferable
- [x] Cherry-pick clean (no behavior change vs original #146)
- [x] Mirror discipline preserved (line-1 MIRRORED headers intact)

## Out of scope

- Adding `DdbTokenCache` (deferred per PRD #21 Q17 until a real second adapter is needed)
- Migrating any test that imported `TokenCache` Protocol directly (none did — surface was internal)

## Test plan

- [x] `make test` / `uv run pytest` passes in both services
- [x] `temper verify -s specs/0004-token-cache/` still green once #151 lands (spec doesn't depend on the Protocol surface)

**Size:** S