### PR TITLE
feat(web): add _headers to disable CDN caching of HTML

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,13 @@
+# Cloudflare Pages headers.
+# https://developers.cloudflare.com/pages/configuration/headers/
+#
+# HTML files must NOT be cached by the CDN — a stale HTML response served from
+# CF cache can point at JS/CSS bundles that were removed by the next deploy,
+# producing a "ghost route" 404 chain until the cache expires. Assets are
+# content-hashed (vite default) so they remain safe to cache aggressively.
+
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/
+  Cache-Control: public, max-age=0, must-revalidate


### PR DESCRIPTION
## Summary

Adds `web/public/_headers` so Cloudflare Pages stops caching HTML files with long TTLs. CF was returning stale `index.html` that pointed at JS/CSS bundles already removed by the next deploy, producing the ghost-route 404 chain. Asset files (`/assets/*`) keep their default long cache because vite content-hashes them.

## Test plan

- [ ] After deploy: `curl -sI https://grug.lol/` shows `Cache-Control: public, max-age=0, must-revalidate`
- [ ] `curl -sI https://grug.lol/assets/<hashed>.js` keeps long cache
- [ ] No regression in landing page load

## Out of scope

- CF cache purge step in deploy workflow (covered by #198)
- Post-deploy smoke test (covered by #197)

Size: XS

closes #196