### PR TITLE
fix(ci): use self-hosted runner for temper one-time build

### DIFF
--- a/.github/workflows/build.temper-binary.yml
+++ b/.github/workflows/build.temper-binary.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-and-release:
     name: build temper + publish release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, srv-unraid-gha]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

The manual-dispatch temper build workflow cannot complete on ubuntu-latest — the 2-core GitHub-hosted runner takes 40+ minutes for a cold Rust build, exceeding even a 45-minute timeout. Switch to the self-hosted runner (srv-unraid-gha) which has more CPU. This only affects the one-time build workflow, not the PR verification workflow (which will download the pre-built binary from the GH release).

## Test plan

- [ ] After merge: trigger Build · temper workflow, verify completes on self-hosted
- [ ] Verify release artifact created

Size: XS

## Out of scope

- The PR workflow (check.temper-specs.yml) stays on ubuntu-latest — it downloads, doesn't compile