### PR TITLE
feat: dashboard enforcement indicator (3-state + fix button)

### DIFF
--- a/services/api/adapters/install_store.py
+++ b/services/api/adapters/install_store.py
@@ -196,9 +196,11 @@ def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
     )
     item = resp.get("Item")
     if not item:
-        return dict(_DEFAULT_PERSONA_CONFIG)
+        return {**_DEFAULT_PERSONA_CONFIG, "enforcement_ruleset_id": None}
+    rid = item.get("enforcement_ruleset_id")
     return {
         "tpm_enabled": bool(item.get("tpm_enabled", _DEFAULT_PERSONA_CONFIG["tpm_enabled"])),
+        "enforcement_ruleset_id": int(rid) if rid is not None else None,
     }
 
 

--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -289,3 +289,81 @@ def update_repo_config(
         _toggle_enforcement(install_id, repo_id, full_name, default_branch, enable=False)
 
     return {"repo_id": repo_id, "full_name": full_name, "config": cfg}
+
+
+@router.get("/installations/{install_id}/repos/{repo_id}/enforcement")
+def get_enforcement(
+    install_id: int,
+    repo_id: int,
+    user: UserIdentity = Depends(require_authenticated),
+) -> dict[str, Any]:
+    """Live enforcement detection — queries GitHub Rulesets + legacy BP."""
+    install = get_installation(install_id)
+    if not install:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="install not found")
+    _ensure_can_access(install, user)
+
+    from github_rulesets_client import detect_enforcement  # type: ignore
+    from enforcement import GRUG_DOR_CHECK_NAME  # type: ignore
+
+    def _detect(token: str) -> dict[str, Any]:
+        repos = _resolve_repo(token, install_id, repo_id)
+        if not repos:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="repo not found")
+        full_name, default_branch = repos
+        owner, repo_name = full_name.split("/", 1)
+        state = detect_enforcement(token, owner, repo_name, default_branch, GRUG_DOR_CHECK_NAME)
+        return {"repo_id": repo_id, "enforcement_state": state}
+
+    return with_install_token_retry(install_id, _detect)
+
+
+@router.post("/installations/{install_id}/repos/{repo_id}/enforcement")
+def fix_enforcement(
+    install_id: int,
+    repo_id: int,
+    user: UserIdentity = Depends(require_authenticated),
+) -> dict[str, Any]:
+    """Create Grug-managed enforcement ruleset (the "Fix" button)."""
+    install = get_installation(install_id)
+    if not install:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="install not found")
+    _ensure_can_access(install, user)
+
+    from enforcement import ensure_enforcement  # type: ignore
+
+    def _fix(token: str) -> dict[str, Any]:
+        repos = _resolve_repo(token, install_id, repo_id)
+        if not repos:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="repo not found")
+        full_name, default_branch = repos
+        owner, repo_name = full_name.split("/", 1)
+        state = ensure_enforcement(token, owner, repo_name, default_branch, install_id, repo_id)
+        return {"repo_id": repo_id, "enforcement_state": state}
+
+    return with_install_token_retry(install_id, _fix)
+
+
+def _resolve_repo(
+    token: str, install_id: int, repo_id: int,
+) -> tuple[str, str] | None:
+    """Find repo full_name + default_branch from the installation's repos."""
+    with httpx.Client(timeout=10) as client:
+        page = 1
+        while True:
+            resp = client.get(
+                f"{_GH_API}/installation/repositories",
+                headers={
+                    "Authorization": f"token {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                params={"per_page": 100, "page": page},
+            )
+            resp.raise_for_status()
+            body = resp.json()
+            for r in body.get("repositories", []):
+                if r["id"] == repo_id:
+                    return r["full_name"], r.get("default_branch", "main")
+            if len(body.get("repositories", [])) < 100:
+                return None
+            page += 1

--- a/services/webhook/adapters/install_store.py
+++ b/services/webhook/adapters/install_store.py
@@ -196,9 +196,11 @@ def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
     )
     item = resp.get("Item")
     if not item:
-        return dict(_DEFAULT_PERSONA_CONFIG)
+        return {**_DEFAULT_PERSONA_CONFIG, "enforcement_ruleset_id": None}
+    rid = item.get("enforcement_ruleset_id")
     return {
         "tpm_enabled": bool(item.get("tpm_enabled", _DEFAULT_PERSONA_CONFIG["tpm_enabled"])),
+        "enforcement_ruleset_id": int(rid) if rid is not None else None,
     }
 
 

--- a/web/src/lib/installations.ts
+++ b/web/src/lib/installations.ts
@@ -10,6 +10,7 @@ export interface Installation {
 
 export interface RepoConfig {
   tpm_enabled: boolean;
+  enforcement_ruleset_id: number | null;
 }
 
 export interface Repo {
@@ -32,6 +33,31 @@ export function useInstallRepos(installId: number | undefined) {
     queryKey: ["installations", installId, "repos"],
     queryFn: () => api(`/api/v1/installations/${installId}/repos`),
     enabled: installId != null,
+  });
+}
+
+export type EnforcementState = "grug_managed" | "external" | "none";
+
+export function useEnforcement(installId: number | undefined, repoId: number | undefined) {
+  return useQuery<{ repo_id: number; enforcement_state: EnforcementState }>({
+    queryKey: ["enforcement", installId, repoId],
+    queryFn: () => api(`/api/v1/installations/${installId}/repos/${repoId}/enforcement`),
+    enabled: installId != null && repoId != null,
+    staleTime: 60_000,
+  });
+}
+
+export function useFixEnforcement(installId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (repoId: number) =>
+      api(`/api/v1/installations/${installId}/repos/${repoId}/enforcement`, {
+        method: "POST",
+      }),
+    onSuccess: (_data, repoId) => {
+      qc.invalidateQueries({ queryKey: ["enforcement", installId, repoId] });
+      qc.invalidateQueries({ queryKey: ["installations", installId, "repos"] });
+    },
   });
 }
 

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -6,6 +6,8 @@ import {
   useInstallRepos,
   useInstallations,
   useSetRepoConfig,
+  useEnforcement,
+  useFixEnforcement,
   type Repo,
 } from "../lib/installations";
 
@@ -105,6 +107,7 @@ export function Dashboard() {
 function RepoPanel({ installId }: { installId: number | null }) {
   const repos = useInstallRepos(installId ?? undefined);
   const setConfig = useSetRepoConfig(installId ?? 0);
+  const fixEnforcement = useFixEnforcement(installId ?? 0);
 
   if (installId == null) {
     return (
@@ -126,10 +129,13 @@ function RepoPanel({ installId }: { installId: number | null }) {
           <RepoRow
             key={r.repo_id}
             repo={r}
+            installId={installId}
             onToggle={(enabled) =>
               setConfig.mutate({ repo_id: r.repo_id, tpm_enabled: enabled })
             }
+            onFix={() => fixEnforcement.mutate(r.repo_id)}
             pending={setConfig.isPending && setConfig.variables?.repo_id === r.repo_id}
+            fixPending={fixEnforcement.isPending && fixEnforcement.variables === r.repo_id}
           />
         ))}
       </div>
@@ -138,15 +144,25 @@ function RepoPanel({ installId }: { installId: number | null }) {
 }
 
 function RepoRow({
-  repo, onToggle, pending,
+  repo, installId, onToggle, onFix, pending, fixPending,
 }: {
   repo: Repo;
+  installId: number;
   onToggle: (enabled: boolean) => void;
+  onFix: () => void;
   pending: boolean;
+  fixPending: boolean;
 }) {
+  const enforcement = useEnforcement(
+    repo.config.tpm_enabled ? installId : undefined,
+    repo.config.tpm_enabled ? repo.repo_id : undefined,
+  );
+  const state = enforcement.data?.enforcement_state;
+  const hasStoredId = repo.config.enforcement_ruleset_id != null;
+
   return (
     <div className="flex items-center justify-between px-4 py-3">
-      <div>
+      <div className="flex items-center gap-3">
         <a
           href={`https://github.com/${repo.full_name}`}
           className="font-mono text-sm text-stone-200 hover:text-amber-400"
@@ -154,19 +170,74 @@ function RepoRow({
           {repo.full_name}
         </a>
         {repo.private && (
-          <span className="ml-2 text-xs text-stone-500 uppercase tracking-wider">private</span>
+          <span className="text-xs text-stone-500 uppercase tracking-wider">private</span>
         )}
+        {repo.config.tpm_enabled && <EnforcementBadge state={state} hasStoredId={hasStoredId} loading={enforcement.isLoading} />}
       </div>
-      <label className="flex items-center gap-2 text-xs font-mono text-stone-400 select-none cursor-pointer">
-        <input
-          type="checkbox"
-          className="accent-amber-400"
-          checked={repo.config.tpm_enabled}
-          disabled={pending}
-          onChange={(e) => onToggle(e.target.checked)}
-        />
-        tpm
-      </label>
+      <div className="flex items-center gap-3">
+        {repo.config.tpm_enabled && state === "none" && !fixPending && (
+          <button
+            type="button"
+            onClick={onFix}
+            className="text-xs font-mono px-2 py-1 rounded-sm border border-amber-600 text-amber-400 hover:bg-amber-950/50"
+          >
+            fix
+          </button>
+        )}
+        {fixPending && (
+          <span className="text-xs font-mono text-stone-500">fixing…</span>
+        )}
+        <label className="flex items-center gap-2 text-xs font-mono text-stone-400 select-none cursor-pointer">
+          <input
+            type="checkbox"
+            className="accent-amber-400"
+            checked={repo.config.tpm_enabled}
+            disabled={pending}
+            onChange={(e) => onToggle(e.target.checked)}
+          />
+          tpm
+        </label>
+      </div>
     </div>
   );
+}
+
+function EnforcementBadge({
+  state, hasStoredId, loading,
+}: {
+  state: string | undefined;
+  hasStoredId: boolean;
+  loading: boolean;
+}) {
+  if (loading && !hasStoredId) {
+    return <span className="text-xs text-stone-500 font-mono">checking…</span>;
+  }
+
+  const resolved = state ?? (hasStoredId ? "grug_managed" : undefined);
+
+  if (resolved === "grug_managed") {
+    return (
+      <span className="text-xs font-mono text-emerald-400" title="Grug-enforced ruleset active">
+        ✓ enforced
+      </span>
+    );
+  }
+  if (resolved === "external") {
+    return (
+      <span className="text-xs font-mono text-blue-400" title="Enforced via external ruleset or branch protection">
+        ✓ external
+      </span>
+    );
+  }
+  if (resolved === "none") {
+    return (
+      <span className="text-xs font-mono text-amber-400" title="TPM enabled but check is not required to merge">
+        ⚠ not enforced
+      </span>
+    );
+  }
+  if (loading) {
+    return <span className="text-xs text-stone-500 font-mono">checking…</span>;
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary

Add per-repo enforcement status to the Grug dashboard. Each repo with TPM enabled shows a 3-state indicator: green "enforced" (Grug-managed ruleset), blue "external" (user-managed ruleset or legacy BP), or amber "not enforced" with a "fix" button. Two new API endpoints support this: GET for live enforcement detection via the Rulesets + legacy BP APIs, and POST to create a Grug-managed ruleset (the fix button action). The dashboard uses lazy loading — enforcement state is fetched per repo only when TPM is enabled, and the stored enforcement_ruleset_id from DDB provides an instant indicator without GitHub API calls while the full 3-state detection loads in the background.

## Test plan

- [x] TypeScript compiles clean (tsc --noEmit)
- [x] Full backend test suite passes (184 passed, 14 skipped)
- [x] Mirror CI gate passes (14 pairs verified)
- [ ] Manual: dashboard shows "enforced" badge for repos with Grug rulesets
- [ ] Manual: dashboard shows "not enforced" + fix button for repos without enforcement
- [ ] Manual: clicking fix creates ruleset and updates badge to "enforced"

Size: S

## Out of scope

- Backend tests for the new API endpoints (would require full FastAPI TestClient setup — follow-up)
- Enforcement indicator caching/optimization beyond staleTime
- Batch enforcement detection for all repos at once

closes #207