### PR TITLE
feat: enforcement migration — backfill rulesets on 13 existing repos

### DIFF
--- a/scripts/migrate_enforcement.py
+++ b/scripts/migrate_enforcement.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""One-time migration: backfill enforcement rulesets on all TPM-enabled repos.
+
+For each installation with TPM enabled, detects current enforcement state
+and creates a Grug-managed ruleset where none exists. Skips externally-
+enforced repos. Special-cases the grug repo (legacy branch protection →
+ruleset migration).
+
+Usage:
+    python scripts/migrate_enforcement.py --dry-run
+    python scripts/migrate_enforcement.py
+
+Requires:
+    AWS creds with DDB read/write + SSM read (for GitHub App secrets).
+    GRUG_DDB_TABLE env var (default: grug-main).
+    GITHUB_APP_ID_SSM env var (SSM param name for App ID).
+    GITHUB_APP_PRIVATE_KEY_SSM env var (SSM param name for App private key).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import boto3
+import httpx
+import jwt
+
+# ── Constants ───────────────────────────────────────────────────────
+
+_GH_API = "https://api.github.com"
+GRUG_RULESET_PREFIX = "Grug — "
+GRUG_TPM_RULESET_NAME = "Grug — TPM Enforcement"
+GRUG_DOR_CHECK_NAME = "Grug — Definition of Ready"
+
+_HEADERS_TEMPLATE = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+log = logging.getLogger("migrate_enforcement")
+
+# ── GitHub App auth (standalone — no service-module dependency) ──────
+
+
+class _TokenManager:
+    def __init__(self) -> None:
+        self._ssm = boto3.client("ssm")
+        self._app_id: str | None = None
+        self._app_key: str | None = None
+        self._jwt: str | None = None
+        self._jwt_exp: float = 0
+        self._install_tokens: dict[int, tuple[str, float]] = {}
+
+    def _get_ssm(self, name: str) -> str:
+        resp = self._ssm.get_parameter(Name=name, WithDecryption=True)
+        return resp["Parameter"]["Value"]
+
+    def _ensure_secrets(self) -> None:
+        if self._app_id is None:
+            self._app_id = self._get_ssm(os.environ["GITHUB_APP_ID_SSM"])
+        if self._app_key is None:
+            self._app_key = self._get_ssm(os.environ["GITHUB_APP_PRIVATE_KEY_SSM"])
+
+    def get_app_jwt(self) -> str:
+        now = time.time()
+        if self._jwt and now < self._jwt_exp:
+            return self._jwt
+        self._ensure_secrets()
+        payload = {
+            "iat": int(now - 60),
+            "exp": int(now + 9 * 60),
+            "iss": self._app_id,
+        }
+        self._jwt = jwt.encode(payload, self._app_key, algorithm="RS256")
+        self._jwt_exp = now + 8 * 60
+        return self._jwt
+
+    def get_install_token(self, install_id: int) -> str:
+        now = time.time()
+        if install_id in self._install_tokens:
+            tok, exp = self._install_tokens[install_id]
+            if now < exp:
+                return tok
+        resp = httpx.post(
+            f"{_GH_API}/app/installations/{install_id}/access_tokens",
+            headers={
+                "Authorization": f"Bearer {self.get_app_jwt()}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+        tok = resp.json()["token"]
+        self._install_tokens[install_id] = (tok, now + 55 * 60)
+        return tok
+
+
+# ── GitHub API helpers ──────────────────────────────────────────────
+
+
+def _auth_headers(token: str) -> dict[str, str]:
+    return {**_HEADERS_TEMPLATE, "Authorization": f"Bearer {token}"}
+
+
+def _list_rulesets(token: str, owner: str, repo: str) -> list[dict]:
+    resp = httpx.get(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        headers=_auth_headers(token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _detect_enforcement(token: str, owner: str, repo: str, branch: str) -> str:
+    rulesets = _list_rulesets(token, owner, repo)
+    grug_match = False
+    external_match = False
+    for rs in rulesets:
+        has_check = False
+        for rule in rs.get("rules", []):
+            if rule.get("type") != "required_status_checks":
+                continue
+            for check in rule.get("parameters", {}).get("required_status_checks", []):
+                if check.get("context") == GRUG_DOR_CHECK_NAME:
+                    has_check = True
+                    break
+        if not has_check:
+            continue
+        if rs.get("name", "").startswith(GRUG_RULESET_PREFIX):
+            grug_match = True
+        else:
+            external_match = True
+
+    if grug_match:
+        return "grug_managed"
+    if external_match:
+        return "external"
+
+    try:
+        from urllib.parse import quote
+        legacy_resp = httpx.get(
+            f"{_GH_API}/repos/{owner}/{repo}/branches/{quote(branch, safe='')}/protection/required_status_checks",
+            headers=_auth_headers(token),
+            timeout=10,
+        )
+        legacy_resp.raise_for_status()
+        data = legacy_resp.json()
+        if GRUG_DOR_CHECK_NAME in data.get("contexts", []):
+            return "external"
+        for check in data.get("checks", []):
+            if isinstance(check, dict) and check.get("context") == GRUG_DOR_CHECK_NAME:
+                return "external"
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code not in (404, 403):
+            raise
+
+    return "none"
+
+
+def _create_ruleset(token: str, owner: str, repo: str) -> dict:
+    body = {
+        "name": GRUG_TPM_RULESET_NAME,
+        "target": "branch",
+        "enforcement": "active",
+        "conditions": {
+            "ref_name": {"include": ["~DEFAULT_BRANCH"], "exclude": []},
+        },
+        "rules": [{
+            "type": "required_status_checks",
+            "parameters": {
+                "strict_required_status_checks_policy": False,
+                "required_status_checks": [
+                    {"context": GRUG_DOR_CHECK_NAME, "integration_id": None},
+                ],
+            },
+        }],
+    }
+    resp = httpx.post(
+        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        json=body,
+        headers=_auth_headers(token),
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _remove_check_from_legacy_bp(
+    token: str, owner: str, repo: str, branch: str, check_name: str,
+) -> bool:
+    """Remove a single check from legacy branch protection. Returns True if removed."""
+    from urllib.parse import quote
+    url = f"{_GH_API}/repos/{owner}/{repo}/branches/{quote(branch, safe='')}/protection/required_status_checks"
+    try:
+        resp = httpx.get(url, headers=_auth_headers(token), timeout=10)
+        resp.raise_for_status()
+    except httpx.HTTPStatusError:
+        return False
+
+    data = resp.json()
+    contexts = data.get("contexts", [])
+    checks = data.get("checks", [])
+
+    new_contexts = [c for c in contexts if c != check_name]
+    new_checks = [c for c in checks if not (isinstance(c, dict) and c.get("context") == check_name)]
+
+    if len(new_contexts) == len(contexts) and len(new_checks) == len(checks):
+        return False
+
+    patch_body: dict[str, Any] = {"strict": data.get("strict", False)}
+    if new_checks:
+        patch_body["checks"] = new_checks
+    else:
+        patch_body["contexts"] = new_contexts
+
+    patch_resp = httpx.patch(
+        url, json=patch_body, headers=_auth_headers(token), timeout=10,
+    )
+    patch_resp.raise_for_status()
+    return True
+
+
+# ── DDB scan ────────────────────────────────────────────────────────
+
+
+def _scan_tpm_repos(table_name: str) -> list[dict]:
+    """Return all REPO# rows with tpm_enabled across all installations."""
+    ddb = boto3.resource("dynamodb")
+    table = ddb.Table(table_name)
+
+    items: list[dict] = []
+    scan_kwargs: dict[str, Any] = {
+        "FilterExpression": "begins_with(SK, :repo_prefix)",
+        "ExpressionAttributeValues": {":repo_prefix": "REPO#"},
+    }
+    while True:
+        resp = table.scan(**scan_kwargs)
+        items.extend(resp.get("Items", []))
+        if "LastEvaluatedKey" not in resp:
+            break
+        scan_kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    installs: list[dict] = []
+    scan_kwargs = {
+        "FilterExpression": "SK = :meta AND attribute_exists(account_login)",
+        "ExpressionAttributeValues": {":meta": "META"},
+    }
+    while True:
+        resp = table.scan(**scan_kwargs)
+        installs.extend(resp.get("Items", []))
+        if "LastEvaluatedKey" not in resp:
+            break
+        scan_kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    install_map = {}
+    for inst in installs:
+        pk = inst.get("PK", "")
+        if pk.startswith("INST#"):
+            install_map[pk] = inst
+
+    results = []
+    for item in items:
+        pk = item.get("PK", "")
+        sk = item.get("SK", "")
+        tpm_enabled = bool(item.get("tpm_enabled", True))
+        if not tpm_enabled:
+            continue
+        inst = install_map.get(pk)
+        if not inst:
+            continue
+        install_id = int(pk.split("#")[1])
+        repo_id = int(sk.split("#")[1])
+        results.append({
+            "install_id": install_id,
+            "repo_id": repo_id,
+            "repo_full_name": item.get("repo_full_name", ""),
+            "account_login": inst.get("account_login", ""),
+            "enforcement_ruleset_id": item.get("enforcement_ruleset_id"),
+        })
+
+    return results
+
+
+def _scan_all_installs(table_name: str) -> list[dict]:
+    """Return INST# META rows for installations that have no REPO# rows yet."""
+    ddb = boto3.resource("dynamodb")
+    table = ddb.Table(table_name)
+
+    installs: list[dict] = []
+    scan_kwargs: dict[str, Any] = {
+        "FilterExpression": "SK = :meta AND begins_with(PK, :inst) AND attribute_exists(account_login)",
+        "ExpressionAttributeValues": {":meta": "META", ":inst": "INST#"},
+    }
+    while True:
+        resp = table.scan(**scan_kwargs)
+        installs.extend(resp.get("Items", []))
+        if "LastEvaluatedKey" not in resp:
+            break
+        scan_kwargs["ExclusiveStartKey"] = resp["LastEvaluatedKey"]
+
+    return installs
+
+
+def _set_enforcement_id(
+    table_name: str, install_id: int, repo_id: int, ruleset_id: int | None,
+) -> None:
+    ddb = boto3.resource("dynamodb")
+    table = ddb.Table(table_name)
+    if ruleset_id is not None:
+        table.update_item(
+            Key={"PK": f"INST#{install_id}", "SK": f"REPO#{repo_id}"},
+            UpdateExpression="SET enforcement_ruleset_id = :rid",
+            ExpressionAttributeValues={":rid": ruleset_id},
+        )
+    else:
+        table.update_item(
+            Key={"PK": f"INST#{install_id}", "SK": f"REPO#{repo_id}"},
+            UpdateExpression="REMOVE enforcement_ruleset_id",
+        )
+
+
+# ── Migration logic ────────────────────────────────────────────────
+
+
+def _list_install_repos(token: str, owner: str) -> list[dict]:
+    """List repos accessible by the installation token."""
+    repos: list[dict] = []
+    url = f"{_GH_API}/installation/repositories?per_page=100"
+    while url:
+        resp = httpx.get(url, headers=_auth_headers(token), timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        repos.extend(data.get("repositories", []))
+        link = resp.headers.get("link", "")
+        url = None
+        for part in link.split(","):
+            if 'rel="next"' in part:
+                url = part.split("<")[1].split(">")[0]
+    return repos
+
+
+def _emit(entry: dict) -> None:
+    entry["timestamp"] = datetime.now(timezone.utc).isoformat()
+    print(json.dumps(entry, default=str), flush=True)
+
+
+def migrate(dry_run: bool = True) -> None:
+    table_name = os.environ.get("GRUG_DDB_TABLE", "grug-main")
+    tokens = _TokenManager()
+
+    log.info("scanning DDB for installations...")
+    installs = _scan_all_installs(table_name)
+    repo_rows = _scan_tpm_repos(table_name)
+
+    log.info("found %d installations, %d TPM-enabled repo rows", len(installs), len(repo_rows))
+
+    known_repos = {(r["install_id"], r["repo_id"]) for r in repo_rows}
+    stats = {"created": 0, "external": 0, "grug_managed": 0, "skipped": 0, "legacy_migrated": 0, "errors": 0}
+
+    for inst in installs:
+        pk = inst.get("PK", "")
+        install_id = int(pk.split("#")[1])
+        account_login = inst.get("account_login", "")
+
+        try:
+            token = tokens.get_install_token(install_id)
+        except Exception as e:
+            _emit({"action": "token_failed", "install_id": install_id, "error": str(e)})
+            stats["errors"] += 1
+            continue
+
+        try:
+            repos = _list_install_repos(token, account_login)
+        except Exception as e:
+            _emit({"action": "list_repos_failed", "install_id": install_id, "error": str(e)})
+            stats["errors"] += 1
+            continue
+
+        for repo in repos:
+            repo_id = repo["id"]
+            full_name = repo["full_name"]
+            owner = repo["owner"]["login"]
+            repo_name = repo["name"]
+            default_branch = repo.get("default_branch", "main")
+
+            try:
+                state = _detect_enforcement(token, owner, repo_name, default_branch)
+            except Exception as e:
+                _emit({
+                    "action": "detect_failed",
+                    "install_id": install_id, "repo": full_name,
+                    "error": str(e),
+                })
+                stats["errors"] += 1
+                continue
+
+            if state == "grug_managed":
+                _emit({"action": "skip", "reason": "grug_managed", "repo": full_name})
+                stats["grug_managed"] += 1
+                continue
+
+            if state == "external":
+                _emit({"action": "skip", "reason": "external", "repo": full_name})
+                stats["external"] += 1
+
+                is_grug_repo = full_name.lower() in ("githumps/grug",)
+                if is_grug_repo:
+                    _emit({"action": "legacy_bp_migration_candidate", "repo": full_name})
+                    if not dry_run:
+                        try:
+                            result = _create_ruleset(token, owner, repo_name)
+                            new_id = result["id"]
+                            _set_enforcement_id(table_name, install_id, repo_id, new_id)
+                            _emit({"action": "ruleset_created", "repo": full_name, "ruleset_id": new_id})
+
+                            removed = _remove_check_from_legacy_bp(
+                                token, owner, repo_name, default_branch, GRUG_DOR_CHECK_NAME,
+                            )
+                            if removed:
+                                _emit({"action": "legacy_bp_check_removed", "repo": full_name})
+                            stats["legacy_migrated"] += 1
+                        except Exception as e:
+                            _emit({"action": "legacy_migration_failed", "repo": full_name, "error": str(e)})
+                            stats["errors"] += 1
+                    else:
+                        _emit({"action": "dry_run_would_migrate_legacy", "repo": full_name})
+                        stats["legacy_migrated"] += 1
+                continue
+
+            # state == "none" — create ruleset
+            if dry_run:
+                _emit({"action": "dry_run_would_create", "repo": full_name, "install_id": install_id})
+                stats["created"] += 1
+            else:
+                try:
+                    result = _create_ruleset(token, owner, repo_name)
+                    new_id = result["id"]
+                    _set_enforcement_id(table_name, install_id, repo_id, new_id)
+                    _emit({"action": "ruleset_created", "repo": full_name, "ruleset_id": new_id})
+                    stats["created"] += 1
+                except Exception as e:
+                    _emit({"action": "create_failed", "repo": full_name, "error": str(e)})
+                    stats["errors"] += 1
+
+    _emit({"action": "migration_complete", "dry_run": dry_run, "stats": stats})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Backfill enforcement rulesets on TPM-enabled repos")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would happen without making changes")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    migrate(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_migrate_enforcement.py
+++ b/scripts/tests/test_migrate_enforcement.py
@@ -1,0 +1,195 @@
+"""Tests for the enforcement migration script.
+
+Uses moto for DDB and unittest.mock for GitHub API calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import boto3
+import moto
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import migrate_enforcement as mod
+
+
+@pytest.fixture
+def _ddb_table(monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("GRUG_DDB_TABLE", "grug-test")
+
+    with moto.mock_aws():
+        ddb = boto3.resource("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName="grug-test",
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        table = ddb.Table("grug-test")
+        table.put_item(Item={
+            "PK": "INST#100", "SK": "META",
+            "account_login": "githumps", "account_type": "User",
+            "installed_by_user_id": "59060157",
+        })
+        table.put_item(Item={
+            "PK": "INST#100", "SK": "REPO#7777",
+            "tpm_enabled": True, "repo_full_name": "githumps/infra",
+        })
+        table.put_item(Item={
+            "PK": "INST#100", "SK": "REPO#8888",
+            "tpm_enabled": True, "repo_full_name": "githumps/grug",
+        })
+        table.put_item(Item={
+            "PK": "INST#100", "SK": "REPO#9999",
+            "tpm_enabled": False, "repo_full_name": "githumps/disabled-repo",
+        })
+        yield table
+
+
+def _mock_repos():
+    return [
+        {"id": 7777, "full_name": "githumps/infra", "name": "infra",
+         "owner": {"login": "githumps"}, "default_branch": "main"},
+        {"id": 8888, "full_name": "githumps/grug", "name": "grug",
+         "owner": {"login": "githumps"}, "default_branch": "main"},
+        {"id": 9999, "full_name": "githumps/disabled-repo", "name": "disabled-repo",
+         "owner": {"login": "githumps"}, "default_branch": "main"},
+    ]
+
+
+def test_dry_run_does_not_create_rulesets(_ddb_table, capsys, monkeypatch):
+    """--dry-run emits what would happen without mutation."""
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    with patch.object(mod._TokenManager, "get_install_token", return_value="tok"), \
+         patch.object(mod, "_list_install_repos", return_value=_mock_repos()), \
+         patch.object(mod, "_detect_enforcement", return_value="none"), \
+         patch.object(mod, "_create_ruleset") as mock_create:
+        mod.migrate(dry_run=True)
+
+    mock_create.assert_not_called()
+    output = capsys.readouterr().out
+    lines = [json.loads(l) for l in output.strip().split("\n")]
+    actions = [l["action"] for l in lines]
+    assert "dry_run_would_create" in actions
+    assert "migration_complete" in actions
+
+
+def test_creates_rulesets_for_unenforced_repos(_ddb_table, capsys, monkeypatch):
+    """Repos with state=none get a ruleset created."""
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    with patch.object(mod._TokenManager, "get_install_token", return_value="tok"), \
+         patch.object(mod, "_list_install_repos", return_value=_mock_repos()), \
+         patch.object(mod, "_detect_enforcement", return_value="none"), \
+         patch.object(mod, "_create_ruleset", return_value={"id": 42}) as mock_create, \
+         patch.object(mod, "_set_enforcement_id") as mock_set:
+        mod.migrate(dry_run=False)
+
+    assert mock_create.call_count == 3
+    assert mock_set.call_count == 3
+
+
+def test_skips_externally_enforced_repos(_ddb_table, capsys, monkeypatch):
+    """Repos with state=external are skipped (no ruleset created)."""
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    with patch.object(mod._TokenManager, "get_install_token", return_value="tok"), \
+         patch.object(mod, "_list_install_repos", return_value=_mock_repos()), \
+         patch.object(mod, "_detect_enforcement", return_value="external"), \
+         patch.object(mod, "_create_ruleset") as mock_create:
+        mod.migrate(dry_run=False)
+
+    output = capsys.readouterr().out
+    lines = [json.loads(l) for l in output.strip().split("\n")]
+    skip_actions = [l for l in lines if l["action"] == "skip" and l.get("reason") == "external"]
+    assert len(skip_actions) >= 2
+    # grug repo is special-cased separately (legacy_bp_migration_candidate)
+
+
+def test_skips_already_grug_managed(_ddb_table, capsys, monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    with patch.object(mod._TokenManager, "get_install_token", return_value="tok"), \
+         patch.object(mod, "_list_install_repos", return_value=_mock_repos()), \
+         patch.object(mod, "_detect_enforcement", return_value="grug_managed"), \
+         patch.object(mod, "_create_ruleset") as mock_create:
+        mod.migrate(dry_run=False)
+
+    mock_create.assert_not_called()
+
+
+def test_grug_repo_legacy_migration(_ddb_table, capsys, monkeypatch):
+    """githumps/grug with external enforcement triggers legacy BP migration."""
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    def _side_effect_detect(token, owner, repo, branch):
+        if repo == "grug":
+            return "external"
+        return "none"
+
+    with patch.object(mod._TokenManager, "get_install_token", return_value="tok"), \
+         patch.object(mod, "_list_install_repos", return_value=_mock_repos()), \
+         patch.object(mod, "_detect_enforcement", side_effect=_side_effect_detect), \
+         patch.object(mod, "_create_ruleset", return_value={"id": 55}) as mock_create, \
+         patch.object(mod, "_remove_check_from_legacy_bp", return_value=True) as mock_rm, \
+         patch.object(mod, "_set_enforcement_id") as mock_set:
+        mod.migrate(dry_run=False)
+
+    grug_calls = [c for c in mock_create.call_args_list if c.args[2] == "grug"]
+    assert len(grug_calls) == 1
+    mock_rm.assert_called_once()
+
+    output = capsys.readouterr().out
+    lines = [json.loads(l) for l in output.strip().split("\n")]
+    assert any(l["action"] == "legacy_bp_check_removed" for l in lines)
+
+
+def test_idempotent_rerun_skips_grug_managed(_ddb_table, capsys, monkeypatch):
+    """Re-running after successful migration is a no-op."""
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    with patch.object(mod._TokenManager, "get_install_token", return_value="tok"), \
+         patch.object(mod, "_list_install_repos", return_value=_mock_repos()), \
+         patch.object(mod, "_detect_enforcement", return_value="grug_managed"), \
+         patch.object(mod, "_create_ruleset") as mock_create:
+        mod.migrate(dry_run=False)
+        mod.migrate(dry_run=False)
+
+    mock_create.assert_not_called()
+
+
+def test_token_failure_logs_and_continues(_ddb_table, capsys, monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_ID_SSM", "/test/app-id")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY_SSM", "/test/key")
+
+    with patch.object(mod._TokenManager, "get_install_token", side_effect=Exception("auth failed")):
+        mod.migrate(dry_run=False)
+
+    output = capsys.readouterr().out
+    lines = [json.loads(l) for l in output.strip().split("\n")]
+    assert any(l["action"] == "token_failed" for l in lines)
+    complete = [l for l in lines if l["action"] == "migration_complete"][0]
+    assert complete["stats"]["errors"] >= 1

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -42,6 +42,7 @@ The vocabulary used in `services/`, `infra/`, and `web/`. Terms map to identifie
 | **`force_disable_enforcement`** | Optional boolean field on `RepoConfig` DDB row, default `False`. When `True`, the self-healing loop skips re-creation of a deleted Grug-managed ruleset. Escape hatch for users who intentionally remove enforcement without disabling the TPM persona. |
 | **`heal_enforcement()`** | Module-level function in `enforcement.py`. Called from dispatcher when a `repository_ruleset` deleted event fires for a Grug-managed ruleset. Clears the stale `enforcement_ruleset_id`, delegates to `ensure_enforcement()` for idempotent re-creation, and emits an `enforcement_healed` structured log with old + new ruleset IDs. Skipped when `force_disable_enforcement` is `True` or TPM persona is disabled. |
 | **Self-healing** | Reconciliation loop: when a Grug-managed ruleset is externally deleted, the webhook re-creates it if the repo still wants enforcement. Triggered by `repository_ruleset` webhook event with `action=deleted`. The `force_disable_enforcement` flag on `RepoConfig` is the opt-out. |
+| **Enforcement migration** | One-time backfill script (`scripts/migrate_enforcement.py`) that scans all installations for TPM-enabled repos and creates Grug-managed rulesets where none exist. Handles the grug repo's legacy branch protection → ruleset migration. Supports `--dry-run`. Idempotent. |
 
 ## Identity & authorization concepts
 


### PR DESCRIPTION
## Summary

One-time migration script that scans all DDB installations, lists their accessible repos via the GitHub API, detects current enforcement state, and creates Grug-managed rulesets where none exist. Special-cases the grug repo which has a legacy branch protection rule — creates a proper ruleset then removes the check from the legacy BP. The script is standalone (no service-module imports), supports --dry-run, emits structured JSONL for every action, and is idempotent for safe re-runs.

## Test plan

- [x] Dry-run emits planned actions without creating rulesets
- [x] Creates rulesets for unenforced repos and stores IDs in DDB
- [x] Skips externally-enforced repos
- [x] Skips already grug-managed repos
- [x] grug repo triggers legacy BP migration (create ruleset + remove from BP)
- [x] Re-running is idempotent (no duplicate rulesets)
- [x] Token failures are logged and don't halt other installations

Size: S

## Out of scope

- Automated scheduling (this is a one-time manual run)
- Self-healing on future deletions (covered by #208)
- Observability/metrics for migration (covered by #210)

closes #209