### PR TITLE
fix(tests): make conftest.py docstring sibling-aware

### DIFF
--- a/services/api/conftest.py
+++ b/services/api/conftest.py
@@ -1,4 +1,4 @@
-"""pytest config for services/webhook/ tests.
+"""pytest config for services/{api,webhook}/ tests.
 
 Adds the parent directory to sys.path so tests can `from hmac_verify
 import ...` without a package install (handler files live alongside the

--- a/services/webhook/conftest.py
+++ b/services/webhook/conftest.py
@@ -1,4 +1,4 @@
-"""pytest config for services/webhook/ tests.
+"""pytest config for services/{api,webhook}/ tests.
 
 Adds the parent directory to sys.path so tests can `from hmac_verify
 import ...` without a package install (handler files live alongside the


### PR DESCRIPTION
## Summary

\`services/api/conftest.py\` was misleadingly attributed to the webhook service after the mirror-discipline sweep (#138 + #139). Both copies now read \"pytest config for services/{api,webhook}/ tests.\" which is accurate for either copy and preserves the byte-identical mirror gate in \`scripts/check-mirrored-files.sh\`.

## Test plan

- [x] Both copies remain byte-identical (verified with \`diff\`)
- [x] Docstring no longer misattributes either copy
- [ ] CI drift-lint gate passes

## Out of scope

- Extracting conftest.py to a shared package (deferred per ADR-0001 rule-of-three)
- Adding a MIRRORED-from header (currently in MIRRORED_BYTE_IDENTICAL set — header optional)

Size: XS

closes #149