### PR TITLE
feat(web): add Datadog RUM via SDD (spec 0013 RumInstrumentation)

### DIFF
--- a/.github/workflows/check.temper-specs.yml
+++ b/.github/workflows/check.temper-specs.yml
@@ -42,6 +42,13 @@ on:
       - 'web/index.html'
       - 'web/app.html'
       - 'web/vite.config.ts'
+      # Spec 0013 (RumInstrumentation) attesters scan the SPA entry chain
+      # + the static HTML CDN snippets + the Pulumi RUM component.
+      - 'web/src/main.tsx'
+      - 'web/src/rum.ts'
+      - 'web/package.json'
+      - 'infra/pulumi/components/dd_rum.py'
+      - 'infra/pulumi/__main__.py'
       - '.github/workflows/check.temper-specs.yml'
   workflow_dispatch:
 
@@ -172,6 +179,9 @@ jobs:
       - name: Verify spec 0012 (Landing)
         run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0012-landing/
 
+      - name: Verify spec 0013 (RumInstrumentation)
+        run: ${{ steps.temper-locate.outputs.binary }} verify -s specs/0013-rum-instrumentation/
+
       # ────────────── Grounding attesters ──────────────
       # Each attester PROVES a spec bool against real source. Temper
       # verifies the IOA is internally consistent; attesters close the
@@ -234,3 +244,9 @@ jobs:
 
       - name: Attester · Landing URL-slug canonical — /index.html owns root, no CF Pretty-URLs trap (spec 0012)
         run: python3 infra/scripts/attest_landing_url_slug_canonical.py
+
+      - name: Attester · RUM Pulumi registration + SSM secret-wrap (spec 0013)
+        run: python3 infra/scripts/attest_rum_pulumi_registration.py
+
+      - name: Attester · RUM SDK loaded — SPA chain + 3 static HTML snippets + service:'grug-web' (spec 0013)
+        run: python3 infra/scripts/attest_rum_sdk_in_html.py

--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -76,6 +76,24 @@ jobs:
           echo "CLOUDFLARE_API_TOKEN=$CF_API_TOKEN" >> "$GITHUB_ENV"
           echo "CLOUDFLARE_ACCOUNT_ID=$CF_ACCOUNT_ID" >> "$GITHUB_ENV"
 
+          # DD RUM credentials (spec 0013). Both are public-by-design
+          # (they live in the browser bundle) but sourced from SSM so a
+          # rotation is `pulumi up`, not a git commit. Pulumi component
+          # dd_rum.py owns the SSM values. If missing, the build still
+          # succeeds — the RUM init checks for placeholders and no-ops.
+          DD_RUM_APP_ID=$(aws ssm get-parameter \
+            --name /grug/dd-rum-application-id --with-decryption \
+            --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          DD_RUM_TOKEN=$(aws ssm get-parameter \
+            --name /grug/dd-rum-client-token --with-decryption \
+            --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+          # Mask both — they're not high-sensitivity but masking
+          # prevents accidental log leaks.
+          [ -n "$DD_RUM_APP_ID" ] && echo "::add-mask::$DD_RUM_APP_ID"
+          [ -n "$DD_RUM_TOKEN" ] && echo "::add-mask::$DD_RUM_TOKEN"
+          echo "DD_RUM_APP_ID=$DD_RUM_APP_ID" >> "$GITHUB_ENV"
+          echo "DD_RUM_TOKEN=$DD_RUM_TOKEN" >> "$GITHUB_ENV"
+
       - name: 05. Install deps
         working-directory: web
         run: npm ci --no-audit --no-fund
@@ -84,9 +102,54 @@ jobs:
         working-directory: web
         run: npm run typecheck
 
+      # Vite build consumes VITE_DD_RUM_* env vars and inlines them into
+      # the SPA bundle via web/src/rum.ts (spec 0013). Resolve the deploy
+      # env from the branch: `main` and tags = prod, anything else = dev.
       - name: 07. Build
         working-directory: web
+        env:
+          VITE_DD_RUM_APPLICATION_ID: ${{ env.DD_RUM_APP_ID }}
+          VITE_DD_RUM_CLIENT_TOKEN: ${{ env.DD_RUM_TOKEN }}
+          VITE_DD_RUM_ENV: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && 'prod' || 'dev' }}
+          VITE_DD_RUM_VERSION: ${{ github.sha }}
         run: npm run build
+
+      # Substitute the same RUM credentials into the static HTML files
+      # in dist/ (index.html, Privacy.html, Terms.html — the landing +
+      # docs that don't go through Vite's HTML bundling). Spec 0013 bool
+      # `rum_sdk_loaded_on_static_landing_entries_per_observability_intent`.
+      # No-op when DD_RUM_APP_ID is empty so local-preview builds work
+      # without breaking the deploy.
+      - name: 07b. Inject DD RUM credentials into static HTML
+        if: env.DD_RUM_APP_ID != ''
+        working-directory: web/dist
+        env:
+          DD_RUM_ENV: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && 'prod' || 'dev' }}
+        run: |
+          set -euo pipefail
+          for html in index.html Privacy.html Terms.html; do
+            if [ ! -f "$html" ]; then
+              echo "::warning::$html missing from dist/ — skipping RUM substitution"
+              continue
+            fi
+            # `|` as sed delimiter so application-id values containing `/`
+            # don't break the regex. -i.bak for macOS portability; .bak
+            # files removed below.
+            sed -i.bak \
+              -e "s|__DD_RUM_APPLICATION_ID__|${DD_RUM_APP_ID}|g" \
+              -e "s|__DD_RUM_CLIENT_TOKEN__|${DD_RUM_TOKEN}|g" \
+              -e "s|__DD_RUM_ENV__|${DD_RUM_ENV}|g" \
+              -e "s|__DD_RUM_VERSION__|${GITHUB_SHA}|g" \
+              "$html"
+            rm -f "$html.bak"
+            # Sanity check — fail loudly if any placeholder survived.
+            if grep -q '__DD_RUM_' "$html"; then
+              echo "::error::placeholder substitution incomplete in $html"
+              grep -n '__DD_RUM_' "$html" | head -5
+              exit 1
+            fi
+          done
+          echo "✓ DD RUM credentials substituted into 3 static HTML files"
 
       - name: 08. Deploy to Cloudflare Pages
         working-directory: web

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -26,6 +26,7 @@ import pulumi_datadog as _datadog
 from components import (
     cloudflare_dns,
     dd_monitors,
+    dd_rum,
     ddb_table,
     ecr_repo,
     kms_cmk,
@@ -439,6 +440,14 @@ monitors = dd_monitors.create_all(
     provider=_dd_provider,
 )
 
+# DD RUM Application for grug.lol (spec 0013 RumInstrumentation).
+# `name="grug-web"` is the canonical service tag the browser SDK must
+# pass to DD_RUM.init(...) — same name used in attest_rum_*.py.
+# Application ID + client token exported to SSM so web.deploy.yml can
+# substitute them into the build at deploy time without committing
+# either value to the repo.
+rum = dd_rum.create(name="grug-web", provider=_dd_provider)
+
 pulumi.export("webhook_function_url", webhook.function_url)
 pulumi.export("webhook_public_url", f"https://webhook.{domain}/webhook/github")
 pulumi.export("api_function_url", api_lambda.function_url)
@@ -455,3 +464,8 @@ pulumi.export("monitor_api_5xx_id", monitors.api_5xx.id)
 pulumi.export("monitor_sig_verify_fail_id", monitors.sig_verify_fail.id)
 pulumi.export("monitor_cold_start_p99_id", monitors.cold_start_p99.id)
 pulumi.export("synthetic_uptime_id", monitors.uptime.id)
+
+# DD RUM (spec 0013). Outputs are non-sensitive references — the actual
+# values live in SSM SecureStrings managed by the same component.
+pulumi.export("rum_application_id_ssm_name", rum.ssm_application_id.name)
+pulumi.export("rum_client_token_ssm_name", rum.ssm_client_token.name)

--- a/infra/pulumi/components/dd_rum.py
+++ b/infra/pulumi/components/dd_rum.py
@@ -1,0 +1,94 @@
+"""Datadog RUM Application + SSM credential export for grug.lol.
+
+Per spec 0013 (RumInstrumentation) — the spec encodes the contract; this
+component declares the resource.
+
+Output of `create()`:
+
+  - A `datadog.RumApplication` Pulumi resource (type "browser",
+    `rum_event_processing_state="ALL"` — full session capture).
+  - Two SSM SecureString parameters under `/grug/dd-rum-*`:
+      - `/grug/dd-rum-application-id`  (Output[str] of `app.id`)
+      - `/grug/dd-rum-client-token`    (Output[str] of `app.client_token`)
+    Both `Output.secret`-wrapped so they don't leak to `pulumi preview`.
+
+The RUM clientToken + applicationId are PUBLIC-by-design (they live in
+the browser bundle) — but we still source them from SSM at build time so
+a rotation is `pulumi up`, not a git commit.
+
+The web.deploy.yml workflow reads these SSM params before `npm run build`
+and substitutes them into the RUM init snippets.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_aws as aws
+import pulumi_datadog as datadog
+
+
+@dataclass
+class RumBundle:
+    """Resources created by `dd_rum.create()` — kept together so the
+    composition root can export both the app + SSM params via a single
+    return value."""
+    application: datadog.RumApplication
+    ssm_application_id: aws.ssm.Parameter
+    ssm_client_token: aws.ssm.Parameter
+
+
+def create(
+    *,
+    name: str,
+    provider: datadog.Provider,
+) -> RumBundle:
+    """Provision the DD RUM Application + export its credentials to SSM.
+
+    Args:
+      name: Browser RUM application name shown in the DD UI. Doubles as
+        the canonical `service:` tag the SDK init uses (spec 0013 bool
+        `rum_service_tag_is_grug_web_canonical_per_dd_naming_canon`).
+      provider: The pre-configured `datadog.Provider` from `__main__.py`
+        — same one used by `dd_monitors`.
+    """
+    app = datadog.RumApplication(
+        f"{name}-rum-app",
+        name=name,
+        type="browser",
+        # ALL = capture every RUM event type (view/action/error/resource/
+        # long_task). The narrower ERROR_FOCUSED_MODE drops view/action
+        # events which would defeat the point of installing RUM.
+        rum_event_processing_state="ALL",
+        # MAX = keep Product Analytics aggregations long-term. NONE
+        # would disable Product Analytics derivation entirely.
+        product_analytics_retention_state="MAX",
+        opts=pulumi.ResourceOptions(provider=provider),
+    )
+
+    # SSM SecureString export. `Output.secret` so values stay encrypted
+    # in Pulumi state + masked in preview output (per
+    # `feedback_pulumi_preview_secret_leak_guard` memory — leaked DD APP
+    # key 2026-05-17 made the unwrapped-secret pattern a hard rule).
+    ssm_app_id = aws.ssm.Parameter(
+        f"{name}-rum-application-id",
+        name=f"/grug/dd-rum-application-id",
+        type="SecureString",
+        value=pulumi.Output.secret(app.id),
+        description="DD RUM Application ID for grug-web. Public by design (lives in browser bundle); sourced from SSM so rotation is `pulumi up` not a git commit.",
+        tags={"managed_by": "pulumi", "scope": "grug", "service": "grug-web"},
+    )
+    ssm_client_token = aws.ssm.Parameter(
+        f"{name}-rum-client-token",
+        name=f"/grug/dd-rum-client-token",
+        type="SecureString",
+        value=pulumi.Output.secret(app.client_token),
+        description="DD RUM client token for grug-web. Public by design; sourced from SSM so rotation is `pulumi up` not a git commit.",
+        tags={"managed_by": "pulumi", "scope": "grug", "service": "grug-web"},
+    )
+
+    return RumBundle(
+        application=app,
+        ssm_application_id=ssm_app_id,
+        ssm_client_token=ssm_client_token,
+    )

--- a/infra/scripts/attest_rum_pulumi_registration.py
+++ b/infra/scripts/attest_rum_pulumi_registration.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Grounding attester for spec 0013.RumInstrumentation.
+
+Proves NECESSARY conditions for the bools:
+
+  - `rum_application_declared_in_pulumi_per_iac_invariant`
+  - `rum_credentials_exported_to_ssm_per_secret_handling_invariant`
+
+Asserts that `infra/pulumi/__main__.py` AND `infra/pulumi/components/dd_rum.py`
+together:
+
+  1. Define a `datadog.RumApplication` resource.
+  2. Pass `name="grug-web"` (the canonical service tag — spec 0013).
+  3. Use `type="browser"` (catches accidental drift to ios/android/etc).
+  4. Set `rum_event_processing_state="ALL"` (anything else drops event
+     types we want to capture).
+  5. Export `app.id` to SSM at name `/grug/dd-rum-application-id`.
+  6. Export `app.client_token` to SSM at name `/grug/dd-rum-client-token`.
+  7. Both SSM params wrap their value in `pulumi.Output.secret(...)`
+     (per `feedback_pulumi_preview_secret_leak_guard` — unwrapped
+     secret reads leaked the DD APP key in preview 2026-05-17).
+
+Stdlib only — AST parse of the two Python modules.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAIN_PY = REPO_ROOT / "infra/pulumi/__main__.py"
+COMPONENT_PY = REPO_ROOT / "infra/pulumi/components/dd_rum.py"
+
+CANONICAL_SERVICE_NAME = "grug-web"
+CANONICAL_TYPE = "browser"
+CANONICAL_PROCESSING_STATE = "ALL"
+SSM_APP_ID_PATH = "/grug/dd-rum-application-id"
+SSM_CLIENT_TOKEN_PATH = "/grug/dd-rum-client-token"
+
+
+def _kwarg_value(call: ast.Call, name: str) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _str_value(node: ast.AST | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    # `f"/grug/dd-rum-application-id"` parses as ast.JoinedStr with one Str.
+    if isinstance(node, ast.JoinedStr) and len(node.values) == 1:
+        return _str_value(node.values[0])
+    return None
+
+
+def _is_output_secret(node: ast.AST | None) -> bool:
+    """True if `node` is a call to `pulumi.Output.secret(...)`."""
+    if not isinstance(node, ast.Call):
+        return False
+    fn = node.func
+    if (
+        isinstance(fn, ast.Attribute)
+        and fn.attr == "secret"
+        and isinstance(fn.value, ast.Attribute)
+        and fn.value.attr == "Output"
+    ):
+        return True
+    return False
+
+
+def _walk_calls(tree: ast.AST, target_attr: str) -> list[ast.Call]:
+    """All calls of shape `<module>.<target_attr>(...)`."""
+    out: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr == target_attr:
+            out.append(node)
+    return out
+
+
+def _attest_rum_application(failures: list[str]) -> None:
+    if not COMPONENT_PY.exists():
+        failures.append(f"{COMPONENT_PY.relative_to(REPO_ROOT)} missing — dd_rum component absent")
+        return
+    tree = ast.parse(COMPONENT_PY.read_text())
+    apps = _walk_calls(tree, "RumApplication")
+    if not apps:
+        failures.append(
+            f"{COMPONENT_PY.relative_to(REPO_ROOT)}: no `datadog.RumApplication(...)` call found"
+        )
+        return
+    if len(apps) > 1:
+        failures.append(
+            f"{COMPONENT_PY.relative_to(REPO_ROOT)}: {len(apps)} RumApplication calls — expected exactly 1"
+        )
+        return
+    app = apps[0]
+
+    name = _str_value(_kwarg_value(app, "name"))
+    if name != CANONICAL_SERVICE_NAME:
+        # The component takes name as a parameter; the canonical value
+        # must be passed at the call site in __main__.py. Defer to the
+        # __main__ check below.
+        pass
+
+    type_arg = _str_value(_kwarg_value(app, "type"))
+    if type_arg != CANONICAL_TYPE:
+        failures.append(
+            f"{COMPONENT_PY.relative_to(REPO_ROOT)}: RumApplication type={type_arg!r}, "
+            f"expected {CANONICAL_TYPE!r} (other types capture wrong event shape)"
+        )
+
+    state = _str_value(_kwarg_value(app, "rum_event_processing_state"))
+    if state != CANONICAL_PROCESSING_STATE:
+        failures.append(
+            f"{COMPONENT_PY.relative_to(REPO_ROOT)}: rum_event_processing_state={state!r}, "
+            f"expected {CANONICAL_PROCESSING_STATE!r} (anything else drops captured event types)"
+        )
+
+
+def _attest_ssm_exports(failures: list[str]) -> None:
+    """Both SSM params present + both wrapped in pulumi.Output.secret()."""
+    tree = ast.parse(COMPONENT_PY.read_text())
+    ssm_calls = _walk_calls(tree, "Parameter")
+    seen: dict[str, ast.Call] = {}
+    for call in ssm_calls:
+        name = _str_value(_kwarg_value(call, "name"))
+        if name in (SSM_APP_ID_PATH, SSM_CLIENT_TOKEN_PATH):
+            seen[name] = call
+
+    for path in (SSM_APP_ID_PATH, SSM_CLIENT_TOKEN_PATH):
+        if path not in seen:
+            failures.append(
+                f"{COMPONENT_PY.relative_to(REPO_ROOT)}: no `aws.ssm.Parameter(name={path!r}, ...)` call"
+            )
+            continue
+        call = seen[path]
+        # type=SecureString
+        type_arg = _str_value(_kwarg_value(call, "type"))
+        if type_arg != "SecureString":
+            failures.append(
+                f"{COMPONENT_PY.relative_to(REPO_ROOT)}: SSM param {path!r} type={type_arg!r}, "
+                f"expected 'SecureString' (RUM credentials, masking matters)"
+            )
+        # value=pulumi.Output.secret(...)
+        if not _is_output_secret(_kwarg_value(call, "value")):
+            failures.append(
+                f"{COMPONENT_PY.relative_to(REPO_ROOT)}: SSM param {path!r} value is not wrapped in "
+                f"`pulumi.Output.secret(...)` — secret would leak to preview output "
+                f"(per feedback_pulumi_preview_secret_leak_guard)"
+            )
+
+
+def _attest_main_callsite(failures: list[str]) -> None:
+    """__main__.py must call dd_rum.create(name='grug-web', ...)."""
+    if not MAIN_PY.exists():
+        failures.append(f"{MAIN_PY.relative_to(REPO_ROOT)} missing")
+        return
+    tree = ast.parse(MAIN_PY.read_text())
+    creates = _walk_calls(tree, "create")
+    rum_creates = [
+        c for c in creates
+        if isinstance(c.func, ast.Attribute)
+        and isinstance(c.func.value, ast.Name)
+        and c.func.value.id == "dd_rum"
+    ]
+    if not rum_creates:
+        failures.append(
+            f"{MAIN_PY.relative_to(REPO_ROOT)}: no `dd_rum.create(...)` call found"
+        )
+        return
+    if len(rum_creates) > 1:
+        failures.append(
+            f"{MAIN_PY.relative_to(REPO_ROOT)}: {len(rum_creates)} dd_rum.create calls — expected exactly 1"
+        )
+    call = rum_creates[0]
+    name = _str_value(_kwarg_value(call, "name"))
+    if name != CANONICAL_SERVICE_NAME:
+        failures.append(
+            f"{MAIN_PY.relative_to(REPO_ROOT)}: dd_rum.create name={name!r}, "
+            f"expected {CANONICAL_SERVICE_NAME!r} (canonical service tag, "
+            f"spec 0013 rum_service_tag_is_grug_web_canonical_per_dd_naming_canon)"
+        )
+
+
+def main() -> int:
+    failures: list[str] = []
+    _attest_rum_application(failures)
+    _attest_ssm_exports(failures)
+    _attest_main_callsite(failures)
+
+    if failures:
+        print(f"FAIL: RUM Pulumi registration drift ({len(failures)} issues):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(
+        f"OK: dd_rum.create() registered + name={CANONICAL_SERVICE_NAME!r} + "
+        f"type={CANONICAL_TYPE!r} + state={CANONICAL_PROCESSING_STATE!r} + "
+        f"both SSM params (Output.secret-wrapped)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infra/scripts/attest_rum_sdk_in_html.py
+++ b/infra/scripts/attest_rum_sdk_in_html.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Grounding attester for spec 0013.RumInstrumentation.
+
+Proves NECESSARY conditions for the bools:
+
+  - `rum_sdk_loaded_on_react_spa_entry_per_observability_intent`
+  - `rum_sdk_loaded_on_static_landing_entries_per_observability_intent`
+  - `rum_service_tag_is_grug_web_canonical_per_dd_naming_canon`
+
+Two checks:
+
+  1. SPA path (web/app.html → web/src/main.tsx → web/src/rum.ts):
+     - main.tsx imports `initRum` from `./rum` AND calls `initRum()`
+       BEFORE `ReactDOM.createRoot().render()`.
+     - rum.ts imports `datadogRum` from `@datadog/browser-rum`.
+     - rum.ts calls `datadogRum.init({...service: 'grug-web', ...})`.
+
+  2. Static path (web/public/{index,Privacy,Terms}.html):
+     - Each file contains the DD RUM CDN snippet (matched via the
+       canonical CDN URL substring `datadoghq-browser-agent.com`).
+     - Each contains `service: 'grug-web'` (single-quoted in the
+       snippet — strict match catches drift).
+     - Each contains all four placeholders so build-time substitution
+       has a target to replace (`__DD_RUM_APPLICATION_ID__`,
+       `__DD_RUM_CLIENT_TOKEN__`, `__DD_RUM_ENV__`, `__DD_RUM_VERSION__`).
+     - `package.json` lists `@datadog/browser-rum` as a dependency.
+
+Stdlib only (re + html.parser). No third-party deps.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WEB_DIR = REPO_ROOT / "web"
+SRC_DIR = WEB_DIR / "src"
+PUBLIC_DIR = WEB_DIR / "public"
+PKG_JSON = WEB_DIR / "package.json"
+
+CANONICAL_SERVICE = "grug-web"
+CDN_URL_SUBSTRING = "datadoghq-browser-agent.com"
+REQUIRED_PLACEHOLDERS = [
+    "__DD_RUM_APPLICATION_ID__",
+    "__DD_RUM_CLIENT_TOKEN__",
+    "__DD_RUM_ENV__",
+    "__DD_RUM_VERSION__",
+]
+STATIC_HTMLS = ("index.html", "Privacy.html", "Terms.html")
+
+
+def _attest_spa_chain(failures: list[str]) -> None:
+    main_tsx = SRC_DIR / "main.tsx"
+    rum_ts = SRC_DIR / "rum.ts"
+
+    if not main_tsx.exists():
+        failures.append("web/src/main.tsx missing")
+        return
+    if not rum_ts.exists():
+        failures.append("web/src/rum.ts missing — SPA RUM init module absent")
+        return
+
+    main_src = main_tsx.read_text()
+    rum_src = rum_ts.read_text()
+
+    # main.tsx imports initRum from ./rum
+    if not re.search(r"import\s+\{\s*initRum\s*\}\s+from\s+['\"]\./rum['\"]", main_src):
+        failures.append(
+            "web/src/main.tsx: missing `import { initRum } from './rum'` — RUM module not wired in"
+        )
+
+    # main.tsx calls initRum() — before the render. We can't easily AST
+    # this for TypeScript without a TS parser, so verify both ordering
+    # hints: initRum() appears AND it appears before createRoot.
+    init_match = re.search(r"\binitRum\s*\(\s*\)", main_src)
+    render_match = re.search(r"\bcreateRoot\b", main_src)
+    if not init_match:
+        failures.append(
+            "web/src/main.tsx: `initRum()` is never called — module imported but init skipped"
+        )
+    elif render_match and init_match.start() > render_match.start():
+        failures.append(
+            "web/src/main.tsx: `initRum()` called AFTER createRoot — must run "
+            "BEFORE so RUM captures initial view + cold-start errors"
+        )
+
+    # rum.ts imports @datadog/browser-rum
+    if not re.search(
+        r"import\s+\{[^}]*datadogRum[^}]*\}\s+from\s+['\"]@datadog/browser-rum['\"]",
+        rum_src,
+    ):
+        failures.append(
+            "web/src/rum.ts: missing `import { datadogRum } from '@datadog/browser-rum'`"
+        )
+
+    # rum.ts calls datadogRum.init({...})
+    if not re.search(r"datadogRum\.init\s*\(", rum_src):
+        failures.append("web/src/rum.ts: no `datadogRum.init(...)` call found")
+
+    # service: "grug-web" (double OR single quotes)
+    if not re.search(rf"""service:\s*["']{re.escape(CANONICAL_SERVICE)}["']""", rum_src):
+        failures.append(
+            f"web/src/rum.ts: missing `service: \"{CANONICAL_SERVICE}\"` in datadogRum.init(...) — "
+            f"spec 0013 rum_service_tag_is_grug_web_canonical_per_dd_naming_canon"
+        )
+
+    # package.json lists the dep
+    if not PKG_JSON.exists():
+        failures.append("web/package.json missing")
+        return
+    pkg = json.loads(PKG_JSON.read_text())
+    deps = {**pkg.get("dependencies", {}), **pkg.get("devDependencies", {})}
+    if "@datadog/browser-rum" not in deps:
+        failures.append(
+            "web/package.json: `@datadog/browser-rum` not listed as dependency — "
+            "rum.ts import won't resolve at build"
+        )
+
+
+def _attest_static_snippets(failures: list[str]) -> None:
+    for name in STATIC_HTMLS:
+        path = PUBLIC_DIR / name
+        if not path.exists():
+            failures.append(f"web/public/{name} missing")
+            continue
+        body = path.read_text()
+
+        if CDN_URL_SUBSTRING not in body:
+            failures.append(
+                f"web/public/{name}: missing DD RUM CDN script "
+                f"(no reference to `{CDN_URL_SUBSTRING}`)"
+            )
+            # If the CDN snippet itself is missing, the placeholder/service
+            # checks below would be redundant. Continue to next file.
+            continue
+
+        # Strict service-tag check (single-quoted in the CDN snippet)
+        if not re.search(rf"""service:\s*['"]{re.escape(CANONICAL_SERVICE)}['"]""", body):
+            failures.append(
+                f"web/public/{name}: missing `service: '{CANONICAL_SERVICE}'` in CDN snippet"
+            )
+
+        # All four placeholders must be present so the build-time sed
+        # has a target. If any is missing the substitution silently
+        # leaves the others — partial init is worse than no init.
+        for ph in REQUIRED_PLACEHOLDERS:
+            if ph not in body:
+                failures.append(
+                    f"web/public/{name}: missing placeholder `{ph}` — "
+                    f"build-time substitution would leave the field unfilled"
+                )
+
+
+def main() -> int:
+    failures: list[str] = []
+    _attest_spa_chain(failures)
+    _attest_static_snippets(failures)
+
+    if failures:
+        print(f"FAIL: RUM SDK loading drift ({len(failures)} issues):")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+
+    print(
+        f"OK: SPA chain (main.tsx → rum.ts → @datadog/browser-rum) intact + "
+        f"3 static HTML files all carry the CDN snippet with "
+        f"service:'{CANONICAL_SERVICE}' and all 4 placeholders"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/specs/0013-rum-instrumentation/model.csdl.xml
+++ b/specs/0013-rum-instrumentation/model.csdl.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Spec 0013 RumInstrumentation — CSDL companion. -->
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+
+    <Schema Namespace="Temper.Vocab" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Term Name="StateMachine.States" Type="Collection(Edm.String)" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.InitialState" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="StateMachine.ValidFromStates" Type="Collection(Edm.String)" AppliesTo="Action"/>
+      <Term Name="StateMachine.TargetState" Type="Edm.String" AppliesTo="Action"/>
+      <Term Name="Agent.Hint" Type="Edm.String" AppliesTo="Action EntityType"/>
+      <Term Name="ShardKey" Type="Edm.String" AppliesTo="EntityType"/>
+      <Term Name="AuthZ.CedarPolicy" Type="Edm.String" AppliesTo="EntityType Action"/>
+    </Schema>
+
+    <Schema Namespace="Grug.RumInstrumentation" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EnumType Name="RumInstrumentationStatus">
+        <Member Name="NotInstrumented" Value="0"/>
+        <Member Name="Attested" Value="1"/>
+        <Member Name="Built" Value="2"/>
+        <Member Name="Live" Value="3"/>
+      </EnumType>
+
+      <EntityType Name="RumInstrumentation">
+        <Key><PropertyRef Name="CommitSha"/></Key>
+        <Property Name="CommitSha" Type="Edm.String" Nullable="false"/>
+        <Property Name="Status" Type="Grug.RumInstrumentation.RumInstrumentationStatus" Nullable="false"/>
+
+        <Property Name="rum_application_declared_in_pulumi_per_iac_invariant" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="rum_credentials_exported_to_ssm_per_secret_handling_invariant" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="rum_sdk_loaded_on_react_spa_entry_per_observability_intent" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="rum_sdk_loaded_on_static_landing_entries_per_observability_intent" Type="Edm.Boolean" DefaultValue="false"/>
+        <Property Name="rum_service_tag_is_grug_web_canonical_per_dd_naming_canon" Type="Edm.Boolean" DefaultValue="false"/>
+
+        <Annotation Term="Temper.Vocab.StateMachine.States">
+          <Collection><String>NotInstrumented</String><String>Attested</String><String>Built</String><String>Live</String></Collection>
+        </Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.InitialState" String="NotInstrumented"/>
+        <Annotation Term="Temper.Vocab.ShardKey" String="CommitSha"/>
+        <Annotation Term="Temper.Vocab.AuthZ.CedarPolicy" String="policies/rum.cedar"/>
+      </EntityType>
+
+      <Action Name="AttestPulumiRegistration" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>NotInstrumented</String></Collection></Annotation>
+      </Action>
+
+      <Action Name="AttestSpaSdkLoaded" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>NotInstrumented</String></Collection></Annotation>
+      </Action>
+
+      <Action Name="AttestStaticSdkLoaded" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>NotInstrumented</String></Collection></Annotation>
+      </Action>
+
+      <Action Name="AttestServiceTagCanonical" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="attestor" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>NotInstrumented</String></Collection></Annotation>
+      </Action>
+
+      <Action Name="Bundle" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="commit_sha" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>NotInstrumented</String></Collection></Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Attested"/>
+      </Action>
+
+      <Action Name="Deploy" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="commit_sha" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>Attested</String></Collection></Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Built"/>
+      </Action>
+
+      <Action Name="Emit" IsBound="true">
+        <Parameter Name="bindingParameter" Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Parameter Name="commit_sha" Type="Edm.String" Nullable="false"/>
+        <ReturnType Type="Grug.RumInstrumentation.RumInstrumentation"/>
+        <Annotation Term="Temper.Vocab.StateMachine.ValidFromStates"><Collection><String>Built</String></Collection></Annotation>
+        <Annotation Term="Temper.Vocab.StateMachine.TargetState" String="Live"/>
+      </Action>
+
+      <EntityContainer Name="RumInstrumentationService">
+        <EntitySet Name="RumInstrumentations" EntityType="Grug.RumInstrumentation.RumInstrumentation"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/specs/0013-rum-instrumentation/policies/rum.cedar
+++ b/specs/0013-rum-instrumentation/policies/rum.cedar
@@ -1,0 +1,24 @@
+// spec 0013 — RumInstrumentation Cedar policy
+// Default-deny. Principals: CI attesters (the two attest_rum_*.py scripts)
+// and the web deploy role (wrangler in the web.deploy.yml job).
+
+permit (
+    principal in [Grug::RumInstrumentationAttester],
+    action in [
+        Grug::Action::"AttestPulumiRegistration",
+        Grug::Action::"AttestSpaSdkLoaded",
+        Grug::Action::"AttestStaticSdkLoaded",
+        Grug::Action::"AttestServiceTagCanonical"
+    ],
+    resource is Grug::RumInstrumentation
+);
+
+permit (
+    principal in [Grug::WebDeployer],
+    action in [
+        Grug::Action::"Bundle",
+        Grug::Action::"Deploy",
+        Grug::Action::"Emit"
+    ],
+    resource is Grug::RumInstrumentation
+);

--- a/specs/0013-rum-instrumentation/rum.ioa.toml
+++ b/specs/0013-rum-instrumentation/rum.ioa.toml
@@ -1,0 +1,150 @@
+# spec 0013 — RumInstrumentation I/O Automaton
+#
+# Closes the single observability gap surfaced by the 2026-05-24 DD
+# audit (docs/NETWORK-TOPOLOGY.md): zero RUM events from grug.lol
+# despite APM + Logs being fully wired on the AWS Lambdas.
+#
+# Encodes the contract between the Datadog RUM Application resource
+# (Pulumi-managed) and the browser SDK initialization across all four
+# user-facing HTML surfaces:
+#
+#   - web/app.html                 (Vite React SPA entry — npm package init)
+#   - web/public/index.html        (static landing — CDN snippet)
+#   - web/public/Privacy.html      (static doc — CDN snippet)
+#   - web/public/Terms.html        (static doc — CDN snippet)
+#
+# Five contract bools attest distinct invariants. Combined, they
+# prevent silent regressions of the entire RUM pipeline:
+#   - Pulumi forgets to declare the RumApplication resource → no
+#     attribution back to a tracked DD project.
+#   - Credentials drift from SSM to hardcoded → rotation breaks.
+#   - A redesign drops the init snippet from one of the static
+#     surfaces → silent coverage loss without alarm.
+#   - Service tag gets renamed → DD catalog splits the same project
+#     across two service identities.
+#
+# Verified by `temper verify -s specs/0013-rum-instrumentation/`.
+
+[automaton]
+name = "RumInstrumentation"
+states = ["NotInstrumented", "Attested", "Built", "Live"]
+initial = "NotInstrumented"
+
+# --- Pulumi-side contract bools ---
+
+[[state]]
+name = "rum_application_declared_in_pulumi_per_iac_invariant"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "rum_credentials_exported_to_ssm_per_secret_handling_invariant"
+type = "bool"
+initial = "false"
+
+# --- Browser-side contract bools ---
+
+[[state]]
+name = "rum_sdk_loaded_on_react_spa_entry_per_observability_intent"
+type = "bool"
+initial = "false"
+
+[[state]]
+name = "rum_sdk_loaded_on_static_landing_entries_per_observability_intent"
+type = "bool"
+initial = "false"
+
+# --- Cross-cutting naming invariant ---
+
+[[state]]
+name = "rum_service_tag_is_grug_web_canonical_per_dd_naming_canon"
+type = "bool"
+initial = "false"
+
+[[action]]
+name = "AttestPulumiRegistration"
+kind = "input"
+from = ["NotInstrumented"]
+params = ["attestor"]
+guard = "is_false rum_credentials_exported_to_ssm_per_secret_handling_invariant"
+effect = [
+  { type = "set_bool", var = "rum_application_declared_in_pulumi_per_iac_invariant", value = true },
+  { type = "set_bool", var = "rum_credentials_exported_to_ssm_per_secret_handling_invariant", value = true },
+]
+hint = "infra/pulumi/__main__.py declares a `datadog.RumApplication` resource for grug.lol AND writes its applicationId + clientToken to `/grug/dd-rum-application-id` and `/grug/dd-rum-client-token` SSM SecureStrings. Credentials are NOT hardcoded in any web/** file; build-time injection reads from SSM via the web.deploy.yml workflow."
+
+[[action]]
+name = "AttestSpaSdkLoaded"
+kind = "input"
+from = ["NotInstrumented"]
+params = ["attestor"]
+guard = "is_false rum_sdk_loaded_on_react_spa_entry_per_observability_intent"
+effect = [
+  { type = "set_bool", var = "rum_sdk_loaded_on_react_spa_entry_per_observability_intent", value = true },
+]
+hint = "web/app.html is the Vite SPA entry. RUM init happens via `@datadog/browser-rum` npm package imported from web/src/rum.ts, which is imported by web/src/main.tsx BEFORE the React tree mounts. Verified by grep + AST parse of the entry chain — not just `<script>` tag presence."
+
+[[action]]
+name = "AttestStaticSdkLoaded"
+kind = "input"
+from = ["NotInstrumented"]
+params = ["attestor"]
+guard = "is_false rum_sdk_loaded_on_static_landing_entries_per_observability_intent"
+effect = [
+  { type = "set_bool", var = "rum_sdk_loaded_on_static_landing_entries_per_observability_intent", value = true },
+]
+hint = "All three static HTML files (web/public/{index,Privacy,Terms}.html) contain the DD RUM CDN init snippet. The snippet references `datadoghq-browser-agent.com`, calls `DD_RUM.init(...)`, and uses build-time-substituted placeholders (`__DD_RUM_APPLICATION_ID__`, `__DD_RUM_CLIENT_TOKEN__`, `__DD_RUM_ENV__`, `__DD_RUM_VERSION__`) replaced by web.deploy.yml during the Vite build copy step. Missing on ANY of the three = fail."
+
+[[action]]
+name = "AttestServiceTagCanonical"
+kind = "input"
+from = ["NotInstrumented"]
+params = ["attestor"]
+guard = "is_false rum_service_tag_is_grug_web_canonical_per_dd_naming_canon"
+effect = [
+  { type = "set_bool", var = "rum_service_tag_is_grug_web_canonical_per_dd_naming_canon", value = true },
+]
+hint = "Both the SPA init (web/src/rum.ts) AND every static-HTML CDN snippet pass `service: 'grug-web'` to DD_RUM.init(). Wrong/missing service tag causes DD to split the project across phantom service identities in the APM catalog (peer to the `aws.lambda.url` inferred-spans trap closed in 2026-05-07)."
+
+[[action]]
+name = "Bundle"
+kind = "input"
+from = ["NotInstrumented"]
+to = "Attested"
+params = ["commit_sha"]
+guard = [
+  { type = "is_true", var = "rum_application_declared_in_pulumi_per_iac_invariant" },
+  { type = "is_true", var = "rum_credentials_exported_to_ssm_per_secret_handling_invariant" },
+  { type = "is_true", var = "rum_sdk_loaded_on_react_spa_entry_per_observability_intent" },
+  { type = "is_true", var = "rum_sdk_loaded_on_static_landing_entries_per_observability_intent" },
+  { type = "is_true", var = "rum_service_tag_is_grug_web_canonical_per_dd_naming_canon" },
+]
+hint = "All five contract bools attested. `npm run build` produces dist/{index,Privacy,Terms,app}.html with RUM snippets containing real credential values (placeholders replaced via sed in web.deploy.yml). Only reachable once every grounding attester passes."
+
+[[action]]
+name = "Deploy"
+kind = "input"
+from = ["Attested"]
+to = "Built"
+params = ["commit_sha"]
+hint = "wrangler pages deploy dist/ ships the RUM-instrumented bundle to the grug-web CF Pages project."
+
+[[action]]
+name = "Emit"
+kind = "input"
+from = ["Built"]
+to = "Live"
+params = ["commit_sha"]
+hint = "First real browser visit fires `DD_RUM.init()`, opens a session, starts emitting view / action / error / resource events to https://browser-intake-datadoghq.com. DD APM catalog now shows `service:grug-web` alongside `grug-api` and `grug-webhook`."
+
+[[invariant]]
+name = "MustAttestBeforeBundle"
+assert = "ordering(NotInstrumented, Attested)"
+
+[[invariant]]
+name = "MustBundleBeforeDeploy"
+assert = "ordering(Attested, Built)"
+
+[[invariant]]
+name = "MustDeployBeforeEmit"
+assert = "ordering(Built, Live)"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "grug-web",
       "version": "0.1.0",
       "dependencies": {
+        "@datadog/browser-rum": "^6.33.0",
         "@tanstack/react-query": "^5.59.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -317,6 +318,39 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-6.33.0.tgz",
+      "integrity": "sha512-h/xuBuY4Xi32CbBHkChMMWlOQ4al/mFF08x3o0hqrderfJvX7VO5tD3OVNwF+pfMXOGlDtBCIhwazr9sn24h3g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@datadog/browser-rum": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum/-/browser-rum-6.33.0.tgz",
+      "integrity": "sha512-zdxs1PyKt1RQ/fdxsmaCJUeBhB+leCIaPJBcum7uDi/DL8nuu9A9NUc5qGVPlY9zc12v7t2NI8bLpOrMjv+jTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.33.0",
+        "@datadog/browser-rum-core": "6.33.0"
+      },
+      "peerDependencies": {
+        "@datadog/browser-logs": "6.33.0"
+      },
+      "peerDependenciesMeta": {
+        "@datadog/browser-logs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@datadog/browser-rum-core": {
+      "version": "6.33.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-rum-core/-/browser-rum-core-6.33.0.tgz",
+      "integrity": "sha512-Ais4x7zQBrBI6JyILYwFAmjUsqy0iQp2C7JcEEfzU4YYYcVO3DGpyVuYYrqHT27jY1QToHY8EnQUr3Yaj6saDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@datadog/browser-core": "6.33.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@datadog/browser-rum": "^6.33.0",
     "@tanstack/react-query": "^5.59.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/public/Privacy.html
+++ b/web/public/Privacy.html
@@ -4,6 +4,36 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Privacy — Grug</title>
+  <!-- Datadog RUM (spec 0013 RumInstrumentation). Placeholders are
+       replaced at build time by web.deploy.yml using values read from
+       SSM /grug/dd-rum-*. When placeholders remain (local preview /
+       missing SSM), init is skipped so the page works either way. -->
+  <script>
+    (function(h,o,u,n,d){h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}};d=o.createElement(u);d.async=1;d.src=n;n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)})(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM');
+    window.DD_RUM.onReady(function () {
+      var appId = '__DD_RUM_APPLICATION_ID__';
+      var clientToken = '__DD_RUM_CLIENT_TOKEN__';
+      if (appId.indexOf('__DD_') === 0 || clientToken.indexOf('__DD_') === 0) {
+        console.info('[rum] init skipped — placeholders not substituted (local preview or SSM unset)');
+        return;
+      }
+      window.DD_RUM.init({
+        applicationId: appId,
+        clientToken: clientToken,
+        site: 'datadoghq.com',
+        service: 'grug-web',
+        env: '__DD_RUM_ENV__',
+        version: '__DD_RUM_VERSION__',
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 100,
+        defaultPrivacyLevel: 'mask-user-input',
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true
+      });
+      window.DD_RUM.startSessionReplayRecording();
+    });
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/web/public/Terms.html
+++ b/web/public/Terms.html
@@ -4,6 +4,36 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Terms — Grug</title>
+  <!-- Datadog RUM (spec 0013 RumInstrumentation). Placeholders are
+       replaced at build time by web.deploy.yml using values read from
+       SSM /grug/dd-rum-*. When placeholders remain (local preview /
+       missing SSM), init is skipped so the page works either way. -->
+  <script>
+    (function(h,o,u,n,d){h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}};d=o.createElement(u);d.async=1;d.src=n;n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)})(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM');
+    window.DD_RUM.onReady(function () {
+      var appId = '__DD_RUM_APPLICATION_ID__';
+      var clientToken = '__DD_RUM_CLIENT_TOKEN__';
+      if (appId.indexOf('__DD_') === 0 || clientToken.indexOf('__DD_') === 0) {
+        console.info('[rum] init skipped — placeholders not substituted (local preview or SSM unset)');
+        return;
+      }
+      window.DD_RUM.init({
+        applicationId: appId,
+        clientToken: clientToken,
+        site: 'datadoghq.com',
+        service: 'grug-web',
+        env: '__DD_RUM_ENV__',
+        version: '__DD_RUM_VERSION__',
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 100,
+        defaultPrivacyLevel: 'mask-user-input',
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true
+      });
+      window.DD_RUM.startSessionReplayRecording();
+    });
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -4,6 +4,36 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Grug — Grug crush bug. Grug guard code. Grug run project.</title>
+  <!-- Datadog RUM (spec 0013 RumInstrumentation). Placeholders are
+       replaced at build time by web.deploy.yml using values read from
+       SSM /grug/dd-rum-*. When placeholders remain (local preview /
+       missing SSM), init is skipped so the page works either way. -->
+  <script>
+    (function(h,o,u,n,d){h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}};d=o.createElement(u);d.async=1;d.src=n;n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)})(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM');
+    window.DD_RUM.onReady(function () {
+      var appId = '__DD_RUM_APPLICATION_ID__';
+      var clientToken = '__DD_RUM_CLIENT_TOKEN__';
+      if (appId.indexOf('__DD_') === 0 || clientToken.indexOf('__DD_') === 0) {
+        console.info('[rum] init skipped — placeholders not substituted (local preview or SSM unset)');
+        return;
+      }
+      window.DD_RUM.init({
+        applicationId: appId,
+        clientToken: clientToken,
+        site: 'datadoghq.com',
+        service: 'grug-web',
+        env: '__DD_RUM_ENV__',
+        version: '__DD_RUM_VERSION__',
+        sessionSampleRate: 100,
+        sessionReplaySampleRate: 100,
+        defaultPrivacyLevel: 'mask-user-input',
+        trackUserInteractions: true,
+        trackResources: true,
+        trackLongTasks: true
+      });
+      window.DD_RUM.startSessionReplayRecording();
+    });
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,10 +4,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import "./index.css";
+// Spec 0013: RUM init MUST run before React mounts so the SDK captures
+// the initial view event and any cold-start errors. No-op when env
+// vars are absent (local dev path).
+import { initRum } from "./rum";
 import { Signin } from "./routes/Signin";
 import { Dashboard } from "./routes/Dashboard";
 import { Admin } from "./routes/Admin";
 import { NotFound } from "./routes/NotFound";
+
+initRum();
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/web/src/rum.ts
+++ b/web/src/rum.ts
@@ -1,0 +1,54 @@
+// Datadog RUM SDK initialization for the React SPA (web/app.html entry).
+// Spec 0013 (RumInstrumentation) bool:
+//   `rum_sdk_loaded_on_react_spa_entry_per_observability_intent`
+//
+// Imported by web/src/main.tsx BEFORE the React tree mounts so RUM
+// captures the initial render + first interaction.
+//
+// Credentials come from Vite build-time env vars
+// (VITE_DD_RUM_APPLICATION_ID + VITE_DD_RUM_CLIENT_TOKEN). The
+// web.deploy.yml workflow reads them from SSM
+// (/grug/dd-rum-application-id, /grug/dd-rum-client-token) and exports
+// them before `npm run build`. The Pulumi datadog.RumApplication
+// resource owns the SSM values (spec 0013, component dd_rum.py).
+//
+// If credentials are missing (e.g. local `npm run dev` without env
+// vars), the init is skipped — RUM stays dark instead of throwing.
+import { datadogRum } from "@datadog/browser-rum";
+
+const applicationId = import.meta.env.VITE_DD_RUM_APPLICATION_ID;
+const clientToken = import.meta.env.VITE_DD_RUM_CLIENT_TOKEN;
+const env = import.meta.env.VITE_DD_RUM_ENV ?? "dev";
+const version = import.meta.env.VITE_DD_RUM_VERSION ?? "local";
+
+export function initRum(): void {
+  if (!applicationId || !clientToken) {
+    // Local dev path — leave a breadcrumb in the console but don't throw.
+    console.info("[rum] init skipped — missing VITE_DD_RUM_APPLICATION_ID or VITE_DD_RUM_CLIENT_TOKEN");
+    return;
+  }
+
+  datadogRum.init({
+    applicationId,
+    clientToken,
+    site: "datadoghq.com",
+    // Spec 0013 invariant: service tag MUST be `grug-web` (canonical).
+    // Wrong/missing service tag splits the DD APM catalog across phantom
+    // service identities (same shape as the aws.lambda.url inferred-spans
+    // trap closed 2026-05-07 for grug-{api,webhook}).
+    service: "grug-web",
+    env,
+    version,
+    sessionSampleRate: 100,
+    // 100% session replay per the v1 instrumentation decision. Replay
+    // billing is separate from RUM event count — bump down here if cost
+    // becomes a concern.
+    sessionReplaySampleRate: 100,
+    // mask-user-input is the conservative default — usernames, emails,
+    // passwords get masked in the replay. App data still recorded.
+    defaultPrivacyLevel: "mask-user-input",
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+  });
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -2,6 +2,14 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE?: string;
+  // Datadog RUM build-time credentials (spec 0013). Sourced from SSM
+  // (/grug/dd-rum-{application-id,client-token}) by web.deploy.yml and
+  // exported as env vars before `npm run build`. All four optional —
+  // local `npm run dev` runs without them and RUM stays dark.
+  readonly VITE_DD_RUM_APPLICATION_ID?: string;
+  readonly VITE_DD_RUM_CLIENT_TOKEN?: string;
+  readonly VITE_DD_RUM_ENV?: string;
+  readonly VITE_DD_RUM_VERSION?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Closes the single observability gap surfaced by the 2026-05-24 audit (`docs/NETWORK-TOPOLOGY.md`): APM ✅, Logs ✅, Monitors ✅, **RUM ❌**. End-to-end SDD slice matching the existing 12-spec pattern.

Size: M

### Acceptance criteria

- [ ] Spec 0013 (RumInstrumentation) passes the temper L0+L1+L2+L3 cascade in CI
- [ ] Both new grounding attesters pass against the shipped code
- [ ] `npm run build` succeeds with the new RUM module + SDK dependency
- [ ] After deploy, `service:grug-web` appears in the DD APM catalog alongside `grug-api` and `grug-webhook`
- [ ] After deploy, `@view.url:*grug.lol*` returns RUM events in the DD UI
- [ ] Session replay records visits (100% sample) — visible in DD Session Replay UI
- [ ] Local `npm run dev` works without DD env vars (init no-ops with a console breadcrumb)

## Why

End-to-end observability requires RUM to close the loop between user-visible UX and backend traces. Without it: errors that happen client-side never surface; LCP/FCP/CLS regressions ship silently; you can't correlate a dashboard interaction with the backend trace it triggered. Spec 0013 turns "remember to install RUM" into a CI-enforced contract so future redesigns can't drop the SDK silently from any of the four user-facing HTML surfaces.

## SDD layer

| Spec bool | Attester | What it proves |
|---|---|---|
| `rum_application_declared_in_pulumi_per_iac_invariant` | `attest_rum_pulumi_registration.py` | `datadog.RumApplication` exists in `dd_rum.py` with `type=browser`, `rum_event_processing_state=ALL`; `dd_rum.create(name='grug-web', ...)` called from `__main__.py` |
| `rum_credentials_exported_to_ssm_per_secret_handling_invariant` | same attester | Both `/grug/dd-rum-application-id` + `/grug/dd-rum-client-token` are `aws.ssm.Parameter(type='SecureString', value=pulumi.Output.secret(...))` |
| `rum_sdk_loaded_on_react_spa_entry_per_observability_intent` | `attest_rum_sdk_in_html.py` | `main.tsx` imports `initRum` from `./rum` AND calls `initRum()` BEFORE `createRoot()`. `rum.ts` imports `datadogRum` from `@datadog/browser-rum` and calls `datadogRum.init(...)`. `package.json` lists the dep |
| `rum_sdk_loaded_on_static_landing_entries_per_observability_intent` | same attester | All 3 static HTML files carry the CDN snippet (matched via `datadoghq-browser-agent.com` URL) + all 4 placeholders for build-time substitution |
| `rum_service_tag_is_grug_web_canonical_per_dd_naming_canon` | same attester | `service: 'grug-web'` literal present in both `rum.ts` (SPA init) AND all 3 static-HTML snippets — wrong tag would split the DD APM catalog across phantom service identities |

Cascade locally:
```
L0 Symbolic PASSED: 7 guards satisfiable, 4 invariants inductive, 0 unreachable
L1 Model Check PASSED: 19 states explored, all properties hold
L2 Simulation PASSED: 5 seeds, 106 transitions, 0 dropped msgs
L3 Property Tests PASSED: 100 cases, 30 max steps
Result: PASS
```

All 13 specs PASS + all 17 attesters OK locally (12 pre-existing + 3 from spec 0012 + 2 new for spec 0013).

## Implementation notes

- **Credentials are public by design.** The RUM `clientToken` and `applicationId` live in the browser bundle — they're not secrets in the cryptographic sense. We still source them from SSM so a rotation is `pulumi up` instead of a git commit (no PR churn on rotation).
- **SecureString + Output.secret wrap.** Both SSM params use `type='SecureString'` and the Pulumi value is `pulumi.Output.secret(...)`-wrapped per `feedback_pulumi_preview_secret_leak_guard` — leak prevention is policy, not just for high-sensitivity values.
- **Local dev path.** The init checks for missing env vars (SPA) or un-substituted placeholders (static HTML) and no-ops with a console breadcrumb. `npm run dev` works without any DD setup.
- **Session replay = 100%.** Per your v1 decision. Bumps cost slightly but maximizes debuggability while the user-base is small. Easy to tune later via the Pulumi resource args (RUM event processing) or the init arg (replay sample rate).
- **Bundle impact.** SPA bundle grows from 260KB → 440KB (+180KB for RUM SDK) plus 35KB lazy chunks (replay recorder + long-task profiler load on-demand). Gzipped: 82KB → 144KB.

## Out of scope

- React Router auto-instrumentation (`addEventListener('routeChange', ...)`) — RUM v6 captures `view` events on `history.pushState` automatically, so the explicit hook isn't needed for our route shape.
- Custom attributes / RUM context (`datadogRum.setUserProperty`, `setGlobalContextProperty`) — leaving for a follow-up once we know what dimensions matter most (probably installation_id from the dashboard).
- Tracking the Org sales mailto: CTA as a conversion goal — separate Product Analytics task.
- Updating `docs/NETWORK-TOPOLOGY.md` to remove the ❌ RUM row — that doc lives on PR #162; will update via a follow-up commit after both PRs merge.
- Adding a DD monitor on `@view.error_count > 0` — separate spec (will be `0014-rum-error-monitor` if/when added).

## Test plan

- [ ] CI green: `Verify spec 0013 (RumInstrumentation)` step + both `Attester · RUM ...` steps PASS
- [ ] CI green: all 12 pre-existing spec verify steps + 15 pre-existing attester steps stay PASS (no regression)
- [ ] After merge + `iac.deploy.yml` runs: `aws ssm get-parameter --name /grug/dd-rum-application-id` returns a value (Pulumi-created)
- [ ] After merge + `web.deploy.yml` runs: workflow step `07b. Inject DD RUM credentials into static HTML` reports `✓ DD RUM credentials substituted into 3 static HTML files`
- [ ] Live curl + grep: `curl -s https://grug.lol/ | grep -c 'datadoghq-browser-agent.com'` returns 1 (CDN snippet present); `curl -s https://grug.lol/ | grep -c '__DD_RUM_'` returns 0 (all placeholders substituted)
- [ ] DD MCP probe: `search_datadog_rum_events @application.id:*grug*` returns >0 events within 10min of first browser visit
- [ ] DD APM catalog shows `service:grug-web` alongside `grug-api` and `grug-webhook`
- [ ] Adversarial validation (already passed locally): corrupting `service: "grug-web"` in `rum.ts` to a different value triggers attester FAIL with the exact bool name

closes #163

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>