### PR TITLE
feat: self-healing enforcement — re-create ruleset on manual delete

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,6 +39,9 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **`ensure_enforcement()`** | Idempotent function: detect → skip if `grug_managed` or `external` → create ruleset → store `enforcement_ruleset_id`. Called on installation created (webhook) and persona enable (API toggle). |
 | **`remove_enforcement()`** | Deletes the Grug-managed ruleset by ID (read from `RepoConfig`) and clears the stored `enforcement_ruleset_id`. Called on persona disable (API toggle). |
 | **`enforcement_ruleset_id`** | Optional integer field on `RepoConfig` DDB row. Stores the GitHub ruleset ID of the Grug-managed enforcement ruleset for quick lookup during delete. `None` means no Grug-managed ruleset exists. |
+| **`force_disable_enforcement`** | Optional boolean field on `RepoConfig` DDB row, default `False`. When `True`, the self-healing loop skips re-creation of a deleted Grug-managed ruleset. Escape hatch for users who intentionally remove enforcement without disabling the TPM persona. |
+| **`heal_enforcement()`** | Module-level function in `enforcement.py`. Called from dispatcher when a `repository_ruleset` deleted event fires for a Grug-managed ruleset. Clears the stale `enforcement_ruleset_id`, delegates to `ensure_enforcement()` for idempotent re-creation, and emits an `enforcement_healed` structured log with old + new ruleset IDs. Skipped when `force_disable_enforcement` is `True` or TPM persona is disabled. |
+| **Self-healing** | Reconciliation loop: when a Grug-managed ruleset is externally deleted, the webhook re-creates it if the repo still wants enforcement. Triggered by `repository_ruleset` webhook event with `action=deleted`. The `force_disable_enforcement` flag on `RepoConfig` is the opt-out. |
 
 ## Identity & authorization concepts
 

--- a/services/api/adapters/install_store.py
+++ b/services/api/adapters/install_store.py
@@ -196,11 +196,12 @@ def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
     )
     item = resp.get("Item")
     if not item:
-        return {**_DEFAULT_PERSONA_CONFIG, "enforcement_ruleset_id": None}
+        return {**_DEFAULT_PERSONA_CONFIG, "enforcement_ruleset_id": None, "force_disable_enforcement": False}
     rid = item.get("enforcement_ruleset_id")
     return {
         "tpm_enabled": bool(item.get("tpm_enabled", _DEFAULT_PERSONA_CONFIG["tpm_enabled"])),
         "enforcement_ruleset_id": int(rid) if rid is not None else None,
+        "force_disable_enforcement": bool(item.get("force_disable_enforcement", False)),
     }
 
 

--- a/services/api/enforcement.py
+++ b/services/api/enforcement.py
@@ -72,6 +72,44 @@ def ensure_enforcement(
     return "grug_managed"
 
 
+def heal_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    default_branch: str,
+    install_id: int,
+    repo_id: int,
+    *,
+    old_ruleset_id: int,
+) -> EnforcementState:
+    """Re-create a Grug-managed ruleset after external deletion.
+
+    Clears the stale enforcement_ruleset_id first, then delegates to
+    ensure_enforcement for idempotent re-creation.
+    """
+    from adapters.install_store import set_enforcement_id  # type: ignore
+    set_enforcement_id(install_id, repo_id, None)
+
+    new_state = ensure_enforcement(
+        install_token, owner, repo, default_branch, install_id, repo_id,
+    )
+
+    if new_state == "grug_managed":
+        from adapters.install_store import get_enforcement_id  # type: ignore
+        new_ruleset_id = get_enforcement_id(install_id, repo_id)
+        log.info(
+            "enforcement_healed",
+            extra={
+                "owner": owner, "repo": repo,
+                "install_id": install_id, "repo_id": repo_id,
+                "old_ruleset_id": old_ruleset_id,
+                "new_ruleset_id": new_ruleset_id,
+            },
+        )
+
+    return new_state
+
+
 def remove_enforcement(
     install_token: str,
     owner: str,

--- a/services/webhook/adapters/install_store.py
+++ b/services/webhook/adapters/install_store.py
@@ -196,11 +196,12 @@ def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
     )
     item = resp.get("Item")
     if not item:
-        return {**_DEFAULT_PERSONA_CONFIG, "enforcement_ruleset_id": None}
+        return {**_DEFAULT_PERSONA_CONFIG, "enforcement_ruleset_id": None, "force_disable_enforcement": False}
     rid = item.get("enforcement_ruleset_id")
     return {
         "tpm_enabled": bool(item.get("tpm_enabled", _DEFAULT_PERSONA_CONFIG["tpm_enabled"])),
         "enforcement_ruleset_id": int(rid) if rid is not None else None,
+        "force_disable_enforcement": bool(item.get("force_disable_enforcement", False)),
     }
 
 

--- a/services/webhook/dispatcher.py
+++ b/services/webhook/dispatcher.py
@@ -18,6 +18,7 @@ from typing import Any
 from adapters.install_store import (
     delete_installation,
     get_installation,
+    get_repo_config,
     is_install_allowlisted,
     is_persona_enabled,
     record_installation,
@@ -40,6 +41,8 @@ def dispatch(event_name: str, payload: dict[str, Any]) -> dict[str, str]:
         return {"status": "no_op", "reason": "no persona for pull_request_review yet"}
     if event_name == "issue_comment":
         return _handle_issue_comment(payload)
+    if event_name == "repository_ruleset":
+        return _handle_repository_ruleset(payload)
     return {"status": "no_op", "reason": f"no handler for event {event_name}"}
 
 
@@ -98,6 +101,78 @@ def _handle_installation(payload: dict[str, Any]) -> dict[str, str]:
         return {"status": "no_op", "reason": f"{action} ack — installer preserved"}
 
     return {"status": "no_op", "reason": f"installation action={action} unhandled"}
+
+
+def _handle_repository_ruleset(payload: dict[str, Any]) -> dict[str, str]:
+    action = payload.get("action", "")
+    if action != "deleted":
+        return {"status": "no_op", "reason": f"repository_ruleset action={action} not gated"}
+
+    ruleset = payload.get("repository_ruleset") or {}
+    ruleset_name = ruleset.get("name", "")
+    ruleset_id = ruleset.get("id")
+
+    from github_rulesets_client import GRUG_RULESET_PREFIX  # type: ignore
+    if not ruleset_name.startswith(GRUG_RULESET_PREFIX):
+        return {"status": "no_op", "reason": "not grug-managed ruleset"}
+
+    repo = payload.get("repository") or {}
+    installation = payload.get("installation") or {}
+    install_id = installation.get("id")
+    repo_id = repo.get("id")
+    owner = (repo.get("owner") or {}).get("login", "")
+    repo_name = repo.get("name", "")
+    default_branch = repo.get("default_branch", "main")
+
+    if not all([install_id, repo_id, owner, repo_name]):
+        return {"status": "skip", "reason": "incomplete_payload"}
+
+    if not is_install_allowlisted(int(install_id)):
+        return {"status": "no_op", "reason": "installer not allowlisted"}
+
+    if not is_persona_enabled(int(install_id), int(repo_id), "tpm"):
+        log.info(
+            "self_heal_skip_tpm_disabled",
+            extra={"install_id": install_id, "repo": f"{owner}/{repo_name}"},
+        )
+        return {"status": "no_op", "reason": "tpm disabled for this repo"}
+
+    cfg = get_repo_config(int(install_id), int(repo_id))
+    if cfg.get("force_disable_enforcement", False):
+        log.info(
+            "self_heal_skip_force_disable",
+            extra={"install_id": install_id, "repo": f"{owner}/{repo_name}"},
+        )
+        return {"status": "no_op", "reason": "force_disable_enforcement is set"}
+
+    _heal_enforcement_on_repo(
+        int(install_id), int(repo_id), owner, repo_name,
+        default_branch, int(ruleset_id),
+    )
+    return {"status": "healed", "old_ruleset_id": str(ruleset_id)}
+
+
+def _heal_enforcement_on_repo(
+    install_id: int, repo_id: int, owner: str, repo_name: str,
+    default_branch: str, old_ruleset_id: int,
+) -> None:
+    from github_app_auth import with_install_token_retry  # type: ignore
+    from enforcement import heal_enforcement  # type: ignore
+
+    try:
+        with_install_token_retry(
+            install_id,
+            lambda token, o=owner, r=repo_name, db=default_branch, iid=install_id, rid=repo_id, old=old_ruleset_id: (
+                heal_enforcement(token, o, r, db, iid, rid, old_ruleset_id=old)
+            ),
+        )
+    except Exception:
+        log.warning(
+            "self_heal_failed",
+            extra={"install_id": install_id, "repo": f"{owner}/{repo_name}",
+                   "old_ruleset_id": old_ruleset_id},
+            exc_info=True,
+        )
 
 
 def _enforce_on_repos(install_id: int, repositories: list[dict]) -> None:

--- a/services/webhook/enforcement.py
+++ b/services/webhook/enforcement.py
@@ -72,6 +72,44 @@ def ensure_enforcement(
     return "grug_managed"
 
 
+def heal_enforcement(
+    install_token: str,
+    owner: str,
+    repo: str,
+    default_branch: str,
+    install_id: int,
+    repo_id: int,
+    *,
+    old_ruleset_id: int,
+) -> EnforcementState:
+    """Re-create a Grug-managed ruleset after external deletion.
+
+    Clears the stale enforcement_ruleset_id first, then delegates to
+    ensure_enforcement for idempotent re-creation.
+    """
+    from adapters.install_store import set_enforcement_id  # type: ignore
+    set_enforcement_id(install_id, repo_id, None)
+
+    new_state = ensure_enforcement(
+        install_token, owner, repo, default_branch, install_id, repo_id,
+    )
+
+    if new_state == "grug_managed":
+        from adapters.install_store import get_enforcement_id  # type: ignore
+        new_ruleset_id = get_enforcement_id(install_id, repo_id)
+        log.info(
+            "enforcement_healed",
+            extra={
+                "owner": owner, "repo": repo,
+                "install_id": install_id, "repo_id": repo_id,
+                "old_ruleset_id": old_ruleset_id,
+                "new_ruleset_id": new_ruleset_id,
+            },
+        )
+
+    return new_state
+
+
 def remove_enforcement(
     install_token: str,
     owner: str,

--- a/services/webhook/tests/test_dispatcher.py
+++ b/services/webhook/tests/test_dispatcher.py
@@ -231,3 +231,81 @@ def test_new_permissions_accepted_backfills_when_no_existing_row():
         out = dispatch("installation", payload)
     assert out["status"] == "recorded" and "backfill" in out["action"]
     mock_rec.assert_called_once()
+
+
+# ── repository_ruleset (self-healing) ───────────────────────────────
+
+
+def _ruleset_deleted_payload(
+    *,
+    ruleset_name: str = "Grug — TPM Enforcement",
+    ruleset_id: int = 42,
+    install_id: int = 999,
+    repo_id: int = 7777,
+    repo_full_name: str = "githumps/infra",
+    default_branch: str = "main",
+):
+    return {
+        "action": "deleted",
+        "repository_ruleset": {"id": ruleset_id, "name": ruleset_name},
+        "repository": {
+            "id": repo_id,
+            "name": repo_full_name.split("/")[1],
+            "full_name": repo_full_name,
+            "owner": {"login": repo_full_name.split("/")[0]},
+            "default_branch": default_branch,
+        },
+        "installation": {"id": install_id},
+    }
+
+
+def test_repository_ruleset_non_delete_action_noop():
+    out = dispatch("repository_ruleset", {"action": "created", "repository_ruleset": {"id": 1, "name": "x"}})
+    assert out["status"] == "no_op"
+
+
+def test_repository_ruleset_non_grug_ruleset_noop():
+    payload = _ruleset_deleted_payload(ruleset_name="CI Required")
+    out = dispatch("repository_ruleset", payload)
+    assert out["status"] == "no_op" and "not grug-managed" in out["reason"]
+
+
+def test_repository_ruleset_heals_when_tpm_enabled():
+    payload = _ruleset_deleted_payload()
+    with patch("dispatcher.is_install_allowlisted", return_value=True), \
+         patch("dispatcher.is_persona_enabled", return_value=True), \
+         patch("dispatcher.get_repo_config", return_value={
+             "tpm_enabled": True, "enforcement_ruleset_id": 42,
+             "force_disable_enforcement": False,
+         }), \
+         patch("dispatcher._heal_enforcement_on_repo") as mock_heal:
+        out = dispatch("repository_ruleset", payload)
+    assert out["status"] == "healed"
+    mock_heal.assert_called_once()
+
+
+def test_repository_ruleset_skips_when_not_allowlisted():
+    payload = _ruleset_deleted_payload()
+    with patch("dispatcher.is_install_allowlisted", return_value=False):
+        out = dispatch("repository_ruleset", payload)
+    assert out["status"] == "no_op" and "not allowlisted" in out["reason"]
+
+
+def test_repository_ruleset_skips_when_tpm_disabled():
+    payload = _ruleset_deleted_payload()
+    with patch("dispatcher.is_install_allowlisted", return_value=True), \
+         patch("dispatcher.is_persona_enabled", return_value=False):
+        out = dispatch("repository_ruleset", payload)
+    assert out["status"] == "no_op" and "tpm disabled" in out["reason"]
+
+
+def test_repository_ruleset_skips_when_force_disable():
+    payload = _ruleset_deleted_payload()
+    with patch("dispatcher.is_install_allowlisted", return_value=True), \
+         patch("dispatcher.is_persona_enabled", return_value=True), \
+         patch("dispatcher.get_repo_config", return_value={
+             "tpm_enabled": True, "enforcement_ruleset_id": 42,
+             "force_disable_enforcement": True,
+         }):
+        out = dispatch("repository_ruleset", payload)
+    assert out["status"] == "no_op" and "force_disable" in out["reason"]

--- a/services/webhook/tests/test_enforcement.py
+++ b/services/webhook/tests/test_enforcement.py
@@ -1,8 +1,8 @@
-"""Tests for enforcement lifecycle — ensure/remove enforcement.
+"""Tests for enforcement lifecycle — ensure/remove/heal enforcement.
 
 Covers the enable → create → disable → delete lifecycle, idempotent
-skip on existing enforcement, DDB persistence of ruleset_id, and
-best-effort error handling.
+skip on existing enforcement, DDB persistence of ruleset_id,
+self-healing on external delete, and best-effort error handling.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from enforcement import (
     ensure_enforcement,
+    heal_enforcement,
     remove_enforcement,
     GRUG_TPM_RULESET_NAME,
     GRUG_DOR_CHECK_NAME,
@@ -141,3 +142,40 @@ def test_ruleset_name():
 
 def test_check_name():
     assert GRUG_DOR_CHECK_NAME == "Grug — Definition of Ready"
+
+
+# ── heal_enforcement ────────────────────────────────────────────────
+
+def test_heal_clears_stale_id_and_recreates():
+    """Deleted Grug ruleset → clear old ID → ensure creates a new one."""
+    with patch("adapters.install_store.set_enforcement_id") as mock_set, \
+         patch("enforcement.detect_enforcement", return_value="none"), \
+         patch("enforcement.create_ruleset", return_value={"id": 99}), \
+         patch("adapters.install_store.set_enforcement_id") as mock_set:
+        result = heal_enforcement("tok", "o", "r", "main", 1, 2, old_ruleset_id=42)
+
+    assert result == "grug_managed"
+    calls = mock_set.call_args_list
+    assert calls[0].args == (1, 2, None)
+    assert calls[1].args == (1, 2, 99)
+
+
+def test_heal_returns_new_state():
+    """heal_enforcement returns the EnforcementState from ensure."""
+    with patch("adapters.install_store.set_enforcement_id"), \
+         patch("enforcement.detect_enforcement", return_value="none"), \
+         patch("enforcement.create_ruleset", return_value={"id": 50}):
+        result = heal_enforcement("tok", "o", "r", "main", 1, 2, old_ruleset_id=10)
+
+    assert result == "grug_managed"
+
+
+def test_heal_noop_when_external_enforcement_exists():
+    """If someone added an external ruleset before we heal, skip creation."""
+    with patch("adapters.install_store.set_enforcement_id") as mock_set, \
+         patch("enforcement.detect_enforcement", return_value="external"), \
+         patch("enforcement.create_ruleset") as mock_create:
+        result = heal_enforcement("tok", "o", "r", "main", 1, 2, old_ruleset_id=42)
+
+    assert result == "external"
+    mock_create.assert_not_called()

--- a/services/webhook/tests/test_install_store.py
+++ b/services/webhook/tests/test_install_store.py
@@ -157,14 +157,14 @@ def test_list_user_installations_via_gsi1(_ddb_table):
 def test_repo_config_default_is_tpm_enabled_true(_ddb_table):
     mod = _ddb_table
     cfg = mod.get_repo_config(install_id=1, repo_id=42)
-    assert cfg == {"tpm_enabled": True}
+    assert cfg == {"tpm_enabled": True, "enforcement_ruleset_id": None, "force_disable_enforcement": False}
 
 
 def test_set_then_get_repo_config(_ddb_table):
     mod = _ddb_table
     mod.set_repo_config(install_id=1, repo_id=42, repo_full_name="x/y",
                         tpm_enabled=False, updated_by_user_id="100")
-    assert mod.get_repo_config(1, 42) == {"tpm_enabled": False}
+    assert mod.get_repo_config(1, 42) == {"tpm_enabled": False, "enforcement_ruleset_id": None, "force_disable_enforcement": False}
 
 
 def test_is_persona_enabled_default_true(_ddb_table):

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -39,6 +39,9 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **`ensure_enforcement()`** | Idempotent function: detect → skip if `grug_managed` or `external` → create ruleset → store `enforcement_ruleset_id`. Called on installation created (webhook) and persona enable (API toggle). |
 | **`remove_enforcement()`** | Deletes the Grug-managed ruleset by ID (read from `RepoConfig`) and clears the stored `enforcement_ruleset_id`. Called on persona disable (API toggle). |
 | **`enforcement_ruleset_id`** | Optional integer field on `RepoConfig` DDB row. Stores the GitHub ruleset ID of the Grug-managed enforcement ruleset for quick lookup during delete. `None` means no Grug-managed ruleset exists. |
+| **`force_disable_enforcement`** | Optional boolean field on `RepoConfig` DDB row, default `False`. When `True`, the self-healing loop skips re-creation of a deleted Grug-managed ruleset. Escape hatch for users who intentionally remove enforcement without disabling the TPM persona. |
+| **`heal_enforcement()`** | Module-level function in `enforcement.py`. Called from dispatcher when a `repository_ruleset` deleted event fires for a Grug-managed ruleset. Clears the stale `enforcement_ruleset_id`, delegates to `ensure_enforcement()` for idempotent re-creation, and emits an `enforcement_healed` structured log with old + new ruleset IDs. Skipped when `force_disable_enforcement` is `True` or TPM persona is disabled. |
+| **Self-healing** | Reconciliation loop: when a Grug-managed ruleset is externally deleted, the webhook re-creates it if the repo still wants enforcement. Triggered by `repository_ruleset` webhook event with `action=deleted`. The `force_disable_enforcement` flag on `RepoConfig` is the opt-out. |
 
 ## Identity & authorization concepts
 


### PR DESCRIPTION
## Summary

Add self-healing for Grug-managed enforcement rulesets. When someone manually deletes a Grug-managed ruleset from GitHub settings, the webhook now listens for `repository_ruleset` events and re-creates the ruleset if the TPM persona is still enabled. A new `force_disable_enforcement` boolean on RepoConfig provides an opt-out escape hatch for users who intentionally remove enforcement without disabling TPM.

Implementation adds `heal_enforcement()` to enforcement.py which composes existing primitives (clear stale ID → `ensure_enforcement()`), routes the new event in the dispatcher with all existing gates (allowlist, persona toggle, force_disable), and mirrors changes to both api and webhook services.

## Test plan

- [x] Verify `heal_enforcement` clears stale ID and delegates to `ensure_enforcement`
- [x] Verify heal skips when external enforcement already present
- [x] Verify dispatcher routes `repository_ruleset` `deleted` event correctly
- [x] Verify dispatcher no-ops on non-Grug-managed ruleset deletion
- [x] Verify dispatcher skips when TPM disabled, not allowlisted, or force_disable set
- [x] Verify `get_repo_config` includes `force_disable_enforcement` field
- [x] Full webhook test suite passes (207 tests)
- [x] Mirror parity verified between api and webhook sides

Size: S

## Out of scope

- UI for setting `force_disable_enforcement` (direct DDB update for now)
- Dashboard indicator for self-healing state
- Metrics/monitors for heal events (covered by #210)

closes #208