### PR TITLE
ci(iac-deploy): install uv on ubuntu-latest (was silently broken since #156)

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -93,10 +93,20 @@ jobs:
           echo "::add-mask::$TOKEN"
           echo "PULUMI_ACCESS_TOKEN=$TOKEN" >> $GITHUB_ENV
 
-      # Runner has system Python 3.14 + uv (installed at /usr/local/bin/uv
-      # via the runner-tooling bootstrap). Pyproject requires >=3.11 so
-      # 3.14 satisfies. actions/setup-python lacks Ubuntu 26.04 prebuilds.
-      - name: 05. Verify Python + uv
+      # ubuntu-latest ships system Python 3.12 but does NOT include uv.
+      # (The previous comment here claimed uv came from the runner-tooling
+      # bootstrap — that was true for srv-unraid-gha; ubuntu-latest needs
+      # it installed explicitly. PR #156's runner swap silently broke
+      # every iac.deploy from 2026-05-24 until this hotfix because uv was
+      # missing.) Use astral-sh/setup-uv for the cached, pinned install.
+      # Pinned to the same SHA used across infrastructure/.github/workflows/
+      # iac.pulumi.*.yml — keeps the uv version in lockstep with sibling
+      # Pulumi projects so a bump (or known-good rollback) is one greppable
+      # edit across all repos.
+      - name: 05a. Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+
+      - name: 05b. Verify Python + uv
         run: |
           python3 --version
           uv --version


### PR DESCRIPTION
## Summary

PR #156's runner swap silently broke `iac.deploy.yml` because the workflow's `05. Verify Python + uv` step assumed `uv` was preinstalled. That assertion was true for srv-unraid-gha (runner-tooling bootstrap), false for ubuntu-latest. Pulumi has not successfully run since 2026-05-24.

Size: XS

### Acceptance criteria

- [ ] iac.deploy.yml's new `05a. Install uv` step succeeds
- [ ] iac.deploy.yml's new `05b. Verify Python + uv` step prints both versions
- [ ] First post-merge iac.deploy run proceeds past step 05 and reaches `pulumi up`
- [ ] After the first successful iac.deploy: `aws ssm get-parameter --name /grug/dd-rum-application-id` returns a value (Pulumi created the resource)
- [ ] After the first subsequent web.deploy: live HTML at `grug.lol` no longer contains `__DD_RUM_` placeholders; replaced with real credentials

## Why

PR #156 swapped iac.deploy + web.deploy from `[self-hosted, srv-unraid-gha]` to `ubuntu-latest`. The iac.deploy step had a comment claiming uv came from runner-tooling bootstrap — true for the old runner, false for ubuntu-latest. **Pulumi has not successfully run since #156 merged** — every iac.deploy for PRs #157, #160, #164 silently failed at step 05 with `uv: command not found`.

Downstream impact (none user-visible):
- #157 + #160 Pulumi changes (no-ops since they didn't add new AWS resources, just modified Lambda code paths that were already deployed).
- #164 (RUM SDD) — the `datadog.RumApplication` resource was never created. SSM params don't exist. web.deploy fell through to empty fallback. Static HTML deployed with un-substituted `__DD_RUM_*__` placeholders. RUM init's graceful self-skip means the site works, RUM is dark.

## Out of scope

- web.deploy.yml — uses Node, not uv. Unaffected.
- Auditing other workflows for similar runner-swap assumptions. Saved as memory `feedback_runner_swap_check_preinstalled_tools.md` for future PR review.
- Re-triggering iac.deploy + web.deploy after this merges — separate operation, will do post-merge.

## Test plan

- [ ] CI green on this PR
- [ ] Post-merge iac.deploy run on the merge SHA proceeds past step 05
- [ ] Post-merge iac.deploy run completes; `aws ssm get-parameter --name /grug/dd-rum-application-id` returns a value
- [ ] Re-triggered web.deploy substitutes the new SSM creds into static HTML; `curl -s https://grug.lol/ | grep __DD_RUM_` returns nothing
- [ ] DD MCP: first browser visit produces RUM events (`@application.id:*grug*` returns rows)

closes #165

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>