### PR TITLE
feat: enforcement lifecycle — create/delete ruleset on persona toggle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,6 +35,10 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **EnforcementState** | Literal type — `"grug_managed" \| "external" \| "none"`. Returned by `detect_enforcement()`. `grug_managed`: at least one `Grug —`-prefixed ruleset exists with `required_status_checks` matching the check name. `external`: no grug-managed ruleset, but the check is enforced via a non-Grug ruleset or legacy branch protection. `none`: check is not enforced anywhere. |
 | **`detect_enforcement()`** | Module-level function in `github_rulesets_client.py` that determines the enforcement state for a given status check. Queries both the Rulesets API and the legacy Branch Protection API (`GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks`) to cover repos that haven't migrated to rulesets. |
 | **Legacy branch protection** | Pre-rulesets mechanism for requiring status checks. Still active on many repos. `detect_enforcement()` checks this as a fallback when no ruleset-based enforcement is found. |
+| **`enforcement.py`** | Mirrored module containing enforcement lifecycle functions. `ensure_enforcement()` detects current state and creates a Grug-managed ruleset if none exists; `remove_enforcement()` deletes it. Both persist the `enforcement_ruleset_id` on the `RepoConfig` DDB row. See [`services/{api,webhook}/enforcement.py`](services/api/enforcement.py). |
+| **`ensure_enforcement()`** | Idempotent function: detect → skip if `grug_managed` or `external` → create ruleset → store `enforcement_ruleset_id`. Called on installation created (webhook) and persona enable (API toggle). |
+| **`remove_enforcement()`** | Deletes the Grug-managed ruleset by ID (read from `RepoConfig`) and clears the stored `enforcement_ruleset_id`. Called on persona disable (API toggle). |
+| **`enforcement_ruleset_id`** | Optional integer field on `RepoConfig` DDB row. Stores the GitHub ruleset ID of the Grug-managed enforcement ruleset for quick lookup during delete. `None` means no Grug-managed ruleset exists. |
 
 ## Identity & authorization concepts
 
@@ -43,7 +47,7 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **UserIdentity** | The GitHub user behind a session. Identifier: `github_user_id` (integer, stable across login renames). Definitions in `services/api/adapters/user_store.py`. |
 | **UserWithTokens** | `UserIdentity` plus an attached `oauth_*_blob` (KMS-envelope-encrypted access + refresh tokens). Used only by the api Lambda — webhook never needs it. |
 | **Installation** | A `Grug` install on one GitHub account or organization. Identified by `install_id` (GitHub-issued integer). Carries metadata: `account_login`, `account_type` (User/Organization), `installed_at`, `installed_by_user_id`. |
-| **RepoConfig** | Per-repo settings stored under an `Installation`. Today the schema has exactly one field: `tpm_enabled: bool` (default `True`). Storage shape in [`services/{api,webhook}/adapters/install_store.py`](services/api/adapters/install_store.py). When more personas ship, the field set grows (e.g. `code_reviewer_enabled`); the `_DEFAULT_PERSONA_CONFIG` dict is the source of truth. |
+| **RepoConfig** | Per-repo settings stored under an `Installation`. Fields: `tpm_enabled: bool` (default `True`) and `enforcement_ruleset_id: int \| None` (GitHub ruleset ID managed by Grug, default `None`). Storage shape in [`services/{api,webhook}/adapters/install_store.py`](services/api/adapters/install_store.py). When more personas ship, the field set grows (e.g. `code_reviewer_enabled`); the `_DEFAULT_PERSONA_CONFIG` dict is the source of truth. |
 | **AllowlistGate** | Defense-in-depth check: webhook handler refuses to act on any `Installation` whose `installed_by_user_id` is not in the `allowlist` set on the user's DDB row. Independent of GitHub App's public/private listing. Bypass guard for the hosted SaaS while ramp is closed. |
 | **AppJWT** | RSA-signed JWT identifying Grug as a GitHub App (10-min TTL). Generated from the App private key (loaded from SSM SecureString `/grug/github-app-private-key`). Used to exchange for installation tokens. |
 | **InstallToken** | Short-lived (~1h TTL) token returned by `POST /app/installations/{id}/access_tokens`. Lets Grug act on behalf of the installation against the GitHub API. Cached per-`Installation` in `TokenCache`. |
@@ -61,7 +65,7 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 
 ## Cross-service primitives (mirrored)
 
-The following seven modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
+The following eight modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
 
 | Module | Purpose |
 |---|---|
@@ -69,6 +73,7 @@ The following seven modules exist as byte-identical copies under both `services/
 | `secrets_loader.py` | SSM SecureString reads at cold start (`GITHUB_APP_ID_SSM`, `GITHUB_APP_WEBHOOK_SECRET_SSM`, etc.). |
 | `github_checks_client.py` | Thin `httpx`-based wrapper over GitHub's Checks API; carries the `CheckRunResult` dataclass. |
 | `github_rulesets_client.py` | Thin `httpx`-based wrapper over GitHub's Repository Rulesets API + legacy branch protection; carries `EnforcementState` type and `detect_enforcement()`. |
+| `enforcement.py` | Enforcement lifecycle — `ensure_enforcement()` and `remove_enforcement()` wired from dispatcher + API. |
 | `adapters/install_store.py` | DDB single-table CRUD for `Installation` + `RepoConfig` + `AllowlistGate` reads. |
 | `ports/token_cache.py` | `TokenCache` Protocol + `InMemoryTokenCache` impl. |
 | `personas/tpm/dor_checks.py` | The 5 `DoR check` rules + the `CheckResult` dataclass. |

--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -29,6 +29,7 @@ cd "$(dirname "$0")/.."
 
 MIRRORED_WITH_HEADER=(
   "adapters/install_store.py"
+  "enforcement.py"
   "github_checks_client.py"
   "github_rulesets_client.py"
   "observability.py"

--- a/services/api/adapters/install_store.py
+++ b/services/api/adapters/install_store.py
@@ -224,6 +224,35 @@ def set_repo_config(
     return {"tpm_enabled": item["tpm_enabled"]}
 
 
+def get_enforcement_id(install_id: int, repo_id: int) -> int | None:
+    """Return the stored Grug-managed ruleset ID, or None."""
+    resp = _table.get_item(
+        Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+    )
+    item = resp.get("Item")
+    if not item:
+        return None
+    val = item.get("enforcement_ruleset_id")
+    return int(val) if val is not None else None
+
+
+def set_enforcement_id(
+    install_id: int, repo_id: int, ruleset_id: int | None,
+) -> None:
+    """Update only the enforcement_ruleset_id field on a RepoConfig row."""
+    if ruleset_id is not None:
+        _table.update_item(
+            Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+            UpdateExpression="SET enforcement_ruleset_id = :rid",
+            ExpressionAttributeValues={":rid": ruleset_id},
+        )
+    else:
+        _table.update_item(
+            Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+            UpdateExpression="REMOVE enforcement_ruleset_id",
+        )
+
+
 def is_persona_enabled(install_id: int, repo_id: int, persona: str) -> bool:
     """Webhook-style check: is `persona` enabled for this repo?
 

--- a/services/api/adapters/install_store.py
+++ b/services/api/adapters/install_store.py
@@ -210,18 +210,26 @@ def set_repo_config(
     tpm_enabled: bool,
     updated_by_user_id: str,
 ) -> dict[str, Any]:
-    """Upsert per-repo override. Returns the resolved config."""
+    """Upsert per-repo override. Returns the resolved config.
+
+    Uses update_item (not put_item) to preserve fields managed by
+    other writers — e.g. enforcement_ruleset_id set by enforcement.py.
+    """
     now = datetime.now(timezone.utc).isoformat()
-    item = {
-        "PK": _inst_pk(install_id),
-        "SK": _repo_sk(repo_id),
-        "repo_full_name": repo_full_name,
-        "tpm_enabled": bool(tpm_enabled),
-        "updated_at": now,
-        "updated_by_user_id": str(updated_by_user_id),
-    }
-    _table.put_item(Item=item)
-    return {"tpm_enabled": item["tpm_enabled"]}
+    _table.update_item(
+        Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+        UpdateExpression=(
+            "SET repo_full_name = :fn, tpm_enabled = :te,"
+            " updated_at = :ua, updated_by_user_id = :ub"
+        ),
+        ExpressionAttributeValues={
+            ":fn": repo_full_name,
+            ":te": bool(tpm_enabled),
+            ":ua": now,
+            ":ub": str(updated_by_user_id),
+        },
+    )
+    return {"tpm_enabled": bool(tpm_enabled)}
 
 
 def get_enforcement_id(install_id: int, repo_id: int) -> int | None:

--- a/services/api/enforcement.py
+++ b/services/api/enforcement.py
@@ -1,0 +1,116 @@
+# MIRRORED — sibling at services/webhook/enforcement.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Enforcement lifecycle — create/delete Grug-managed rulesets.
+
+Called from dispatcher.py (on installation) and installations.py (on
+persona toggle). Functions take install_token directly — callers wrap
+with with_install_token_retry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from github_rulesets_client import (
+    EnforcementState,
+    GRUG_RULESET_PREFIX,
+    create_ruleset,
+    delete_ruleset,
+    detect_enforcement,
+    list_rulesets,
+)
+
+log = logging.getLogger("grug.enforcement")
+
+GRUG_TPM_RULESET_NAME = "Grug — TPM Enforcement"
+GRUG_DOR_CHECK_NAME = "Grug — Definition of Ready"
+
+
+def ensure_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    default_branch: str,
+    install_id: int,
+    repo_id: int,
+) -> EnforcementState:
+    """Create a Grug-managed ruleset if no enforcement exists. Idempotent.
+
+    Returns the resulting enforcement state after the operation.
+    """
+    state = detect_enforcement(
+        install_token, owner, repo, default_branch, GRUG_DOR_CHECK_NAME,
+    )
+    if state != "none":
+        log.info(
+            "enforcement_already_present",
+            extra={
+                "owner": owner, "repo": repo,
+                "install_id": install_id, "repo_id": repo_id,
+                "state": state,
+            },
+        )
+        return state
+
+    result = create_ruleset(
+        install_token, owner, repo,
+        GRUG_TPM_RULESET_NAME, [GRUG_DOR_CHECK_NAME],
+    )
+    ruleset_id = result["id"]
+
+    from adapters.install_store import set_enforcement_id  # type: ignore
+    set_enforcement_id(install_id, repo_id, ruleset_id)
+
+    log.info(
+        "enforcement_created",
+        extra={
+            "owner": owner, "repo": repo,
+            "install_id": install_id, "repo_id": repo_id,
+            "ruleset_id": ruleset_id,
+        },
+    )
+    return "grug_managed"
+
+
+def remove_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    install_id: int,
+    repo_id: int,
+) -> None:
+    """Delete the Grug-managed ruleset if one exists.
+
+    Reads the stored ruleset_id from DDB first. If not stored, falls
+    back to listing rulesets and finding by name prefix.
+    """
+    from adapters.install_store import get_enforcement_id, set_enforcement_id  # type: ignore
+
+    ruleset_id = get_enforcement_id(install_id, repo_id)
+
+    if ruleset_id is None:
+        rulesets = list_rulesets(install_token, owner, repo)
+        for rs in rulesets:
+            if rs.get("name", "").startswith(GRUG_RULESET_PREFIX):
+                ruleset_id = rs["id"]
+                break
+
+    if ruleset_id is None:
+        log.info(
+            "enforcement_nothing_to_remove",
+            extra={"owner": owner, "repo": repo,
+                   "install_id": install_id, "repo_id": repo_id},
+        )
+        return
+
+    delete_ruleset(install_token, owner, repo, ruleset_id)
+    set_enforcement_id(install_id, repo_id, None)
+
+    log.info(
+        "enforcement_deleted",
+        extra={
+            "owner": owner, "repo": repo,
+            "install_id": install_id, "repo_id": repo_id,
+            "ruleset_id": ruleset_id,
+        },
+    )

--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -227,7 +227,7 @@ def update_repo_config(
     # endpoint that lists ONLY this install's repos) and verify
     # membership.
     # Wrapped in with_install_token_retry — see list_repos above.
-    def _lookup(token: str) -> tuple[bool, str]:
+    def _lookup(token: str) -> tuple[bool, str, str]:
         page = 1
         with httpx.Client(timeout=10) as client:
             while True:

--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -169,6 +169,42 @@ def list_install_repos(
     return {"repos": repos}
 
 
+def _toggle_enforcement(
+    install_id: int, repo_id: int,
+    full_name: str, default_branch: str,
+    *, enable: bool,
+) -> None:
+    """Best-effort enforcement create/delete on persona toggle."""
+    from enforcement import ensure_enforcement, remove_enforcement  # type: ignore
+
+    parts = full_name.split("/", 1)
+    if len(parts) != 2:
+        return
+    owner, repo_name = parts
+    try:
+        if enable:
+            with_install_token_retry(
+                install_id,
+                lambda token: ensure_enforcement(
+                    token, owner, repo_name, default_branch, install_id, repo_id,
+                ),
+            )
+        else:
+            with_install_token_retry(
+                install_id,
+                lambda token: remove_enforcement(
+                    token, owner, repo_name, install_id, repo_id,
+                ),
+            )
+    except Exception:
+        log.warning(
+            "enforcement_toggle_failed",
+            extra={"install_id": install_id, "repo_id": repo_id,
+                   "full_name": full_name, "enable": enable},
+            exc_info=True,
+        )
+
+
 @router.put("/installations/{install_id}/repos/{repo_id}/config")
 def update_repo_config(
     install_id: int,
@@ -217,19 +253,20 @@ def update_repo_config(
                     )
                 for r in body_json["repositories"]:
                     if r["id"] == repo_id:
-                        return True, r["full_name"]
+                        return True, r["full_name"], r.get("default_branch", "main")
                 if len(body_json["repositories"]) < 100:
-                    return False, ""
+                    return False, "", ""
                 page += 1
                 # No page cap — single-repo membership lookup must scan
                 # all pages on large org installs (>1000 repos). Codex
                 # P2 follow-up to the Sentry CRITICAL fix. Worst case
                 # ~Npages*100ms; acceptable for an admin write path.
 
-    found, full_name = with_install_token_retry(install_id, _lookup)
+    found, full_name, default_branch = with_install_token_retry(install_id, _lookup)
     if not found:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="repo not visible to install")
 
+    previous_cfg = get_repo_config(install_id, repo_id)
     cfg = set_repo_config(
         install_id=install_id, repo_id=repo_id,
         repo_full_name=full_name, tpm_enabled=body.tpm_enabled,
@@ -243,4 +280,12 @@ def update_repo_config(
             **cfg,
         },
     )
+
+    was_enabled = previous_cfg.get("tpm_enabled", True)
+    now_enabled = body.tpm_enabled
+    if now_enabled and not was_enabled:
+        _toggle_enforcement(install_id, repo_id, full_name, default_branch, enable=True)
+    elif was_enabled and not now_enabled:
+        _toggle_enforcement(install_id, repo_id, full_name, default_branch, enable=False)
+
     return {"repo_id": repo_id, "full_name": full_name, "config": cfg}

--- a/services/webhook/adapters/install_store.py
+++ b/services/webhook/adapters/install_store.py
@@ -224,6 +224,35 @@ def set_repo_config(
     return {"tpm_enabled": item["tpm_enabled"]}
 
 
+def get_enforcement_id(install_id: int, repo_id: int) -> int | None:
+    """Return the stored Grug-managed ruleset ID, or None."""
+    resp = _table.get_item(
+        Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+    )
+    item = resp.get("Item")
+    if not item:
+        return None
+    val = item.get("enforcement_ruleset_id")
+    return int(val) if val is not None else None
+
+
+def set_enforcement_id(
+    install_id: int, repo_id: int, ruleset_id: int | None,
+) -> None:
+    """Update only the enforcement_ruleset_id field on a RepoConfig row."""
+    if ruleset_id is not None:
+        _table.update_item(
+            Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+            UpdateExpression="SET enforcement_ruleset_id = :rid",
+            ExpressionAttributeValues={":rid": ruleset_id},
+        )
+    else:
+        _table.update_item(
+            Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+            UpdateExpression="REMOVE enforcement_ruleset_id",
+        )
+
+
 def is_persona_enabled(install_id: int, repo_id: int, persona: str) -> bool:
     """Webhook-style check: is `persona` enabled for this repo?
 

--- a/services/webhook/adapters/install_store.py
+++ b/services/webhook/adapters/install_store.py
@@ -210,18 +210,26 @@ def set_repo_config(
     tpm_enabled: bool,
     updated_by_user_id: str,
 ) -> dict[str, Any]:
-    """Upsert per-repo override. Returns the resolved config."""
+    """Upsert per-repo override. Returns the resolved config.
+
+    Uses update_item (not put_item) to preserve fields managed by
+    other writers — e.g. enforcement_ruleset_id set by enforcement.py.
+    """
     now = datetime.now(timezone.utc).isoformat()
-    item = {
-        "PK": _inst_pk(install_id),
-        "SK": _repo_sk(repo_id),
-        "repo_full_name": repo_full_name,
-        "tpm_enabled": bool(tpm_enabled),
-        "updated_at": now,
-        "updated_by_user_id": str(updated_by_user_id),
-    }
-    _table.put_item(Item=item)
-    return {"tpm_enabled": item["tpm_enabled"]}
+    _table.update_item(
+        Key={"PK": _inst_pk(install_id), "SK": _repo_sk(repo_id)},
+        UpdateExpression=(
+            "SET repo_full_name = :fn, tpm_enabled = :te,"
+            " updated_at = :ua, updated_by_user_id = :ub"
+        ),
+        ExpressionAttributeValues={
+            ":fn": repo_full_name,
+            ":te": bool(tpm_enabled),
+            ":ua": now,
+            ":ub": str(updated_by_user_id),
+        },
+    )
+    return {"tpm_enabled": bool(tpm_enabled)}
 
 
 def get_enforcement_id(install_id: int, repo_id: int) -> int | None:

--- a/services/webhook/dispatcher.py
+++ b/services/webhook/dispatcher.py
@@ -66,6 +66,10 @@ def _handle_installation(payload: dict[str, Any]) -> dict[str, str]:
             account_type=account.get("type", "User"),
             installed_by_user_id=int(installed_by),
         )
+
+        if is_install_allowlisted(int(install_id)):
+            _enforce_on_repos(int(install_id), payload.get("repositories") or [])
+
         return {"status": "recorded", "action": action}
 
     if action in {"new_permissions_accepted", "unsuspend"}:
@@ -94,6 +98,34 @@ def _handle_installation(payload: dict[str, Any]) -> dict[str, str]:
         return {"status": "no_op", "reason": f"{action} ack — installer preserved"}
 
     return {"status": "no_op", "reason": f"installation action={action} unhandled"}
+
+
+def _enforce_on_repos(install_id: int, repositories: list[dict]) -> None:
+    """Best-effort enforcement creation for repos in an install payload."""
+    from github_app_auth import with_install_token_retry  # type: ignore
+    from enforcement import ensure_enforcement  # type: ignore
+
+    for repo in repositories:
+        repo_id = repo.get("id")
+        full_name = repo.get("full_name", "")
+        default_branch = repo.get("default_branch", "main")
+        parts = full_name.split("/", 1)
+        if len(parts) != 2 or not repo_id:
+            continue
+        owner, repo_name = parts
+        try:
+            with_install_token_retry(
+                install_id,
+                lambda token, o=owner, r=repo_name, db=default_branch, iid=install_id, rid=int(repo_id): (
+                    ensure_enforcement(token, o, r, db, iid, rid)
+                ),
+            )
+        except Exception:
+            log.warning(
+                "enforcement_create_failed",
+                extra={"install_id": install_id, "repo": full_name},
+                exc_info=True,
+            )
 
 
 def _handle_pull_request(payload: dict[str, Any]) -> dict[str, str]:

--- a/services/webhook/enforcement.py
+++ b/services/webhook/enforcement.py
@@ -1,0 +1,116 @@
+# MIRRORED — sibling at services/api/enforcement.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Enforcement lifecycle — create/delete Grug-managed rulesets.
+
+Called from dispatcher.py (on installation) and installations.py (on
+persona toggle). Functions take install_token directly — callers wrap
+with with_install_token_retry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from github_rulesets_client import (
+    EnforcementState,
+    GRUG_RULESET_PREFIX,
+    create_ruleset,
+    delete_ruleset,
+    detect_enforcement,
+    list_rulesets,
+)
+
+log = logging.getLogger("grug.enforcement")
+
+GRUG_TPM_RULESET_NAME = "Grug — TPM Enforcement"
+GRUG_DOR_CHECK_NAME = "Grug — Definition of Ready"
+
+
+def ensure_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    default_branch: str,
+    install_id: int,
+    repo_id: int,
+) -> EnforcementState:
+    """Create a Grug-managed ruleset if no enforcement exists. Idempotent.
+
+    Returns the resulting enforcement state after the operation.
+    """
+    state = detect_enforcement(
+        install_token, owner, repo, default_branch, GRUG_DOR_CHECK_NAME,
+    )
+    if state != "none":
+        log.info(
+            "enforcement_already_present",
+            extra={
+                "owner": owner, "repo": repo,
+                "install_id": install_id, "repo_id": repo_id,
+                "state": state,
+            },
+        )
+        return state
+
+    result = create_ruleset(
+        install_token, owner, repo,
+        GRUG_TPM_RULESET_NAME, [GRUG_DOR_CHECK_NAME],
+    )
+    ruleset_id = result["id"]
+
+    from adapters.install_store import set_enforcement_id  # type: ignore
+    set_enforcement_id(install_id, repo_id, ruleset_id)
+
+    log.info(
+        "enforcement_created",
+        extra={
+            "owner": owner, "repo": repo,
+            "install_id": install_id, "repo_id": repo_id,
+            "ruleset_id": ruleset_id,
+        },
+    )
+    return "grug_managed"
+
+
+def remove_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    install_id: int,
+    repo_id: int,
+) -> None:
+    """Delete the Grug-managed ruleset if one exists.
+
+    Reads the stored ruleset_id from DDB first. If not stored, falls
+    back to listing rulesets and finding by name prefix.
+    """
+    from adapters.install_store import get_enforcement_id, set_enforcement_id  # type: ignore
+
+    ruleset_id = get_enforcement_id(install_id, repo_id)
+
+    if ruleset_id is None:
+        rulesets = list_rulesets(install_token, owner, repo)
+        for rs in rulesets:
+            if rs.get("name", "").startswith(GRUG_RULESET_PREFIX):
+                ruleset_id = rs["id"]
+                break
+
+    if ruleset_id is None:
+        log.info(
+            "enforcement_nothing_to_remove",
+            extra={"owner": owner, "repo": repo,
+                   "install_id": install_id, "repo_id": repo_id},
+        )
+        return
+
+    delete_ruleset(install_token, owner, repo, ruleset_id)
+    set_enforcement_id(install_id, repo_id, None)
+
+    log.info(
+        "enforcement_deleted",
+        extra={
+            "owner": owner, "repo": repo,
+            "install_id": install_id, "repo_id": repo_id,
+            "ruleset_id": ruleset_id,
+        },
+    )

--- a/services/webhook/tests/test_enforcement.py
+++ b/services/webhook/tests/test_enforcement.py
@@ -1,0 +1,160 @@
+"""Tests for enforcement lifecycle — ensure/remove enforcement.
+
+Covers the enable → create → disable → delete lifecycle, idempotent
+skip on existing enforcement, DDB persistence of ruleset_id, and
+best-effort error handling.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock, call
+
+import httpx
+import pytest
+
+from enforcement import (
+    ensure_enforcement,
+    remove_enforcement,
+    GRUG_TPM_RULESET_NAME,
+    GRUG_DOR_CHECK_NAME,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+def _ok_response(json_body=None, status_code=200):
+    r = MagicMock(spec=httpx.Response)
+    r.status_code = status_code
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=json_body if json_body is not None else {})
+    return r
+
+
+# ── ensure_enforcement ───────────────────────────────────────────────
+
+def test_ensure_creates_ruleset_when_none():
+    """No enforcement → create ruleset + store ID in DDB."""
+    rulesets_resp = _ok_response([])
+    legacy_resp = _ok_response({"contexts": []})
+    create_resp = _ok_response({"id": 42}, 201)
+
+    with patch("enforcement.detect_enforcement", return_value="none") as mock_detect, \
+         patch("enforcement.create_ruleset", return_value={"id": 42}) as mock_create, \
+         patch("adapters.install_store.set_enforcement_id") as mock_set:
+        result = ensure_enforcement("tok", "myorg", "myrepo", "main", 100, 200)
+
+    assert result == "grug_managed"
+    mock_detect.assert_called_once_with("tok", "myorg", "myrepo", "main", GRUG_DOR_CHECK_NAME)
+    mock_create.assert_called_once_with(
+        "tok", "myorg", "myrepo", GRUG_TPM_RULESET_NAME, [GRUG_DOR_CHECK_NAME],
+    )
+    mock_set.assert_called_once_with(100, 200, 42)
+
+
+def test_ensure_skips_when_grug_managed():
+    """Already grug_managed → no-op."""
+    with patch("enforcement.detect_enforcement", return_value="grug_managed"), \
+         patch("enforcement.create_ruleset") as mock_create:
+        result = ensure_enforcement("tok", "o", "r", "main", 1, 2)
+
+    assert result == "grug_managed"
+    mock_create.assert_not_called()
+
+
+def test_ensure_skips_when_external():
+    """External enforcement → no-op (don't duplicate)."""
+    with patch("enforcement.detect_enforcement", return_value="external"), \
+         patch("enforcement.create_ruleset") as mock_create:
+        result = ensure_enforcement("tok", "o", "r", "main", 1, 2)
+
+    assert result == "external"
+    mock_create.assert_not_called()
+
+
+def test_ensure_stores_ruleset_id_from_create_response():
+    """Ruleset ID from GitHub's create response is persisted in DDB."""
+    with patch("enforcement.detect_enforcement", return_value="none"), \
+         patch("enforcement.create_ruleset", return_value={"id": 777}), \
+         patch("adapters.install_store.set_enforcement_id") as mock_set:
+        ensure_enforcement("tok", "o", "r", "main", 10, 20)
+
+    mock_set.assert_called_once_with(10, 20, 777)
+
+
+# ── remove_enforcement ───────────────────────────────────────────────
+
+def test_remove_deletes_by_stored_id():
+    """Stored ruleset_id → delete directly, clear DDB."""
+    with patch("adapters.install_store.get_enforcement_id", return_value=42), \
+         patch("enforcement.delete_ruleset") as mock_del, \
+         patch("adapters.install_store.set_enforcement_id") as mock_set:
+        remove_enforcement("tok", "myorg", "myrepo", 100, 200)
+
+    mock_del.assert_called_once_with("tok", "myorg", "myrepo", 42)
+    mock_set.assert_called_once_with(100, 200, None)
+
+
+def test_remove_falls_back_to_list_when_no_stored_id():
+    """No stored ID → list rulesets, find by prefix, delete."""
+    rulesets = [
+        {"id": 99, "name": "Grug — TPM Enforcement"},
+        {"id": 50, "name": "CI Required"},
+    ]
+    with patch("adapters.install_store.get_enforcement_id", return_value=None), \
+         patch("enforcement.list_rulesets", return_value=rulesets), \
+         patch("enforcement.delete_ruleset") as mock_del, \
+         patch("adapters.install_store.set_enforcement_id") as mock_set:
+        remove_enforcement("tok", "o", "r", 1, 2)
+
+    mock_del.assert_called_once_with("tok", "o", "r", 99)
+    mock_set.assert_called_once_with(1, 2, None)
+
+
+def test_remove_noop_when_nothing_exists():
+    """No stored ID, no Grug-prefixed rulesets → nothing to do."""
+    with patch("adapters.install_store.get_enforcement_id", return_value=None), \
+         patch("enforcement.list_rulesets", return_value=[{"id": 1, "name": "CI"}]), \
+         patch("enforcement.delete_ruleset") as mock_del:
+        remove_enforcement("tok", "o", "r", 1, 2)
+
+    mock_del.assert_not_called()
+
+
+def test_remove_noop_when_list_empty():
+    """No stored ID, no rulesets at all → nothing to do."""
+    with patch("adapters.install_store.get_enforcement_id", return_value=None), \
+         patch("enforcement.list_rulesets", return_value=[]), \
+         patch("enforcement.delete_ruleset") as mock_del:
+        remove_enforcement("tok", "o", "r", 1, 2)
+
+    mock_del.assert_not_called()
+
+
+# ── lifecycle round-trip ─────────────────────────────────────────────
+
+def test_enable_then_disable_lifecycle():
+    """Full lifecycle: enable creates, disable deletes."""
+    with patch("enforcement.detect_enforcement", return_value="none"), \
+         patch("enforcement.create_ruleset", return_value={"id": 55}), \
+         patch("adapters.install_store.set_enforcement_id") as mock_set:
+        ensure_enforcement("tok", "o", "r", "main", 1, 2)
+
+    mock_set.assert_called_with(1, 2, 55)
+
+    with patch("adapters.install_store.get_enforcement_id", return_value=55), \
+         patch("enforcement.delete_ruleset") as mock_del, \
+         patch("adapters.install_store.set_enforcement_id") as mock_set2:
+        remove_enforcement("tok", "o", "r", 1, 2)
+
+    mock_del.assert_called_once_with("tok", "o", "r", 55)
+    mock_set2.assert_called_once_with(1, 2, None)
+
+
+# ── constants ────────────────────────────────────────────────────────
+
+def test_ruleset_name():
+    assert GRUG_TPM_RULESET_NAME == "Grug — TPM Enforcement"
+
+
+def test_check_name():
+    assert GRUG_DOR_CHECK_NAME == "Grug — Definition of Ready"

--- a/services/webhook/tests/test_enforcement.py
+++ b/services/webhook/tests/test_enforcement.py
@@ -7,10 +7,7 @@ best-effort error handling.
 
 from __future__ import annotations
 
-from unittest.mock import patch, MagicMock, call
-
-import httpx
-import pytest
+from unittest.mock import patch
 
 from enforcement import (
     ensure_enforcement,
@@ -20,24 +17,10 @@ from enforcement import (
 )
 
 
-# ── helpers ──────────────────────────────────────────────────────────
-
-def _ok_response(json_body=None, status_code=200):
-    r = MagicMock(spec=httpx.Response)
-    r.status_code = status_code
-    r.raise_for_status = MagicMock()
-    r.json = MagicMock(return_value=json_body if json_body is not None else {})
-    return r
-
-
 # ── ensure_enforcement ───────────────────────────────────────────────
 
 def test_ensure_creates_ruleset_when_none():
     """No enforcement → create ruleset + store ID in DDB."""
-    rulesets_resp = _ok_response([])
-    legacy_resp = _ok_response({"contexts": []})
-    create_resp = _ok_response({"id": 42}, 201)
-
     with patch("enforcement.detect_enforcement", return_value="none") as mock_detect, \
          patch("enforcement.create_ruleset", return_value={"id": 42}) as mock_create, \
          patch("adapters.install_store.set_enforcement_id") as mock_set:

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -35,6 +35,10 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **EnforcementState** | Literal type — `"grug_managed" \| "external" \| "none"`. Returned by `detect_enforcement()`. `grug_managed`: at least one `Grug —`-prefixed ruleset exists with `required_status_checks` matching the check name. `external`: no grug-managed ruleset, but the check is enforced via a non-Grug ruleset or legacy branch protection. `none`: check is not enforced anywhere. |
 | **`detect_enforcement()`** | Module-level function in `github_rulesets_client.py` that determines the enforcement state for a given status check. Queries both the Rulesets API and the legacy Branch Protection API (`GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks`) to cover repos that haven't migrated to rulesets. |
 | **Legacy branch protection** | Pre-rulesets mechanism for requiring status checks. Still active on many repos. `detect_enforcement()` checks this as a fallback when no ruleset-based enforcement is found. |
+| **`enforcement.py`** | Mirrored module containing enforcement lifecycle functions. `ensure_enforcement()` detects current state and creates a Grug-managed ruleset if none exists; `remove_enforcement()` deletes it. Both persist the `enforcement_ruleset_id` on the `RepoConfig` DDB row. See [`services/{api,webhook}/enforcement.py`](services/api/enforcement.py). |
+| **`ensure_enforcement()`** | Idempotent function: detect → skip if `grug_managed` or `external` → create ruleset → store `enforcement_ruleset_id`. Called on installation created (webhook) and persona enable (API toggle). |
+| **`remove_enforcement()`** | Deletes the Grug-managed ruleset by ID (read from `RepoConfig`) and clears the stored `enforcement_ruleset_id`. Called on persona disable (API toggle). |
+| **`enforcement_ruleset_id`** | Optional integer field on `RepoConfig` DDB row. Stores the GitHub ruleset ID of the Grug-managed enforcement ruleset for quick lookup during delete. `None` means no Grug-managed ruleset exists. |
 
 ## Identity & authorization concepts
 
@@ -43,7 +47,7 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **UserIdentity** | The GitHub user behind a session. Identifier: `github_user_id` (integer, stable across login renames). Definitions in `services/api/adapters/user_store.py`. |
 | **UserWithTokens** | `UserIdentity` plus an attached `oauth_*_blob` (KMS-envelope-encrypted access + refresh tokens). Used only by the api Lambda — webhook never needs it. |
 | **Installation** | A `Grug` install on one GitHub account or organization. Identified by `install_id` (GitHub-issued integer). Carries metadata: `account_login`, `account_type` (User/Organization), `installed_at`, `installed_by_user_id`. |
-| **RepoConfig** | Per-repo settings stored under an `Installation`. Today the schema has exactly one field: `tpm_enabled: bool` (default `True`). Storage shape in [`services/{api,webhook}/adapters/install_store.py`](services/api/adapters/install_store.py). When more personas ship, the field set grows (e.g. `code_reviewer_enabled`); the `_DEFAULT_PERSONA_CONFIG` dict is the source of truth. |
+| **RepoConfig** | Per-repo settings stored under an `Installation`. Fields: `tpm_enabled: bool` (default `True`) and `enforcement_ruleset_id: int \| None` (GitHub ruleset ID managed by Grug, default `None`). Storage shape in [`services/{api,webhook}/adapters/install_store.py`](services/api/adapters/install_store.py). When more personas ship, the field set grows (e.g. `code_reviewer_enabled`); the `_DEFAULT_PERSONA_CONFIG` dict is the source of truth. |
 | **AllowlistGate** | Defense-in-depth check: webhook handler refuses to act on any `Installation` whose `installed_by_user_id` is not in the `allowlist` set on the user's DDB row. Independent of GitHub App's public/private listing. Bypass guard for the hosted SaaS while ramp is closed. |
 | **AppJWT** | RSA-signed JWT identifying Grug as a GitHub App (10-min TTL). Generated from the App private key (loaded from SSM SecureString `/grug/github-app-private-key`). Used to exchange for installation tokens. |
 | **InstallToken** | Short-lived (~1h TTL) token returned by `POST /app/installations/{id}/access_tokens`. Lets Grug act on behalf of the installation against the GitHub API. Cached per-`Installation` in `TokenCache`. |
@@ -61,7 +65,7 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 
 ## Cross-service primitives (mirrored)
 
-The following seven modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
+The following eight modules exist as byte-identical copies under both `services/api/` and `services/webhook/`. See [ADR-0001](docs/adr/0001-mirror-with-rule-of-three-deferral.md) for the load-bearing reasoning.
 
 | Module | Purpose |
 |---|---|
@@ -69,6 +73,7 @@ The following seven modules exist as byte-identical copies under both `services/
 | `secrets_loader.py` | SSM SecureString reads at cold start (`GITHUB_APP_ID_SSM`, `GITHUB_APP_WEBHOOK_SECRET_SSM`, etc.). |
 | `github_checks_client.py` | Thin `httpx`-based wrapper over GitHub's Checks API; carries the `CheckRunResult` dataclass. |
 | `github_rulesets_client.py` | Thin `httpx`-based wrapper over GitHub's Repository Rulesets API + legacy branch protection; carries `EnforcementState` type and `detect_enforcement()`. |
+| `enforcement.py` | Enforcement lifecycle — `ensure_enforcement()` and `remove_enforcement()` wired from dispatcher + API. |
 | `adapters/install_store.py` | DDB single-table CRUD for `Installation` + `RepoConfig` + `AllowlistGate` reads. |
 | `ports/token_cache.py` | `TokenCache` Protocol + `InMemoryTokenCache` impl. |
 | `personas/tpm/dor_checks.py` | The 5 `DoR check` rules + the `CheckResult` dataclass. |


### PR DESCRIPTION
## Summary

Add the enforcement lifecycle module (`enforcement.py`, mirrored per ADR-0001) that automatically creates a GitHub Repository Ruleset when the TPM persona is enabled and deletes it when disabled. On `installation:created`, the webhook dispatcher creates enforcement for all repos in the payload. On persona toggle via the API dashboard, enforcement is created or removed based on the state change. The DDB `RepoConfig` row gains an `enforcement_ruleset_id` field (via `update_item`) to track the Grug-managed ruleset ID for fast delete. Detection is idempotent — skips creation if grug_managed or external enforcement already exists, and falls back to listing rulesets by name prefix if no stored ID exists on delete.

## Test plan

- [x] 11 tests in `test_enforcement.py` covering the full enable/disable lifecycle
- [x] `ensure_enforcement()` creates ruleset + stores ID when state is "none"
- [x] `ensure_enforcement()` skips when grug_managed (idempotent)
- [x] `ensure_enforcement()` skips when external enforcement exists (no duplicates)
- [x] `remove_enforcement()` deletes by stored ruleset_id + clears DDB
- [x] `remove_enforcement()` falls back to list + prefix match when no stored ID
- [x] `remove_enforcement()` is no-op when nothing to delete
- [x] Full lifecycle round-trip: enable → create → disable → delete
- [x] Mirror CI gate passes (14 pairs verified)
- [x] Full webhook test suite passes (184 passed, 14 skipped)

Size: M

## Out of scope

- Self-healing on manual ruleset delete (issue #208)
- Migration backfill for existing 13 repos (issue #209)
- DD custom metrics for enforcement events (issue #210)
- Dashboard enforcement indicator (issue #207)
- `installation_repositories:added` event handling (additive future slice)

closes #206