### PR TITLE
fix(ci): bump temper build timeout 15m → 25m

### DIFF
--- a/.github/workflows/check.temper-specs.yml
+++ b/.github/workflows/check.temper-specs.yml
@@ -54,7 +54,7 @@ jobs:
   build:
     name: build temper
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Locate or build temper binary
         id: temper-locate


### PR DESCRIPTION
## Summary

Cold cargo builds of the temper binary on GitHub-hosted `ubuntu-latest` runners take ~18 minutes when the GHA cache misses. The 15-minute timeout caused repeated flapping failures — the build would compile successfully but get killed right before upload. Warm cache builds complete in ~8 minutes. Bumping to 25 minutes covers both cases with margin and stops the CI flapping that blocked PRs #214-#216.

## Test plan

- [x] Verify timeout changed from 15 to 25 in build job only (verify jobs stay at 10)
- [ ] Next PR touching specs should build temper without timeout

Size: XS

## Out of scope

- Pre-building temper binary as a GH release artifact (better long-term fix)
- Switching temper build to a faster runner

closes #217