### PR TITLE
feat(ci): purge CF cache after deploy + document required token scopes

### DIFF
--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -163,12 +163,51 @@ jobs:
             --branch "${GITHUB_REF_NAME}" \
             --commit-hash "${GITHUB_SHA}"
 
+      # Purge CF edge cache so the new build is visible immediately, even
+      # if a path-rule somewhere keeps an HTML response cached. Asset
+      # files are content-hashed and unaffected by purge.
+      #
+      # Token must include `Zone:Cache Purge` scope. If purge returns 403
+      # (Authentication error), the operator needs to add the scope to
+      # `/grug/cloudflare-api-token` via the CF dashboard one-shot:
+      #   dashboard.cloudflare.com → My Profile → API Tokens →
+      #   edit the grug deploy token → add Zone:Cache Purge → save.
+      # The token VALUE doesn't change; no SSM update needed.
+      - name: 09. Purge Cloudflare cache
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        env:
+          CF_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          ZONE_ID=$(aws ssm get-parameter \
+            --name /grug/cloudflare-zone-id \
+            --query 'Parameter.Value' --output text)
+          response=$(curl --silent --show-error --max-time 15 \
+            -w "\n%{http_code}" \
+            -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}')
+          status=$(tail -n1 <<<"$response")
+          body=$(sed '$d' <<<"$response")
+          if [ "$status" = "200" ]; then
+            echo "✓ CF cache purged"
+          elif [ "$status" = "403" ]; then
+            echo "::error::CF cache purge returned 403 — token missing Zone:Cache Purge scope. Add it at dashboard.cloudflare.com → My Profile → API Tokens → edit the grug deploy token → add Zone:Cache Purge → save. Token value does NOT change; no SSM update needed."
+            echo "$body"
+            exit 1
+          else
+            echo "::error::CF cache purge returned HTTP $status"
+            echo "$body"
+            exit 1
+          fi
+
       # Production smoke test — only runs for prod-eligible refs (main +
       # version tags). Asserts that the deploy actually took effect by
       # checking three load-bearing strings in the landing page response.
       # Catches the "wrangler succeeded but CF cache served the previous
       # build" failure mode and any URL-canon drift.
-      - name: 09. Smoke test grug.lol
+      - name: 10. Smoke test grug.lol
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: |
           set -euo pipefail

--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -11,7 +11,9 @@
 #
 # Reads:
 #   - SSM `/grug/cloudflare-api-token`     (Zone:DNS:Edit + Workers
-#                                            Scripts:Edit + Workers Routes:Edit)
+#                                            Scripts:Edit + Workers Routes:Edit
+#                                            + Zone:Cache Purge + Account
+#                                            Settings:Read + User Memberships:Read)
 #   - SSM `/grug/cloudflare-account-id`
 #   - SSM `/grug/cloudflare-zone-id`
 #   - Pulumi stack output `webhook_function_url` (from `pulumi stack output`)

--- a/infra/cloudflare/pages-bootstrap.sh
+++ b/infra/cloudflare/pages-bootstrap.sh
@@ -58,6 +58,9 @@ except Exception:
     - Account → Workers Scripts → Edit
     - Account → Workers Routes → Edit
     - Account → Cloudflare Pages → Edit  ← easy to miss
+    - Zone → Cache Purge → Purge          ← easy to miss
+    - Account → Account Settings → Read
+    - User → Memberships → Read
 
   Fix:
     1. https://dash.cloudflare.com/profile/api-tokens


### PR DESCRIPTION
## Summary

Add a post-deploy cache purge step to `web.deploy.yml` and update the documented set of required CF API token scopes in `deploy.sh` + `pages-bootstrap.sh`. The purge ensures the new build is visible immediately even if a path rule keeps an HTML response cached. Asset files are content-hashed so they're unaffected by purge.

The token at `/grug/cloudflare-api-token` is manually created, not Pulumi-managed (Pulumi only reads it from SSM). Adding the `Zone:Cache Purge` scope is an HITL operator action via the CF dashboard.

## Test plan

- [ ] After merge: next deploy triggers purge step
- [ ] If token has scope → purge returns 200, smoke test sees fresh content
- [ ] If token missing scope → purge returns 403 with a clear actionable error message pointing operator to the dashboard
- [ ] Adding the scope does not change the token value, so no SSM update is needed

## Out of scope

- Migrating CF token to Pulumi management (separate work; Pulumi-managed CF tokens require Account API Token resource which has its own scope-set caveats)
- Selective purge by URL pattern (purge_everything is fine at this scale)

Size: S

closes #198