### PR TITLE
fix(ci): add cargo cache to temper build workflow

### DIFF
--- a/.github/workflows/build.temper-binary.yml
+++ b/.github/workflows/build.temper-binary.yml
@@ -21,8 +21,10 @@ jobs:
   build-and-release:
     name: build temper + publish release
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
@@ -35,9 +37,16 @@ jobs:
 
       - name: Clone temper
         run: |
+          rm -rf /tmp/temper
           git clone https://github.com/${{ env.TEMPER_REPO }}.git /tmp/temper
           cd /tmp/temper
           git checkout ${{ env.TEMPER_REPO_SHA }}
+
+      - name: Cache temper cargo build
+        uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
+        with:
+          workspaces: /tmp/temper
+          prefix-key: temper-release-${{ env.TEMPER_REPO_SHA }}
 
       - name: Build temper (release)
         run: |


### PR DESCRIPTION
## Summary

The manual-dispatch temper build workflow had no cargo cache, causing 40+ minute cold compilation on ubuntu-latest 2-core runners. Added `rust-cache` action and bumped timeout to 45 min. After merge, retrigger the workflow — with cache it should complete in ~18 min.

## Test plan

- [ ] After merge: trigger Build · temper workflow, verify completes with cache
- [ ] Verify release artifact created at tag `temper-<SHA>`

Size: XS

## Out of scope

- Switching to a larger runner (free unlimited for public repos but overkill for a one-time build)