### PR TITLE
fix(iam): grant ssm:PutParameter on /grug/* to grug-gha-deploy role

### DIFF
--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -153,6 +153,31 @@ def create(
                         # follow-up. Slice 1 prioritizes "deploy works".
                         "Resource": "*",
                     },
+                    {
+                        # Pulumi-managed SSM writes. Scoped tighter than
+                        # the general policy above: only `/grug/*` paths
+                        # the grug stack owns, never the cross-cutting
+                        # `/shared/*` namespace (which is read-only from
+                        # this role's POV — Pulumi for `/shared/*` lives
+                        # in infrastructure/pulumi/aws-cicd-bootstrap).
+                        #
+                        # Spec 0013 (RumInstrumentation) needs PutParameter
+                        # so the dd_rum component can persist the
+                        # `datadog.RumApplication` ID + client token to
+                        # SSM after creation. Caught when Pulumi #166's
+                        # iac.deploy got past the DD scope check but
+                        # failed with `AccessDeniedException: ssm:PutParameter`.
+                        "Effect": "Allow",
+                        "Action": [
+                            "ssm:PutParameter",
+                            "ssm:DeleteParameter",
+                            "ssm:AddTagsToResource",
+                            "ssm:RemoveTagsFromResource",
+                            "ssm:ListTagsForResource",
+                            "ssm:LabelParameterVersion",
+                        ],
+                        "Resource": "arn:aws:ssm:*:*:parameter/grug/*",
+                    },
                 ],
             },
         )


### PR DESCRIPTION
## Summary

Spec 0013's `dd_rum` component is the first Pulumi-managed SSM writer in the grug stack. The deploy role's IAM policy was read-only on SSM, so iac.deploy hit `AccessDeniedException` after every other gate cleared. Fix adds a scoped Put grant on `/grug/*`.

Size: XS

### Acceptance criteria

- [ ] Next iac.deploy run completes (`pulumi up` succeeds with 0 errored)
- [ ] `aws ssm get-parameter --name /grug/dd-rum-application-id` returns a value
- [ ] `aws ssm get-parameter --name /grug/dd-rum-client-token --with-decryption` returns a value
- [ ] DD UI shows a new RUM Application named `grug-web`

## Why

PR #164 (RUM SDD) added `datadog.RumApplication` + 2x `aws.ssm.Parameter` SecureStrings. After clearing every prior failure (uv missing → PR #166; `rum_apps_*` scopes → DD UI; `product_analytics_apps_write` scope → DD UI), the final blocker surfaced:

\`\`\`
AccessDeniedException: User: arn:aws:sts::...:assumed-role/grug-gha-deploy/GitHubActions
is not authorized to perform: ssm:PutParameter on resource:
arn:aws:ssm:us-east-1:...:parameter/grug/dd-rum-client-token
\`\`\`

The role had `ssm:GetParameter*` but not Put — read-only was enough until now because every other /grug/* SSM secret was pre-loaded by hand per `HITL_PREREQUISITES.md`.

Fix: append a second IAM Statement granting Put + sibling actions, scoped to `arn:aws:ssm:*:*:parameter/grug/*`. The cross-cutting `/shared/*` namespace stays read-only from this role's perspective — those are managed by `infrastructure/pulumi/aws-cicd-bootstrap`, not by grug.

## Out of scope

- Tightening to `/grug/dd-rum-*` specifically (the `/grug/*` scope is conservative enough — the role is OIDC-scoped to the githumps/grug repo + main/feat/fix/hotfix branches).
- Auditing other roles for similar read-only gaps in IaC repos.
- Re-triggering iac.deploy + web.deploy after merge — separate operation, will do post-merge.

## Test plan

- [ ] CI green on this PR
- [ ] Post-merge iac.deploy run on the merge SHA reaches `pulumi up` and completes successfully
- [ ] Post-merge: `aws ssm get-parameter --name /grug/dd-rum-application-id --with-decryption` returns a UUID
- [ ] Re-triggered web.deploy substitutes RUM creds into static HTML; `curl -s https://grug.lol/ | grep __DD_RUM_` returns 0 matches
- [ ] DD MCP probe: `search_datadog_rum_events @application.id:<uuid>` returns events after first browser visit
- [ ] DD APM catalog shows `service:grug-web` alongside `grug-api` and `grug-webhook`

closes #170

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>