### PR TITLE
feat(ci): add post-deploy smoke test for grug.lol

### DIFF
--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -162,3 +162,30 @@ jobs:
             --project-name grug-web \
             --branch "${GITHUB_REF_NAME}" \
             --commit-hash "${GITHUB_SHA}"
+
+      # Production smoke test — only runs for prod-eligible refs (main +
+      # version tags). Asserts that the deploy actually took effect by
+      # checking three load-bearing strings in the landing page response.
+      # Catches the "wrangler succeeded but CF cache served the previous
+      # build" failure mode and any URL-canon drift.
+      - name: 09. Smoke test grug.lol
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        run: |
+          set -euo pipefail
+          echo "Waiting 30s for Cloudflare Pages propagation..."
+          sleep 30
+          BODY=$(curl --fail --silent --show-error --location \
+            --max-time 15 --retry 3 --retry-delay 5 \
+            -A "grug-deploy-smoke/1.0" \
+            https://grug.lol/)
+          assert() {
+            if grep -Fq "$1" <<<"$BODY"; then
+              echo "✓ found: $1"
+            else
+              echo "::error::smoke test failed — landing page missing: $1"
+              exit 1
+            fi
+          }
+          assert 'href="/signin"'
+          assert 'grug-tribe'
+          echo "✓ grug.lol smoke test passed"


### PR DESCRIPTION
## Summary

After wrangler deploy succeeds, wait 30 seconds for CF Pages propagation then curl the landing page and assert that the canonical install link slug (`grug-tribe`) and the sign-in href (`/signin`) are present. Catches the failure mode where wrangler reports success but CF cache serves a stale landing, and any URL-canon drift in install links. Only runs on prod-eligible refs (`main` + version tags) so feature branches don't fight the prod URL.

## Test plan

- [ ] Next merge to main triggers smoke test
- [ ] Verify it passes on a healthy deploy
- [ ] Verify it fails loudly if the landing string disappears (manual: temporarily change the assertion to a string that doesn't exist)

## Out of scope

- Smoke testing dashboard / api endpoints (separate scope)
- Synthetic monitoring (covered by DD synthetics in Pulumi)

Size: S

closes #197