### PR TITLE
ci: move web + iac deploys off self-hosted srv-unraid-gha → ubuntu-latest

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -49,7 +49,16 @@ concurrency:
 
 jobs:
   pulumi-up:
-    runs-on: [self-hosted, Linux, X64, srv-unraid-gha]
+    # Public repo → GitHub-hosted ubuntu-latest is free + unmetered + no
+    # nightly auto-reboot interruption risk. Swapped from
+    # [self-hosted, srv-unraid-gha] 2026-05-24.
+    #
+    # Trade-off: the docker buildx `type=local,src=/tmp/buildx-cache-grug/`
+    # cache below survived across runs on the self-hosted runner but
+    # resets on every fresh ubuntu-latest VM. Each deploy will cold-build
+    # the 2 ECR images (~90s × 2 = ~3 min extra). Follow-up: swap
+    # `type=local` → `type=gha,mode=max` for GitHub's native cache.
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: 01. Checkout

--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -33,7 +33,10 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: [self-hosted, Linux, X64, srv-unraid-gha]
+    # Public repo → GitHub-hosted ubuntu-latest is free + unmetered + no
+    # nightly auto-reboot interruption risk. Swapped from
+    # [self-hosted, srv-unraid-gha] 2026-05-24.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: 01. Checkout


### PR DESCRIPTION
## Why

Public repo = GitHub-hosted ubuntu-latest minutes are free + unmetered. Self-hosted brought two pain points that outweigh the savings:

1. **Nightly auto-reboot risk** — srv-unraid-gha has killed in-flight deploys mid-pulumi-up before
2. **Username leak in public logs** — `/home/mizu/...` paths show up in every public deploy log. Cosmetic, not credential-bearing, but unnecessary noise.

Part of #151

## Acceptance criteria

- [x] web.deploy.yml jobs.build-and-deploy.runs-on: ubuntu-latest
- [x] iac.deploy.yml jobs.pulumi-up.runs-on: ubuntu-latest
- [x] Comments document the swap rationale + cache trade-off

## Trade-off (knowingly accepted)

iac.deploy.yml uses `type=local,src=/tmp/buildx-cache-grug/` for ECR image builds. The cache survived between self-hosted runs; on ubuntu-latest it cold-builds every time → ~3 min slower per deploy. Follow-up options for a future PR:
- Swap `type=local` → `type=gha,mode=max` (idiomatic GitHub-hosted, ~10s warm)
- OR wrap with `actions/cache@v4` keyed on Dockerfile + requirements.txt SHAs

## Out of scope

- The buildx cache swap (separate small PR, keeps this one minimal)
- Decommissioning srv-unraid-gha runner itself (if other repos still use it, leave it)

## Test plan

- [x] Workflow YAML syntactically valid
- [ ] Post-merge: next push triggers both workflows on ubuntu-latest + both succeed (assuming the CF + DD credential rotations in flight succeed)

**Size:** XS
