### PR TITLE
feat: GitHub Rulesets client (CRUD + enforcement detection)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,16 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **`post_check_run` (publisher)** | Module-level function in `github_checks_client.py` that POSTs a `CheckRunResult` to GitHub. The acceptance-criteria spelling "CheckRunPublisher" is the *concept name* — the actual identifier is a function, not a class. |
 | **Scope review (roadmap)** | Advisory LLM pass over PR title + body. Wired as a `poolside_client.py` hook called from `evaluate_pull_request(...)` per the `personas/tpm/__init__.py` docstring, but **`poolside_client.py` does not exist in the repo today** — feature is roadmap-only. Intended behavior: flag title↔body mismatch, AC testability, scope-creep, XL inflation; posted as a comment, never blocking. |
 
+## Enforcement concepts
+
+| Term | Definition |
+|---|---|
+| **GitHub Ruleset** | A GitHub Repository Ruleset that requires specific status checks to pass before merging. Grug creates rulesets to enforce its DoR check on the default branch. Managed via the Repository Rulesets API (`POST/GET/DELETE /repos/{owner}/{repo}/rulesets`). See [`services/{api,webhook}/github_rulesets_client.py`](services/api/github_rulesets_client.py) (mirrored — see ADR-0001). |
+| **Grug-managed ruleset** | A ruleset whose `name` starts with the prefix `Grug —`. This prefix is the ownership marker: `detect_enforcement()` uses it to distinguish rulesets Grug created from externally-managed ones. |
+| **EnforcementState** | Literal type — `"grug_managed" \| "external" \| "none"`. Returned by `detect_enforcement()`. `grug_managed`: at least one `Grug —`-prefixed ruleset exists with `required_status_checks` matching the check name. `external`: no grug-managed ruleset, but the check is enforced via a non-Grug ruleset or legacy branch protection. `none`: check is not enforced anywhere. |
+| **`detect_enforcement()`** | Module-level function in `github_rulesets_client.py` that determines the enforcement state for a given status check. Queries both the Rulesets API and the legacy Branch Protection API (`GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks`) to cover repos that haven't migrated to rulesets. |
+| **Legacy branch protection** | Pre-rulesets mechanism for requiring status checks. Still active on many repos. `detect_enforcement()` checks this as a fallback when no ruleset-based enforcement is found. |
+
 ## Identity & authorization concepts
 
 | Term | Definition |
@@ -51,13 +61,14 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 
 ## Cross-service primitives (mirrored)
 
-The following six modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
+The following seven modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
 
 | Module | Purpose |
 |---|---|
 | `observability.py` | DD-extension-aware logger + JSON formatter. Reads `DD_SERVICE`, `DD_ENV`, `GRUG_LOG_LEVEL`. |
 | `secrets_loader.py` | SSM SecureString reads at cold start (`GITHUB_APP_ID_SSM`, `GITHUB_APP_WEBHOOK_SECRET_SSM`, etc.). |
 | `github_checks_client.py` | Thin `httpx`-based wrapper over GitHub's Checks API; carries the `CheckRunResult` dataclass. |
+| `github_rulesets_client.py` | Thin `httpx`-based wrapper over GitHub's Repository Rulesets API + legacy branch protection; carries `EnforcementState` type and `detect_enforcement()`. |
 | `adapters/install_store.py` | DDB single-table CRUD for `Installation` + `RepoConfig` + `AllowlistGate` reads. |
 | `ports/token_cache.py` | `TokenCache` Protocol + `InMemoryTokenCache` impl. |
 | `personas/tpm/dor_checks.py` | The 5 `DoR check` rules + the `CheckResult` dataclass. |

--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -30,6 +30,7 @@ cd "$(dirname "$0")/.."
 MIRRORED_WITH_HEADER=(
   "adapters/install_store.py"
   "github_checks_client.py"
+  "github_rulesets_client.py"
   "observability.py"
   "personas/tpm/dor_checks.py"
   "ports/token_cache.py"

--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -8,6 +8,7 @@ Tokens fetched per-installation via github_app_auth.
 
 from __future__ import annotations
 
+import logging
 from typing import Literal
 
 import httpx
@@ -17,6 +18,8 @@ _GH_API = "https://api.github.com"
 GRUG_RULESET_PREFIX = "Grug — "
 
 EnforcementState = Literal["grug_managed", "external", "none"]
+
+log = logging.getLogger("grug.rulesets")
 
 _HEADERS_TEMPLATE = {
     "Accept": "application/vnd.github+json",
@@ -110,6 +113,16 @@ def _check_name_in_ruleset(ruleset: dict, check_name: str) -> bool:
     return False
 
 
+def _check_name_in_legacy(legacy_data: dict, check_name: str) -> bool:
+    """Check both legacy ``contexts`` and newer ``checks`` array formats."""
+    if check_name in legacy_data.get("contexts", []):
+        return True
+    for check in legacy_data.get("checks", []):
+        if isinstance(check, dict) and check.get("context") == check_name:
+            return True
+    return False
+
+
 def detect_enforcement(
     install_token: str,
     owner: str,
@@ -141,7 +154,6 @@ def detect_enforcement(
     if external_match:
         return "external"
 
-    # Fall back to legacy branch protection.
     try:
         legacy_resp = httpx.get(
             f"{_GH_API}/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
@@ -149,11 +161,24 @@ def detect_enforcement(
             timeout=10,
         )
         legacy_resp.raise_for_status()
-        contexts = legacy_resp.json().get("contexts", [])
-        if check_name in contexts:
+        if _check_name_in_legacy(legacy_resp.json(), check_name):
             return "external"
     except httpx.HTTPStatusError as e:
         if e.response.status_code != 404:
             raise
+        log.debug(
+            "legacy_branch_protection_not_configured",
+            extra={"owner": owner, "repo": repo, "branch": branch},
+        )
+    except httpx.RequestError as e:
+        log.warning(
+            "legacy_branch_protection_transport_failed",
+            extra={
+                "owner": owner,
+                "repo": repo,
+                "branch": branch,
+                "kind": type(e).__name__,
+            },
+        )
 
     return "none"

--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -165,11 +165,12 @@ def detect_enforcement(
         if _check_name_in_legacy(legacy_resp.json(), check_name):
             return "external"
     except httpx.HTTPStatusError as e:
-        if e.response.status_code != 404:
+        if e.response.status_code not in (404, 403):
             raise
         log.debug(
-            "legacy_branch_protection_not_configured",
-            extra={"owner": owner, "repo": repo, "branch": branch},
+            "legacy_branch_protection_unavailable",
+            extra={"owner": owner, "repo": repo, "branch": branch,
+                   "status": e.response.status_code},
         )
     except httpx.RequestError as e:
         log.warning(

--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -1,0 +1,159 @@
+# MIRRORED — sibling at services/webhook/github_rulesets_client.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""GitHub Repository Rulesets API client — CRUD + enforcement detection.
+
+Wraps the Rulesets endpoints Grug needs for automatic DoR enforcement.
+Also queries legacy branch protection for repos that haven't migrated.
+Tokens fetched per-installation via github_app_auth.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+
+_GH_API = "https://api.github.com"
+
+GRUG_RULESET_PREFIX = "Grug — "
+
+EnforcementState = Literal["grug_managed", "external", "none"]
+
+_HEADERS_TEMPLATE = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+
+def _auth_headers(install_token: str) -> dict[str, str]:
+    return {**_HEADERS_TEMPLATE, "Authorization": f"Bearer {install_token}"}
+
+
+def create_ruleset(
+    install_token: str,
+    owner: str,
+    repo: str,
+    name: str,
+    status_check_contexts: list[str],
+) -> dict:
+    """Create a ruleset requiring status checks on the default branch."""
+    body = {
+        "name": name,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            },
+        },
+        "rules": [
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "strict_required_status_checks_policy": False,
+                    "required_status_checks": [
+                        {"context": ctx, "integration_id": None}
+                        for ctx in status_check_contexts
+                    ],
+                },
+            },
+        ],
+    }
+    resp = httpx.post(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        json=body,
+        headers=_auth_headers(install_token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def delete_ruleset(
+    install_token: str,
+    owner: str,
+    repo: str,
+    ruleset_id: int,
+) -> None:
+    """Delete a ruleset by ID."""
+    resp = httpx.delete(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+        headers=_auth_headers(install_token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+
+
+def list_rulesets(
+    install_token: str,
+    owner: str,
+    repo: str,
+) -> list[dict]:
+    """List all rulesets for a repository."""
+    resp = httpx.get(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        headers=_auth_headers(install_token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _check_name_in_ruleset(ruleset: dict, check_name: str) -> bool:
+    """Return True if any required_status_checks rule in the ruleset matches check_name."""
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        for check in rule.get("parameters", {}).get("required_status_checks", []):
+            if check.get("context") == check_name:
+                return True
+    return False
+
+
+def detect_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    branch: str,
+    check_name: str,
+) -> EnforcementState:
+    """Determine whether check_name is enforced and by whom.
+
+    Checks the Rulesets API first, then falls back to legacy branch
+    protection. Returns ``"grug_managed"`` if a ``Grug —``-prefixed
+    ruleset enforces the check, ``"external"`` if enforced by a
+    non-Grug mechanism, or ``"none"`` if not enforced at all.
+    """
+    rulesets = list_rulesets(install_token, owner, repo)
+
+    grug_match = False
+    external_match = False
+    for rs in rulesets:
+        if not _check_name_in_ruleset(rs, check_name):
+            continue
+        if rs.get("name", "").startswith(GRUG_RULESET_PREFIX):
+            grug_match = True
+        else:
+            external_match = True
+
+    if grug_match:
+        return "grug_managed"
+    if external_match:
+        return "external"
+
+    # Fall back to legacy branch protection.
+    try:
+        legacy_resp = httpx.get(
+            f"{_GH_API}/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+            headers=_auth_headers(install_token),
+            timeout=10,
+        )
+        legacy_resp.raise_for_status()
+        contexts = legacy_resp.json().get("contexts", [])
+        if check_name in contexts:
+            return "external"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code != 404:
+            raise
+
+    return "none"

--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -1,5 +1,5 @@
 # MIRRORED — sibling at services/webhook/github_rulesets_client.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
-"""GitHub Repository Rulesets API client — CRUD + enforcement detection.
+"""GitHub Repository Rulesets API client — create/list/delete + enforcement detection.
 
 Wraps the Rulesets endpoints Grug needs for automatic DoR enforcement.
 Also queries legacy branch protection for repos that haven't migrated.
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from typing import Literal
+from urllib.parse import quote
 
 import httpx
 
@@ -156,7 +157,7 @@ def detect_enforcement(
 
     try:
         legacy_resp = httpx.get(
-            f"{_GH_API}/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+            f"{_GH_API}/repos/{owner}/{repo}/branches/{quote(branch, safe='')}/protection/required_status_checks",
             headers=_auth_headers(install_token),
             timeout=10,
         )

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -8,6 +8,7 @@ Tokens fetched per-installation via github_app_auth.
 
 from __future__ import annotations
 
+import logging
 from typing import Literal
 
 import httpx
@@ -17,6 +18,8 @@ _GH_API = "https://api.github.com"
 GRUG_RULESET_PREFIX = "Grug — "
 
 EnforcementState = Literal["grug_managed", "external", "none"]
+
+log = logging.getLogger("grug.rulesets")
 
 _HEADERS_TEMPLATE = {
     "Accept": "application/vnd.github+json",
@@ -110,6 +113,16 @@ def _check_name_in_ruleset(ruleset: dict, check_name: str) -> bool:
     return False
 
 
+def _check_name_in_legacy(legacy_data: dict, check_name: str) -> bool:
+    """Check both legacy ``contexts`` and newer ``checks`` array formats."""
+    if check_name in legacy_data.get("contexts", []):
+        return True
+    for check in legacy_data.get("checks", []):
+        if isinstance(check, dict) and check.get("context") == check_name:
+            return True
+    return False
+
+
 def detect_enforcement(
     install_token: str,
     owner: str,
@@ -141,7 +154,6 @@ def detect_enforcement(
     if external_match:
         return "external"
 
-    # Fall back to legacy branch protection.
     try:
         legacy_resp = httpx.get(
             f"{_GH_API}/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
@@ -149,11 +161,24 @@ def detect_enforcement(
             timeout=10,
         )
         legacy_resp.raise_for_status()
-        contexts = legacy_resp.json().get("contexts", [])
-        if check_name in contexts:
+        if _check_name_in_legacy(legacy_resp.json(), check_name):
             return "external"
     except httpx.HTTPStatusError as e:
         if e.response.status_code != 404:
             raise
+        log.debug(
+            "legacy_branch_protection_not_configured",
+            extra={"owner": owner, "repo": repo, "branch": branch},
+        )
+    except httpx.RequestError as e:
+        log.warning(
+            "legacy_branch_protection_transport_failed",
+            extra={
+                "owner": owner,
+                "repo": repo,
+                "branch": branch,
+                "kind": type(e).__name__,
+            },
+        )
 
     return "none"

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -1,0 +1,159 @@
+# MIRRORED — sibling at services/api/github_rulesets_client.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""GitHub Repository Rulesets API client — CRUD + enforcement detection.
+
+Wraps the Rulesets endpoints Grug needs for automatic DoR enforcement.
+Also queries legacy branch protection for repos that haven't migrated.
+Tokens fetched per-installation via github_app_auth.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+
+_GH_API = "https://api.github.com"
+
+GRUG_RULESET_PREFIX = "Grug — "
+
+EnforcementState = Literal["grug_managed", "external", "none"]
+
+_HEADERS_TEMPLATE = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+
+def _auth_headers(install_token: str) -> dict[str, str]:
+    return {**_HEADERS_TEMPLATE, "Authorization": f"Bearer {install_token}"}
+
+
+def create_ruleset(
+    install_token: str,
+    owner: str,
+    repo: str,
+    name: str,
+    status_check_contexts: list[str],
+) -> dict:
+    """Create a ruleset requiring status checks on the default branch."""
+    body = {
+        "name": name,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {
+                "include": ["~DEFAULT_BRANCH"],
+                "exclude": [],
+            },
+        },
+        "rules": [
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "strict_required_status_checks_policy": False,
+                    "required_status_checks": [
+                        {"context": ctx, "integration_id": None}
+                        for ctx in status_check_contexts
+                    ],
+                },
+            },
+        ],
+    }
+    resp = httpx.post(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        json=body,
+        headers=_auth_headers(install_token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def delete_ruleset(
+    install_token: str,
+    owner: str,
+    repo: str,
+    ruleset_id: int,
+) -> None:
+    """Delete a ruleset by ID."""
+    resp = httpx.delete(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+        headers=_auth_headers(install_token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+
+
+def list_rulesets(
+    install_token: str,
+    owner: str,
+    repo: str,
+) -> list[dict]:
+    """List all rulesets for a repository."""
+    resp = httpx.get(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        headers=_auth_headers(install_token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _check_name_in_ruleset(ruleset: dict, check_name: str) -> bool:
+    """Return True if any required_status_checks rule in the ruleset matches check_name."""
+    for rule in ruleset.get("rules", []):
+        if rule.get("type") != "required_status_checks":
+            continue
+        for check in rule.get("parameters", {}).get("required_status_checks", []):
+            if check.get("context") == check_name:
+                return True
+    return False
+
+
+def detect_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    branch: str,
+    check_name: str,
+) -> EnforcementState:
+    """Determine whether check_name is enforced and by whom.
+
+    Checks the Rulesets API first, then falls back to legacy branch
+    protection. Returns ``"grug_managed"`` if a ``Grug —``-prefixed
+    ruleset enforces the check, ``"external"`` if enforced by a
+    non-Grug mechanism, or ``"none"`` if not enforced at all.
+    """
+    rulesets = list_rulesets(install_token, owner, repo)
+
+    grug_match = False
+    external_match = False
+    for rs in rulesets:
+        if not _check_name_in_ruleset(rs, check_name):
+            continue
+        if rs.get("name", "").startswith(GRUG_RULESET_PREFIX):
+            grug_match = True
+        else:
+            external_match = True
+
+    if grug_match:
+        return "grug_managed"
+    if external_match:
+        return "external"
+
+    # Fall back to legacy branch protection.
+    try:
+        legacy_resp = httpx.get(
+            f"{_GH_API}/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+            headers=_auth_headers(install_token),
+            timeout=10,
+        )
+        legacy_resp.raise_for_status()
+        contexts = legacy_resp.json().get("contexts", [])
+        if check_name in contexts:
+            return "external"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code != 404:
+            raise
+
+    return "none"

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -1,5 +1,5 @@
 # MIRRORED — sibling at services/api/github_rulesets_client.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
-"""GitHub Repository Rulesets API client — CRUD + enforcement detection.
+"""GitHub Repository Rulesets API client — create/list/delete + enforcement detection.
 
 Wraps the Rulesets endpoints Grug needs for automatic DoR enforcement.
 Also queries legacy branch protection for repos that haven't migrated.
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from typing import Literal
+from urllib.parse import quote
 
 import httpx
 
@@ -156,7 +157,7 @@ def detect_enforcement(
 
     try:
         legacy_resp = httpx.get(
-            f"{_GH_API}/repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks",
+            f"{_GH_API}/repos/{owner}/{repo}/branches/{quote(branch, safe='')}/protection/required_status_checks",
             headers=_auth_headers(install_token),
             timeout=10,
         )

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -165,11 +165,12 @@ def detect_enforcement(
         if _check_name_in_legacy(legacy_resp.json(), check_name):
             return "external"
     except httpx.HTTPStatusError as e:
-        if e.response.status_code != 404:
+        if e.response.status_code not in (404, 403):
             raise
         log.debug(
-            "legacy_branch_protection_not_configured",
-            extra={"owner": owner, "repo": repo, "branch": branch},
+            "legacy_branch_protection_unavailable",
+            extra={"owner": owner, "repo": repo, "branch": branch,
+                   "status": e.response.status_code},
         )
     except httpx.RequestError as e:
         log.warning(

--- a/services/webhook/tests/test_github_rulesets_client.py
+++ b/services/webhook/tests/test_github_rulesets_client.py
@@ -1,4 +1,4 @@
-"""Tests for github_rulesets_client — CRUD + enforcement detection.
+"""Tests for github_rulesets_client — create/list/delete + enforcement detection.
 
 Covers request shape (URL, auth header, API version, body fields),
 enforcement detection across Rulesets API + legacy branch protection,
@@ -315,3 +315,49 @@ def test_detect_legacy_transport_error_returns_none():
         result = detect_enforcement("tok", "o", "r", "main", "check")
 
     assert result == "none"
+
+
+def test_detect_legacy_url_encodes_branch_with_slash():
+    """Branch names like 'feat/foo' must be URL-encoded in the path segment."""
+    rulesets_resp = _ok_response([])
+    legacy_resp = _ok_response({"contexts": ["check-a"]})
+
+    calls = []
+    def capture_get(*a, **kw):
+        calls.append(a[0])
+        if len(calls) == 1:
+            return rulesets_resp
+        return legacy_resp
+
+    with patch("httpx.get", side_effect=capture_get):
+        detect_enforcement("tok", "o", "r", "feat/my-branch", "check-a")
+
+    assert "feat%2Fmy-branch" in calls[1]
+
+
+def test_detect_enforcement_401_propagates(mock_transport_client):
+    """401 from rulesets list_rulesets must propagate so
+    with_install_token_retry can invalidate + refresh."""
+    client = mock_transport_client(status_codes=[401])
+    with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            detect_enforcement("stale", "o", "r", "main", "check")
+    assert exc.value.response.status_code == 401
+
+
+def test_detect_legacy_non_404_error_propagates(mock_transport_client):
+    """500 from the legacy branch protection endpoint must re-raise."""
+    rulesets_resp = _ok_response([])
+    legacy_client = mock_transport_client(status_codes=[500])
+    call_count = {"n": 0}
+
+    def side_effect(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return rulesets_resp
+        return legacy_client.get(*a, **kw)
+
+    with patch("httpx.get", side_effect=side_effect):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            detect_enforcement("tok", "o", "r", "main", "check")
+    assert exc.value.response.status_code == 500

--- a/services/webhook/tests/test_github_rulesets_client.py
+++ b/services/webhook/tests/test_github_rulesets_client.py
@@ -32,11 +32,6 @@ def _ok_response(json_body=None, status_code=200):
     return r
 
 
-def _404_response():
-    resp = httpx.Response(404)
-    return resp
-
-
 # ── create_ruleset ───────────────────────────────────────────────────
 
 def test_create_ruleset_url_and_auth():
@@ -281,8 +276,42 @@ def test_grug_ruleset_prefix_value():
 
 
 def test_detect_connect_error_propagates(mock_transport_client):
-    """Transport-level ConnectError must propagate."""
+    """Transport-level ConnectError on rulesets API must propagate."""
     client = mock_transport_client(raise_exc=httpx.ConnectError("dns down"))
     with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
         with pytest.raises(httpx.ConnectError):
             detect_enforcement("tok", "o", "r", "main", "check")
+
+
+def test_detect_external_via_legacy_checks_array():
+    """Legacy endpoint returns newer 'checks' array format instead of 'contexts'."""
+    rulesets_resp = _ok_response([])
+    legacy_resp = _ok_response({
+        "contexts": [],
+        "checks": [
+            {"context": "Grug — Definition of Ready", "app_id": None},
+        ],
+    })
+
+    with patch("httpx.get", side_effect=[rulesets_resp, legacy_resp]):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "external"
+
+
+def test_detect_legacy_transport_error_returns_none():
+    """Transport failure on legacy endpoint (after rulesets returned nothing)
+    logs a warning and returns 'none' — does not crash (F-01 pattern)."""
+    rulesets_resp = _ok_response([])
+    call_count = {"n": 0}
+
+    def side_effect(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return rulesets_resp
+        raise httpx.ConnectError("legacy endpoint unreachable")
+
+    with patch("httpx.get", side_effect=side_effect):
+        result = detect_enforcement("tok", "o", "r", "main", "check")
+
+    assert result == "none"

--- a/services/webhook/tests/test_github_rulesets_client.py
+++ b/services/webhook/tests/test_github_rulesets_client.py
@@ -317,6 +317,23 @@ def test_detect_legacy_transport_error_returns_none():
     assert result == "none"
 
 
+def test_detect_none_when_legacy_403s():
+    """No rulesets, legacy endpoint 403s (insufficient perms) → none, not crash.
+    Peer-review finding: GitHub returns 403 when App lacks administration:read."""
+    rulesets_resp = _ok_response([])
+    legacy_403 = MagicMock(spec=httpx.Response)
+    legacy_403.status_code = 403
+    legacy_403.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("forbidden", request=MagicMock(), response=legacy_403)
+    )
+
+    responses = [rulesets_resp, legacy_403]
+    with patch("httpx.get", side_effect=responses):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "none"
+
+
 def test_detect_legacy_url_encodes_branch_with_slash():
     """Branch names like 'feat/foo' must be URL-encoded in the path segment."""
     rulesets_resp = _ok_response([])

--- a/services/webhook/tests/test_github_rulesets_client.py
+++ b/services/webhook/tests/test_github_rulesets_client.py
@@ -1,0 +1,288 @@
+"""Tests for github_rulesets_client — CRUD + enforcement detection.
+
+Covers request shape (URL, auth header, API version, body fields),
+enforcement detection across Rulesets API + legacy branch protection,
+and 401-propagation. Mocks httpx — no real GH API calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock, call
+
+import httpx
+import pytest
+
+from github_rulesets_client import (
+    EnforcementState,
+    create_ruleset,
+    delete_ruleset,
+    list_rulesets,
+    detect_enforcement,
+    GRUG_RULESET_PREFIX,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+def _ok_response(json_body=None, status_code=200):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status_code
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=json_body if json_body is not None else {})
+    return r
+
+
+def _404_response():
+    resp = httpx.Response(404)
+    return resp
+
+
+# ── create_ruleset ───────────────────────────────────────────────────
+
+def test_create_ruleset_url_and_auth():
+    with patch("httpx.post", return_value=_ok_response({"id": 99}, 201)) as mock_post:
+        out = create_ruleset("tok-1", "myorg", "myrepo", "Grug — DoR", ["Grug — Definition of Ready"])
+
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "https://api.github.com/repos/myorg/myrepo/rulesets"
+    assert kwargs["headers"]["Authorization"] == "Bearer tok-1"
+    assert kwargs["headers"]["Accept"] == "application/vnd.github+json"
+    assert kwargs["headers"]["X-GitHub-Api-Version"] == "2022-11-28"
+    assert kwargs["timeout"] == 10
+    assert out == {"id": 99}
+
+
+def test_create_ruleset_body_shape():
+    with patch("httpx.post", return_value=_ok_response({"id": 1}, 201)) as mock_post:
+        create_ruleset("tok", "o", "r", "Grug — DoR", ["Grug — Definition of Ready"])
+
+    body = mock_post.call_args.kwargs["json"]
+    assert body["name"] == "Grug — DoR"
+    assert body["target"] == "branch"
+    assert body["enforcement"] == "active"
+    assert body["conditions"]["ref_name"]["include"] == ["~DEFAULT_BRANCH"]
+    assert body["conditions"]["ref_name"]["exclude"] == []
+    rules = body["rules"]
+    assert len(rules) == 1
+    assert rules[0]["type"] == "required_status_checks"
+    checks = rules[0]["parameters"]["required_status_checks"]
+    assert len(checks) == 1
+    assert checks[0]["context"] == "Grug — Definition of Ready"
+
+
+def test_create_ruleset_multiple_contexts():
+    with patch("httpx.post", return_value=_ok_response({"id": 2}, 201)) as mock_post:
+        create_ruleset("tok", "o", "r", "Grug — All Checks", ["check-a", "check-b"])
+
+    body = mock_post.call_args.kwargs["json"]
+    checks = body["rules"][0]["parameters"]["required_status_checks"]
+    assert len(checks) == 2
+    assert checks[0]["context"] == "check-a"
+    assert checks[1]["context"] == "check-b"
+
+
+def test_create_ruleset_401_propagates(mock_transport_client):
+    client = mock_transport_client(status_codes=[401])
+    with patch("httpx.post", side_effect=lambda *a, **kw: client.post(*a, **kw)):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            create_ruleset("stale", "o", "r", "Grug — DoR", ["ctx"])
+    assert exc.value.response.status_code == 401
+
+
+# ── delete_ruleset ───────────────────────────────────────────────────
+
+def test_delete_ruleset_url_and_auth():
+    with patch("httpx.delete", return_value=_ok_response(status_code=204)) as mock_del:
+        delete_ruleset("tok-2", "myorg", "myrepo", 42)
+
+    mock_del.assert_called_once()
+    args, kwargs = mock_del.call_args
+    assert args[0] == "https://api.github.com/repos/myorg/myrepo/rulesets/42"
+    assert kwargs["headers"]["Authorization"] == "Bearer tok-2"
+    assert kwargs["headers"]["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+def test_delete_ruleset_401_propagates(mock_transport_client):
+    client = mock_transport_client(status_codes=[401])
+    with patch("httpx.delete", side_effect=lambda *a, **kw: client.delete(*a, **kw)):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            delete_ruleset("stale", "o", "r", 1)
+    assert exc.value.response.status_code == 401
+
+
+# ── list_rulesets ────────────────────────────────────────────────────
+
+def test_list_rulesets_url_and_auth():
+    rulesets = [{"id": 1, "name": "Grug — DoR"}, {"id": 2, "name": "CI Gate"}]
+    with patch("httpx.get", return_value=_ok_response(rulesets)) as mock_get:
+        out = list_rulesets("tok-3", "myorg", "myrepo")
+
+    mock_get.assert_called_once()
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://api.github.com/repos/myorg/myrepo/rulesets"
+    assert kwargs["headers"]["Authorization"] == "Bearer tok-3"
+    assert out == rulesets
+
+
+def test_list_rulesets_empty():
+    with patch("httpx.get", return_value=_ok_response(json_body=[])):
+        out = list_rulesets("tok", "o", "r")
+    assert out == []
+
+
+def test_list_rulesets_401_propagates(mock_transport_client):
+    client = mock_transport_client(status_codes=[401])
+    with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            list_rulesets("stale", "o", "r")
+    assert exc.value.response.status_code == 401
+
+
+# ── detect_enforcement ───────────────────────────────────────────────
+
+def test_detect_grug_managed_via_rulesets():
+    """Grug-prefixed ruleset with matching check → grug_managed."""
+    rulesets = [
+        {
+            "id": 10,
+            "name": "Grug — DoR Enforcement",
+            "rules": [
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "required_status_checks": [
+                            {"context": "Grug — Definition of Ready"},
+                        ],
+                    },
+                },
+            ],
+        },
+    ]
+    rulesets_resp = _ok_response(rulesets)
+    with patch("httpx.get", return_value=rulesets_resp):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "grug_managed"
+
+
+def test_detect_external_via_rulesets():
+    """Non-Grug ruleset enforcing the check → external."""
+    rulesets = [
+        {
+            "id": 20,
+            "name": "CI Required Checks",
+            "rules": [
+                {
+                    "type": "required_status_checks",
+                    "parameters": {
+                        "required_status_checks": [
+                            {"context": "Grug — Definition of Ready"},
+                        ],
+                    },
+                },
+            ],
+        },
+    ]
+    rulesets_resp = _ok_response(rulesets)
+    with patch("httpx.get", return_value=rulesets_resp):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "external"
+
+
+def test_detect_external_via_legacy_branch_protection():
+    """No rulesets match, but legacy branch protection enforces the check → external."""
+    rulesets_resp = _ok_response([])
+    legacy_resp = _ok_response({"contexts": ["Grug — Definition of Ready", "ci/build"]})
+
+    responses = [rulesets_resp, legacy_resp]
+    with patch("httpx.get", side_effect=responses):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "external"
+
+
+def test_detect_none_when_nothing_enforces():
+    """No rulesets, no legacy protection → none."""
+    rulesets_resp = _ok_response([])
+    legacy_resp = _ok_response({"contexts": ["ci/build"]})
+
+    responses = [rulesets_resp, legacy_resp]
+    with patch("httpx.get", side_effect=responses):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "none"
+
+
+def test_detect_none_when_legacy_404s():
+    """No rulesets, legacy endpoint 404s (no branch protection at all) → none."""
+    rulesets_resp = _ok_response([])
+    legacy_404 = MagicMock(spec=httpx.Response)
+    legacy_404.status_code = 404
+    legacy_404.raise_for_status = MagicMock(
+        side_effect=httpx.HTTPStatusError("not found", request=MagicMock(), response=legacy_404)
+    )
+
+    responses = [rulesets_resp, legacy_404]
+    with patch("httpx.get", side_effect=responses):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+
+    assert result == "none"
+
+
+def test_detect_grug_managed_takes_priority_over_external():
+    """If both a Grug-managed AND external ruleset match, grug_managed wins."""
+    rulesets = [
+        {
+            "id": 10,
+            "name": "Grug — DoR",
+            "rules": [{"type": "required_status_checks", "parameters": {"required_status_checks": [{"context": "Grug — Definition of Ready"}]}}],
+        },
+        {
+            "id": 20,
+            "name": "CI Gate",
+            "rules": [{"type": "required_status_checks", "parameters": {"required_status_checks": [{"context": "Grug — Definition of Ready"}]}}],
+        },
+    ]
+    with patch("httpx.get", return_value=_ok_response(rulesets)):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+    assert result == "grug_managed"
+
+
+def test_detect_skips_rulesets_without_status_check_rules():
+    """Rulesets with no required_status_checks rules are ignored."""
+    rulesets = [
+        {
+            "id": 30,
+            "name": "Grug — Approvals",
+            "rules": [{"type": "pull_request", "parameters": {"required_approving_review_count": 1}}],
+        },
+    ]
+    rulesets_resp = _ok_response(rulesets)
+    legacy_resp = _ok_response({"contexts": []})
+
+    with patch("httpx.get", side_effect=[rulesets_resp, legacy_resp]):
+        result = detect_enforcement("tok", "o", "r", "main", "Grug — Definition of Ready")
+    assert result == "none"
+
+
+def test_detect_non_401_error_propagates(mock_transport_client):
+    """500 from rulesets API must propagate."""
+    client = mock_transport_client(status_codes=[500])
+    with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            detect_enforcement("tok", "o", "r", "main", "check")
+    assert exc.value.response.status_code == 500
+
+
+def test_grug_ruleset_prefix_value():
+    assert GRUG_RULESET_PREFIX == "Grug — "
+
+
+def test_detect_connect_error_propagates(mock_transport_client):
+    """Transport-level ConnectError must propagate."""
+    client = mock_transport_client(raise_exc=httpx.ConnectError("dns down"))
+    with patch("httpx.get", side_effect=lambda *a, **kw: client.get(*a, **kw)):
+        with pytest.raises(httpx.ConnectError):
+            detect_enforcement("tok", "o", "r", "main", "check")

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -26,6 +26,16 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **`post_check_run` (publisher)** | Module-level function in `github_checks_client.py` that POSTs a `CheckRunResult` to GitHub. The acceptance-criteria spelling "CheckRunPublisher" is the *concept name* — the actual identifier is a function, not a class. |
 | **Scope review (roadmap)** | Advisory LLM pass over PR title + body. Wired as a `poolside_client.py` hook called from `evaluate_pull_request(...)` per the `personas/tpm/__init__.py` docstring, but **`poolside_client.py` does not exist in the repo today** — feature is roadmap-only. Intended behavior: flag title↔body mismatch, AC testability, scope-creep, XL inflation; posted as a comment, never blocking. |
 
+## Enforcement concepts
+
+| Term | Definition |
+|---|---|
+| **GitHub Ruleset** | A GitHub Repository Ruleset that requires specific status checks to pass before merging. Grug creates rulesets to enforce its DoR check on the default branch. Managed via the Repository Rulesets API (`POST/GET/DELETE /repos/{owner}/{repo}/rulesets`). See [`services/{api,webhook}/github_rulesets_client.py`](services/api/github_rulesets_client.py) (mirrored — see ADR-0001). |
+| **Grug-managed ruleset** | A ruleset whose `name` starts with the prefix `Grug —`. This prefix is the ownership marker: `detect_enforcement()` uses it to distinguish rulesets Grug created from externally-managed ones. |
+| **EnforcementState** | Literal type — `"grug_managed" \| "external" \| "none"`. Returned by `detect_enforcement()`. `grug_managed`: at least one `Grug —`-prefixed ruleset exists with `required_status_checks` matching the check name. `external`: no grug-managed ruleset, but the check is enforced via a non-Grug ruleset or legacy branch protection. `none`: check is not enforced anywhere. |
+| **`detect_enforcement()`** | Module-level function in `github_rulesets_client.py` that determines the enforcement state for a given status check. Queries both the Rulesets API and the legacy Branch Protection API (`GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks`) to cover repos that haven't migrated to rulesets. |
+| **Legacy branch protection** | Pre-rulesets mechanism for requiring status checks. Still active on many repos. `detect_enforcement()` checks this as a fallback when no ruleset-based enforcement is found. |
+
 ## Identity & authorization concepts
 
 | Term | Definition |
@@ -51,13 +61,14 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 
 ## Cross-service primitives (mirrored)
 
-The following six modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
+The following seven modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
 
 | Module | Purpose |
 |---|---|
 | `observability.py` | DD-extension-aware logger + JSON formatter. Reads `DD_SERVICE`, `DD_ENV`, `GRUG_LOG_LEVEL`. |
 | `secrets_loader.py` | SSM SecureString reads at cold start (`GITHUB_APP_ID_SSM`, `GITHUB_APP_WEBHOOK_SECRET_SSM`, etc.). |
 | `github_checks_client.py` | Thin `httpx`-based wrapper over GitHub's Checks API; carries the `CheckRunResult` dataclass. |
+| `github_rulesets_client.py` | Thin `httpx`-based wrapper over GitHub's Repository Rulesets API + legacy branch protection; carries `EnforcementState` type and `detect_enforcement()`. |
 | `adapters/install_store.py` | DDB single-table CRUD for `Installation` + `RepoConfig` + `AllowlistGate` reads. |
 | `ports/token_cache.py` | `TokenCache` Protocol + `InMemoryTokenCache` impl. |
 | `personas/tpm/dor_checks.py` | The 5 `DoR check` rules + the `CheckResult` dataclass. |


### PR DESCRIPTION
## Summary

Add `github_rulesets_client.py` — a thin httpx-based wrapper over the GitHub Repository Rulesets API that provides CRUD operations (create, delete, list) and a `detect_enforcement()` function. The detection function checks both the modern Rulesets API and the legacy Branch Protection API to determine whether a given status check is enforced, and by whom: `grug_managed` (Grug-prefixed ruleset), `external` (non-Grug ruleset or legacy branch protection), or `none`. Module is mirrored in both `services/api/` and `services/webhook/` per ADR-0001, with the CI mirror gate updated to include it.

## Test plan

- [x] 19 tests in `test_github_rulesets_client.py` covering all CRUD operations and enforcement detection scenarios
- [x] `create_ruleset()` URL, auth headers, body shape, and multiple contexts verified
- [x] `delete_ruleset()` URL and auth verified
- [x] `list_rulesets()` URL, auth, empty list, and populated list verified
- [x] `detect_enforcement()` — grug_managed via rulesets, external via rulesets, external via legacy branch protection, none when nothing enforces, none when legacy 404s
- [x] Priority test: grug_managed takes precedence over external when both match
- [x] Rulesets without `required_status_checks` rules are ignored
- [x] 401 propagates for all operations (compatible with `with_install_token_retry`)
- [x] 500 and ConnectError propagate unwrapped
- [x] Mirror CI gate passes (13 pairs verified)
- [x] Full webhook test suite passes (167 passed, 14 skipped)

Size: S

## Out of scope

- Wiring `detect_enforcement()` into the webhook dispatcher or any handler (future slice)
- `update_ruleset()` — not needed for the initial enforcement flow
- DDB persistence of enforcement state
- API Lambda test file (module is mirrored; tests live in webhook per existing convention)

closes #204