### PR TITLE
[grug] feat(ci): migrate Pulumi workflow to S3 backend

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -81,17 +81,9 @@ jobs:
             echo "stack=dev" >> $GITHUB_OUTPUT
           fi
 
-      # Pulumi access token + DD API key + other cross-repo tokens live
-      # in SSM `/shared/*` per githumps/infrastructure#164. Fetched
-      # at deploy time using OIDC role's ssm:GetParameter on /shared/*.
-      # Mask the value so it never leaks into job logs even if a step
-      # echoes it accidentally.
-      - name: 04. Fetch Pulumi access token from SSM
+      - name: 04. Pulumi login (S3 backend)
         run: |
-          TOKEN=$(aws ssm get-parameter --name /shared/pulumi-access-token \
-            --with-decryption --query 'Parameter.Value' --output text)
-          echo "::add-mask::$TOKEN"
-          echo "PULUMI_ACCESS_TOKEN=$TOKEN" >> $GITHUB_ENV
+          pulumi login s3://pulumi-state-mizu-cloud-castle
 
       # ubuntu-latest ships system Python 3.12 but does NOT include uv.
       # (The previous comment here claimed uv came from the runner-tooling
@@ -178,7 +170,8 @@ jobs:
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
         with:
           command: up
-          stack-name: pulumi_ehumps_me/grug/${{ steps.stack.outputs.stack }}
+          stack-name: ${{ steps.stack.outputs.stack }}
+          cloud-url: s3://pulumi-state-mizu-cloud-castle
           work-dir: infra/pulumi
           # full_commit_sha = 40-char SHA used for DD source-code linking
           # (image_tag is 8-char short SHA; DD source UI requires full).

--- a/infra/pulumi/Pulumi.dev.yaml
+++ b/infra/pulumi/Pulumi.dev.yaml
@@ -1,3 +1,5 @@
+secretsprovider: awskms://alias/pulumi-secrets?region=us-east-1
+encryptedkey: AQICAHhjW4kuB5Y5Y/O/7WODHZsdeqg+NIKyRB1FUcpCkpgCyAG+mp/fpMiKxwV5DaRBcgpHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwo2cBozsx7dga87bAgEQgDuhTDeboTQo7VwwT5sJQ4MMo1UtwrsCcenx5D1JxUDv2BJwAGXlksL2iZgLh5+Cp1yXB9WQaz4WH7LKWg==
 config:
   aws:region: us-east-1
   grug:env: dev


### PR DESCRIPTION
## Summary

- Replace `PULUMI_ACCESS_TOKEN` SSM fetch with direct `pulumi login s3://pulumi-state-mizu-cloud-castle`
- Update stack-name from `pulumi_ehumps_me/grug/$stack` to just `$stack` + `cloud-url` input
- Add `secretsprovider` + `encryptedkey` to `Pulumi.dev.yaml` (matches S3 backend state)

The grug stack was migrated to S3 in infrastructure#657 but the workflow was missed. This aligns the deploy workflow with the rest of the fleet.

## Test plan

- [ ] YAML validates cleanly
- [ ] `grep -rn 'PULUMI_ACCESS_TOKEN\|pulumi_ehumps_me'` returns zero matches
- [ ] Next push-to-main triggers a successful `pulumi up` against S3 backend

Size: XS

## Out of scope

- SSM `/shared/pulumi-access-token` cleanup (done in infrastructure#661)

closes githumps/infrastructure#660