### PR TITLE
[grug] feat(ci): rename stack dev→prod + fix uv deprecation

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -23,15 +23,6 @@ on:
       - 'feat/31-*'
     tags: ['v*']
   workflow_dispatch:
-    inputs:
-      stack:
-        description: "Pulumi stack to deploy (dev|prod)"
-        required: true
-        default: dev
-        type: choice
-        options:
-          - dev
-          - prod
 
 permissions:
   contents: read
@@ -70,16 +61,9 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
           aws-region: us-east-1
 
-      - name: 03. Resolve stack name
+      - name: 03. Stack name (single env)
         id: stack
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "stack=${{ inputs.stack }}" >> $GITHUB_OUTPUT
-          elif [ "${{ github.ref_type }}" = "tag" ]; then
-            echo "stack=prod" >> $GITHUB_OUTPUT
-          else
-            echo "stack=dev" >> $GITHUB_OUTPUT
-          fi
+        run: echo "stack=prod" >> $GITHUB_OUTPUT
 
       - name: 04. Pulumi login (S3 backend)
         run: |

--- a/infra/pulumi/Pulumi.prod.yaml
+++ b/infra/pulumi/Pulumi.prod.yaml
@@ -2,5 +2,5 @@ secretsprovider: awskms://alias/pulumi-secrets?region=us-east-1
 encryptedkey: AQICAHhjW4kuB5Y5Y/O/7WODHZsdeqg+NIKyRB1FUcpCkpgCyAG+mp/fpMiKxwV5DaRBcgpHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwo2cBozsx7dga87bAgEQgDuhTDeboTQo7VwwT5sJQ4MMo1UtwrsCcenx5D1JxUDv2BJwAGXlksL2iZgLh5+Cp1yXB9WQaz4WH7LKWg==
 config:
   aws:region: us-east-1
-  grug:env: dev
+  grug:env: prod
   grug:domain: grug.lol

--- a/infra/pulumi/pyproject.toml
+++ b/infra/pulumi/pyproject.toml
@@ -11,8 +11,8 @@ dependencies = [
     "pulumiverse-time>=0.1.1",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.0",
     "pulumi-policy>=1.0,<2.0",
 ]


### PR DESCRIPTION
## Summary

- Rename Pulumi stack from `dev` to `prod` (single environment, no dev/prod split)
- Rename `Pulumi.dev.yaml` → `Pulumi.prod.yaml`, update `grug:env` config value
- Remove dead workflow_dispatch stack picker (always `prod` now)
- Fix `[tool.uv] dev-dependencies` deprecation → `[dependency-groups] dev`

## Test plan

- [ ] Stack already renamed on S3 backend (`pulumi stack rename prod` ran successfully)
- [ ] Workflow YAML validates
- [ ] Next push-to-main deploys against `prod` stack

Size: XS

## Out of scope

- DD monitor/dashboard `env:dev` → `env:prod` tag migration (will happen on next deploy automatically)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>