### PR TITLE
fix(pulumi): read DD APP key from per-project SSM path

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -412,9 +412,13 @@ cloudflare_dns.create_proxied_cname(
 )
 
 # Datadog monitors (Slice 9 #30). Provider reads DD creds from SSM
-# `/shared/datadog-{api,app}-key` per #164 cross-repo convention.
+# DD APP key: per-project path under `/shared/datadog-app-key/` so a
+# rotation here doesn't clobber sibling repos (somatic-scripts etc.)
+# that may use the un-nested `/shared/datadog-app-key` path. Note: DD
+# API key remains at the shared cross-repo path above (it's submit-only,
+# safe to share + cheaper to rotate once globally).
 _dd_app_key = aws.ssm.get_parameter(
-    name="/shared/datadog-app-key", with_decryption=True,
+    name="/shared/datadog-app-key/github-grug", with_decryption=True,
 )
 _dd_provider = _datadog.Provider(
     "datadog-grug",


### PR DESCRIPTION
## Why

The IaC deploy workflow fails on every push to main with:

`datadog:index:Monitor (grug-webhook-5xx): 403 Forbidden /api/v1/monitor/278912951/validate`

Root cause: the previous DD APP key at the shared cross-repo path `/shared/datadog-app-key` was deleted (operator-initiated), so Pulumi was reading a now-invalid value. The new key now lives at `/shared/datadog-app-key/github-grug` (per-project path, chosen so future rotations don't clobber sibling repos using the shared path).

This PR updates the one line in `infra/pulumi/__main__.py` to read from the per-project path.

Part of #151

## Acceptance criteria

- [x] `_dd_app_key` reads from `/shared/datadog-app-key/github-grug` instead of `/shared/datadog-app-key`
- [x] DD **API** key (submit-only, Lambda extension) stays on the shared cross-repo path `/shared/datadog-api-key` — only the APP key (Pulumi-mutates-DD-config) moves to per-project
- [x] Comment explains the asymmetry so the next operator doesn't wonder why one is per-project and the other shared
- [x] Local sanity: SSM has a value at the new path

## Out of scope

- Migrating the DD API key to per-project (not needed; submit-only keys are safe to share)
- Migrating sibling repos to per-project DD APP keys (separate task per repo)

## Test plan

- [x] `aws ssm get-parameter --name /shared/datadog-app-key/github-grug` returns a non-empty SecureString value
- [ ] Post-merge: `gh workflow run iac.deploy.yml` succeeds (monitor validation no longer 403s)

**Size:** XS