### PR TITLE
ci(temper): cache cargo build via Swatinem/rust-cache — 3-4min → ~30s warm

### DIFF
--- a/.github/workflows/check.temper-specs.yml
+++ b/.github/workflows/check.temper-specs.yml
@@ -99,13 +99,29 @@ jobs:
             sudo apt-get install -y -qq "${missing[@]}"
           fi
 
-      - name: Clone + build temper (cold-path only)
+      - name: Clone temper (cold-path only)
         if: steps.temper-locate.outputs.needs_build == 'true'
         run: |
           rm -rf /tmp/temper
           git clone https://github.com/${{ env.TEMPER_REPO }}.git /tmp/temper
           cd /tmp/temper
           git checkout ${{ env.TEMPER_REPO_SHA }}
+
+      # Cache the temper cargo registry + target/ between runs. Keyed on
+      # the pinned TEMPER_REPO_SHA so a kernel bump invalidates the cache.
+      # Cuts the cold ~3-4 min cargo build to ~10-30s on warm cache. Free
+      # for public repos.
+      - name: Cache temper cargo build
+        if: steps.temper-locate.outputs.needs_build == 'true'
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        with:
+          workspaces: /tmp/temper
+          prefix-key: temper-${{ env.TEMPER_REPO_SHA }}
+
+      - name: Build temper (cold-path only)
+        if: steps.temper-locate.outputs.needs_build == 'true'
+        run: |
+          cd /tmp/temper
           cargo build --release --bin temper
 
       # Per-spec verify steps land below this line. The add-spec-to-workflow.sh


### PR DESCRIPTION
## Why

Temper's cold cargo build takes ~3-4 min on every CI run today; that's the dominant cost in the SDD-spec verification pipeline. Adding \`Swatinem/rust-cache@v2.9.1\` caches the registry + target/ between runs keyed on the pinned TEMPER_REPO_SHA. Warm cache drops it to ~10-30s. Free for public repos.

Part of #151

## Acceptance criteria

- [x] Workflow change is additive (existing cold-build path still works on cache miss)
- [x] Cache key includes the pinned TEMPER_REPO_SHA so kernel bumps invalidate + rebuild (no stale-binary risk)
- [x] Pinned to a specific Swatinem/rust-cache SHA (\`23869a5b...\` = v2.9.1) — matches sibling-workflow SHA-pinning convention
- [x] First post-merge run pays the cold build once to populate; every subsequent PR pulls from cache
- [x] `workspaces: /tmp/temper` points the action at temper's cloned dir (not the github workspace)

## Out of scope

- Apt-package cache (smaller win; not added)
- Self-hosted runner setup (`/opt/temper/<sha>/temper` fast path is already wired; flip `runs-on` to `[self-hosted, ...]` when you stand one up)
- Switching to a "larger runner" (paid, not justified for grug's volume)

**Size:** XS