### PR TITLE
fix(ci): make CF cache purge step warn-only

### DIFF
--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -190,16 +190,18 @@ jobs:
             --data '{"purge_everything":true}')
           status=$(tail -n1 <<<"$response")
           body=$(sed '$d' <<<"$response")
+          # Warn-only: HTML is already uncached by web/public/_headers
+          # so a missing purge scope doesn't break the deploy. Surface
+          # the actionable HITL clearly when the scope IS missing so
+          # the operator can add it on their own schedule.
           if [ "$status" = "200" ]; then
             echo "✓ CF cache purged"
-          elif [ "$status" = "403" ]; then
-            echo "::error::CF cache purge returned 403 — token missing Zone:Cache Purge scope. Add it at dashboard.cloudflare.com → My Profile → API Tokens → edit the grug deploy token → add Zone:Cache Purge → save. Token value does NOT change; no SSM update needed."
+          elif [ "$status" = "401" ] || [ "$status" = "403" ]; then
+            echo "::warning::CF cache purge returned HTTP $status — token missing Zone:Cache Purge scope. Add it at dashboard.cloudflare.com → My Profile → API Tokens → edit the grug deploy token → add Zone:Cache Purge → save. Token value does NOT change; no SSM update needed. Deploy continues — HTML is no-cache via web/public/_headers."
             echo "$body"
-            exit 1
           else
-            echo "::error::CF cache purge returned HTTP $status"
+            echo "::warning::CF cache purge returned HTTP $status — non-auth failure, deploy continues."
             echo "$body"
-            exit 1
           fi
 
       # Production smoke test — only runs for prod-eligible refs (main +


### PR DESCRIPTION
## Summary

The strict-fail CF purge step from #198 is currently blocking every deploy because the API token lacks the \`Zone:Cache Purge\` scope (returns HTTP 401). Since \`web/public/_headers\` from #196 already disables HTML caching at the CDN layer, the purge is no longer correctness-critical — just defense-in-depth. Make the step warn-only so deploys go green while still surfacing the actionable HITL fix clearly in the workflow log.

Both 401 and 403 are now handled (the live token returned 401, not the 403 originally expected).

## Test plan

- [ ] After merge: next deploy completes successfully
- [ ] Workflow log shows the warning with the dashboard instructions
- [ ] Once the operator adds the scope, the warning silently turns into \`✓ CF cache purged\`

## Out of scope

- Forcing the operator to add the scope (separate manual action)
- Migrating CF token management to Pulumi

Size: XS