### PR TITLE
fix(ci): ubuntu-latest + 6h timeout for temper build

### DIFF
--- a/.github/workflows/build.temper-binary.yml
+++ b/.github/workflows/build.temper-binary.yml
@@ -20,8 +20,8 @@ env:
 jobs:
   build-and-release:
     name: build temper + publish release
-    runs-on: ubuntu-latest-xl
-    timeout-minutes: 45
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

`ubuntu-latest-xl` isn't enabled for this repo (needs org settings). Switch back to `ubuntu-latest` with a 360-minute timeout. The 2-core runner takes ~45 min for a cold Rust build, but this is a one-time manual-dispatch workflow — once the release exists, every PR downloads the binary in 5 seconds.

## Test plan

- [ ] After merge: trigger Build · temper, let it finish, verify release created

Size: XS

## Out of scope

- Enabling larger runners (org admin settings required)