### PR TITLE
fix(ci): use ubuntu-latest-xl for temper one-time build

### DIFF
--- a/.github/workflows/build.temper-binary.yml
+++ b/.github/workflows/build.temper-binary.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-and-release:
     name: build temper + publish release
-    runs-on: [self-hosted, srv-unraid-gha]
+    runs-on: ubuntu-latest-xl
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Switch the manual-dispatch temper build workflow from the self-hosted runner to `ubuntu-latest-xl` (8 cores, free for public repos). Both `ubuntu-latest` (2 cores) and `srv-unraid-gha` took 40-90+ minutes to compile temper. The XL runner should finish in ~10 minutes.

## Test plan

- [ ] After merge: trigger Build · temper, verify completes on XL runner
- [ ] Verify release artifact published

Size: XS

## Out of scope

- PR workflow stays on ubuntu-latest (it downloads, doesn't compile)