### PR TITLE
fix(ci): pre-built temper binary via GH Release

### DIFF
--- a/.github/workflows/build.temper-binary.yml
+++ b/.github/workflows/build.temper-binary.yml
@@ -1,0 +1,69 @@
+name: Build · temper · publish pre-built binary
+
+# Builds the temper binary from source and publishes it as a GitHub
+# Release artifact. Run this once per TEMPER_REPO_SHA bump. The PR
+# workflow (check.temper-specs.yml) downloads the release binary
+# instead of compiling from source (~5s vs ~18min).
+#
+# Usage: Actions → Build · temper → Run workflow → main
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  TEMPER_REPO: nerdsane/temper
+  TEMPER_REPO_SHA: 3c2e6267ec179f94ef67da00e373eccf577f23ca
+
+jobs:
+  build-and-release:
+    name: build temper + publish release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libssl-dev pkg-config libz3-dev libclang-dev
+
+      - name: Clone temper
+        run: |
+          git clone https://github.com/${{ env.TEMPER_REPO }}.git /tmp/temper
+          cd /tmp/temper
+          git checkout ${{ env.TEMPER_REPO_SHA }}
+
+      - name: Build temper (release)
+        run: |
+          cd /tmp/temper
+          cargo build --release --bin temper
+          cp target/release/temper /tmp/temper-bin
+          chmod +x /tmp/temper-bin
+          /tmp/temper-bin --version || echo "(no --version flag)"
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="temper-${{ env.TEMPER_REPO_SHA }}"
+          SHORT_SHA="${{ env.TEMPER_REPO_SHA }}"
+          SHORT_SHA="${SHORT_SHA:0:12}"
+
+          # Delete existing release if re-running
+          gh release delete "$TAG" --repo "${{ github.repository }}" --yes 2>/dev/null || true
+          git tag -d "$TAG" 2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
+
+          # Create release with binary
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "temper binary (${SHORT_SHA})" \
+            --notes "Pre-built temper binary for linux/amd64. SHA: ${{ env.TEMPER_REPO_SHA }}" \
+            --latest=false \
+            /tmp/temper-bin

--- a/.github/workflows/check.temper-specs.yml
+++ b/.github/workflows/check.temper-specs.yml
@@ -56,26 +56,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Locate or build temper binary
-        id: temper-locate
+      - name: Download pre-built temper from GH Release
+        id: temper-download
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BAKED=/opt/temper/${{ env.TEMPER_REPO_SHA }}/temper
-          if [[ -x $BAKED ]]; then
-            echo "Using pre-built temper at $BAKED"
-            cp "$BAKED" /tmp/temper-bin
+          TAG="temper-${{ env.TEMPER_REPO_SHA }}"
+          if gh release download "$TAG" \
+               --repo "${{ github.repository }}" \
+               --pattern "temper-bin" \
+               --dir /tmp 2>/dev/null; then
+            chmod +x /tmp/temper-bin
+            echo "Pre-built temper downloaded from release $TAG"
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
           else
+            echo "No release found for $TAG — will build from source"
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Install Rust toolchain
-        if: steps.temper-locate.outputs.needs_build == 'true'
+        if: steps.temper-download.outputs.needs_build == 'true'
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 
       - name: Install temper build deps
-        if: steps.temper-locate.outputs.needs_build == 'true'
+        if: steps.temper-download.outputs.needs_build == 'true'
         run: |
           missing=()
           pkg-config --exists openssl || missing+=("libssl-dev" "pkg-config")
@@ -87,7 +93,7 @@ jobs:
           fi
 
       - name: Clone temper
-        if: steps.temper-locate.outputs.needs_build == 'true'
+        if: steps.temper-download.outputs.needs_build == 'true'
         run: |
           rm -rf /tmp/temper
           git clone https://github.com/${{ env.TEMPER_REPO }}.git /tmp/temper
@@ -95,14 +101,14 @@ jobs:
           git checkout ${{ env.TEMPER_REPO_SHA }}
 
       - name: Cache temper cargo build
-        if: steps.temper-locate.outputs.needs_build == 'true'
+        if: steps.temper-download.outputs.needs_build == 'true'
         uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
           workspaces: /tmp/temper
           prefix-key: temper-${{ env.TEMPER_REPO_SHA }}
 
       - name: Build temper
-        if: steps.temper-locate.outputs.needs_build == 'true'
+        if: steps.temper-download.outputs.needs_build == 'true'
         run: |
           cd /tmp/temper
           cargo build --release --bin temper


### PR DESCRIPTION
## Summary

Replace the 18-minute source compilation of the temper binary with a 5-second download from a GitHub Release. Adds a manual-dispatch workflow (Build · temper) that compiles temper once and publishes it as a release artifact tagged `temper-<SHA>`. The PR workflow now tries to download that release first, falling back to source build only if no release exists for the pinned SHA.

After merging: run Actions → Build · temper → Run workflow → main to publish the binary. Future PR runs will download it in ~5 seconds instead of compiling for 18 minutes.

## Test plan

- [x] `check.temper-specs.yml` falls back to source build when no release exists
- [x] `build.temper-binary.yml` has correct Rust toolchain + deps + release creation
- [ ] After merge: trigger build workflow, verify release created
- [ ] Next PR touching specs downloads binary in ~5s

Size: S

## Out of scope

- Cross-platform binaries (only linux/amd64 needed for ubuntu-latest)
- Auto-triggering build on SHA bump (manual dispatch is fine for monthly bumps)