### PR TITLE
fix(web): redirect /grug lowercase ghost route

### DIFF
--- a/web/public/_redirects
+++ b/web/public/_redirects
@@ -25,6 +25,7 @@
 # via in-app navigation, and unknown root paths SHOULD 404.
 
 /Grug       /           301
+/grug       /           301
 /privacy    /Privacy    200
 /terms      /Terms      200
 /signin     /app        200


### PR DESCRIPTION
**Size:** XS

## Why
CF Pages `_redirects` are case-sensitive. PR #175 added `/Grug → / 301` but `/grug` (lowercase) still serves the ghost page with broken mailto links.

## Out of scope
- Adding `_headers` to set `max-age=0` on HTML files (follow-up)
- S3+CloudFront migration evaluation

## Test plan
- [x] `curl -sI https://grug.lol/grug` returns 301 → `/` after deploy
- [x] `curl -sI https://grug.lol/Grug` returns 301 → `/` (PR #175)
- [x] `curl -s https://grug.lol/` returns correct content