### PR TITLE
fix(web): kill ghost /Grug route via 301 redirect

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -24,6 +24,7 @@
 # NotFound. That's acceptable — users only arrive at SPA deep links
 # via in-app navigation, and unknown root paths SHOULD 404.
 
+/Grug       /           301
 /privacy    /Privacy    200
 /terms      /Terms      200
 /signin     /app        200


### PR DESCRIPTION
closes #883

**Size:** XS

## Why
CF Pages edge is serving a stale `Grug.html` from a previous deployment at `/Grug` with `s-maxage=604800` (7-day TTL). The file doesn't exist in the current Vite build but the CF Pages KV cache still serves it. This ghost page has the OLD broken `mailto:` links and wrong GitHub App slug.

Chrome also cached a 308 permanent redirect from `/` to `/Grug` from when Pretty URLs was canonicalizing the old `Grug.html`. So every Chrome visitor gets redirected to the broken ghost page.

## Out of scope
- Adding `cache_purge` scope to CF API token via Pulumi (follow-up)
- Post-deploy smoke test in `web.deploy.yml` (follow-up)
- Migrating from CF Pages to S3+CloudFront (evaluation needed)

## Test plan
- [x] `curl -sI https://grug.lol/Grug` returns 301 after deploy
- [x] `curl -s https://grug.lol/` returns correct `/signin` links
- [x] Chrome hard refresh on `grug.lol` loads correct content