### PR TITLE
chore(ci): rename drift-lint.yml to check.drift-lint.yml

### DIFF
--- a/.github/workflows/check.drift-lint.yml
+++ b/.github/workflows/check.drift-lint.yml
@@ -13,7 +13,7 @@ on:
       - 'services/api/**'
       - 'services/webhook/**'
       - 'scripts/check-mirrored-files.sh'
-      - '.github/workflows/drift-lint.yml'
+      - '.github/workflows/check.drift-lint.yml'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/check.temper-specs.yml
+++ b/.github/workflows/check.temper-specs.yml
@@ -25,7 +25,7 @@ on:
       - 'services/**/github_app_auth/**'
       - 'services/**/dispatcher.py'
       - 'scripts/check-mirrored-files.sh'
-      - '.github/workflows/drift-lint.yml'
+      - '.github/workflows/check.drift-lint.yml'
       - 'web/public/**'
       - 'web/index.html'
       - 'web/app.html'

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -253,7 +253,7 @@ Webhook handler `receive_github_webhook` is **sync `def`**, NOT `async def`.
 Both Lambda services duplicate ~12 modules (adapters, ports, personas,
 github_app_auth, etc.) until the v1.5 shared-package extraction lands.
 
-`.github/workflows/drift-lint.yml` runs `scripts/check-mirrored-files.sh`
+`.github/workflows/check.drift-lint.yml` runs `scripts/check-mirrored-files.sh`
 on every PR touching either service. The script byte-compares each file
 in `MIRRORED_FILES` and fails with a clear diff when they diverge.
 

--- a/infra/scripts/attest_mirror_policy_consistency.py
+++ b/infra/scripts/attest_mirror_policy_consistency.py
@@ -10,7 +10,7 @@ Proves NECESSARY conditions for these bools:
 Asserts:
   1. `scripts/check-mirrored-files.sh` exists.
   2. It defines BOTH `MIRRORED_WITH_HEADER` and `MIRRORED_BYTE_IDENTICAL` arrays.
-  3. `.github/workflows/drift-lint.yml` exists and invokes the script.
+  3. `.github/workflows/check.drift-lint.yml` exists and invokes the script.
   4. Every file listed in `MIRRORED_WITH_HEADER` exists at both
      `services/api/<relpath>` AND `services/webhook/<relpath>`.
   5. Each of those files starts with the line-1 MIRRORED header pattern
@@ -24,7 +24,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts/check-mirrored-files.sh"
-DRIFT_LINT_WORKFLOW = REPO_ROOT / ".github/workflows/drift-lint.yml"
+DRIFT_LINT_WORKFLOW = REPO_ROOT / ".github/workflows/check.drift-lint.yml"
 
 _ARRAY_RE = re.compile(
     r"(?P<name>MIRRORED_WITH_HEADER|MIRRORED_BYTE_IDENTICAL)=\(\s*(?P<body>[^)]*)\)",

--- a/specs/0010-mirror-discipline/mirror-discipline.ioa.toml
+++ b/specs/0010-mirror-discipline/mirror-discipline.ioa.toml
@@ -92,7 +92,7 @@ effect = [
   { type = "set_bool", var = "drift_lint_runs_on_every_pr_per_cross_service_primitives", value = true },
   { type = "set_bool", var = "scripts_check_mirrored_files_sh_is_authoritative_list_per_cross_service_primitives", value = true },
 ]
-hint = "drift-lint workflow gates every PR via .github/workflows/drift-lint.yml. Script's MIRRORED_WITH_HEADER + MIRRORED_BYTE_IDENTICAL arrays are the authoritative source of truth."
+hint = "drift-lint workflow gates every PR via .github/workflows/check.drift-lint.yml. Script's MIRRORED_WITH_HEADER + MIRRORED_BYTE_IDENTICAL arrays are the authoritative source of truth."
 
 [[action]]
 name = "AttestExtractionContract"


### PR DESCRIPTION
## Summary

Rename \`.github/workflows/drift-lint.yml\` to \`.github/workflows/check.drift-lint.yml\` to conform to the repo's \`<verb>.<scope>.yml\` workflow naming convention. Updates all internal references:

- The workflow's own \`paths\` filter self-reference
- \`check.temper-specs.yml\` paths filter cross-ref
- \`infra/scripts/attest_mirror_policy_consistency.py\` (existence check + docstring)
- \`docs/RUNBOOK.md\` (mirror-discipline section)
- \`specs/0010-mirror-discipline/mirror-discipline.ioa.toml\` (hint text)

The mirror-policy attester still passes locally after the rename.

## Test plan

- [x] \`python3 infra/scripts/attest_mirror_policy_consistency.py\` passes
- [ ] CI temper-specs verify passes
- [ ] CI drift-lint check passes under new name

## Out of scope

- Renaming \`iac.deploy.yml\` and \`web.deploy.yml\` (borderline acceptable per the original issue)
- Pulse workflow renames (already removed)

Size: XS

closes #169