### PR TITLE
feat(infra): provision /grug/cf-shared-secret SSM + grant Lambda read

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -24,6 +24,7 @@ import pulumi_cloudflare as cloudflare
 import pulumi_datadog as _datadog
 
 from components import (
+    cf_shared_secret,
     cloudflare_dns,
     dd_monitors,
     dd_rum,
@@ -116,6 +117,14 @@ _iam_propagation_wait = _deploy_role_bundle.iam_propagation_wait
 grug_main_table = ddb_table.create("grug-main")
 grug_tokens_cmk = kms_cmk.create("grug-tokens")
 
+# CF→AWS auth boundary (issue #231 / parent #173). SSM SecureString
+# holding the shared secret CF Workers inject as X-Grug-CF-Secret. Both
+# Lambdas receive the param name as an env var and the IAM grant via
+# extra_ssm_secrets — middleware (sibling #233) reads at cold start. Safe
+# to deploy alone: until #232 + #233 land, the env var is loaded but
+# nothing validates against it. Production traffic unchanged.
+cf_secret = cf_shared_secret.create()
+
 # ECR repo for the webhook Lambda image. Lifecycle: untagged images expire
 # after 14 days (avoids ~$0.10/GB/mo image graveyard).
 webhook_ecr = ecr_repo.create(
@@ -145,7 +154,12 @@ webhook = lambda_service.create(
     ecr_repo=webhook_ecr,
     image_tag=webhook_image_tag,
     secrets=secrets,
-    extra_ssm_secrets=[_dd_api_key],
+    # The CF-shared-secret SSM param is a Pulumi-managed resource (not a
+    # pre-loaded GetParameterResult) but lambda_service only accesses
+    # `.arn` / `.name`, both of which the Parameter resource exposes
+    # directly. Duck-typed pass-through avoids a circular get_parameter
+    # lookup that would fail on the first `pulumi up`.
+    extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter],
     # NOTE: DD extension is BAKED into the Lambda container image
     # (services/webhook/Dockerfile.lambda copies from
     # public.ecr.aws/datadog/lambda-extension-arm:<v>). Lambda Container
@@ -163,6 +177,11 @@ webhook = lambda_service.create(
         # DDB allowlist gate (Slice 5 #26). Webhook reads INST# + USER#
         # rows directly (no KMS — token blobs are api-Lambda-only).
         "GRUG_DDB_TABLE": grug_main_table.name,
+        # CF→AWS auth boundary (issue #231 / parent #173). Middleware
+        # (sibling #233) reads this env var to locate the SSM param.
+        # Until sibling slices land, the env var is loaded but no path
+        # validates against it — safe rollout.
+        "GRUG_CF_SHARED_SECRET_SSM": cf_secret.ssm_parameter.name,
         # Datadog APM (datadog_lambda wrapper finds real handler via
         # DD_LAMBDA_HANDLER; layer adds the trace agent + log forwarder).
         "DD_LAMBDA_HANDLER": "lambda_handler.handler",
@@ -270,7 +289,9 @@ api_lambda = lambda_service.create(
     ecr_repo=api_ecr,
     image_tag=api_image_tag,
     secrets=secrets,
-    extra_ssm_secrets=[_dd_api_key],
+    # See webhook above for the cf_secret.ssm_parameter duck-typed
+    # pass-through rationale (issue #231 / parent #173).
+    extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter],
     env_vars={
         "GRUG_ENV": env,
         "GRUG_LOG_LEVEL": "INFO",
@@ -278,6 +299,8 @@ api_lambda = lambda_service.create(
         "GRUG_DOMAIN": domain,
         "GRUG_DDB_TABLE": grug_main_table.name,
         "GRUG_KMS_CMK_ARN": grug_tokens_cmk.arn,
+        # CF→AWS auth boundary — see webhook block above (issue #231).
+        "GRUG_CF_SHARED_SECRET_SSM": cf_secret.ssm_parameter.name,
         "GITHUB_APP_WEBHOOK_SECRET_SSM": secrets["github-app-webhook-secret"].name,
         # OAuth (Slice 3 #24 consumes)
         "GITHUB_APP_CLIENT_ID_SSM": secrets["github-app-client-id"].name,
@@ -470,3 +493,8 @@ pulumi.export("synthetic_uptime_id", monitors.uptime.id)
 # values live in SSM SecureStrings managed by the same component.
 pulumi.export("rum_application_id_ssm_name", rum.ssm_application_id.name)
 pulumi.export("rum_client_token_ssm_name", rum.ssm_client_token.name)
+
+# CF→AWS auth boundary (issue #231 / parent #173). Sibling slice #232
+# (infra/cloudflare/deploy.sh) reads this SSM param name and PUTs the
+# value as the GRUG_CF_SECRET binding on both host-rewrite Workers.
+pulumi.export("cf_shared_secret_ssm_name", cf_secret.ssm_parameter.name)

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -151,11 +151,12 @@ webhook = lambda_service.create(
     ecr_repo=webhook_ecr,
     image_tag=webhook_image_tag,
     secrets=secrets,
-    # cf_secret.ssm_parameter is `aws.ssm.Parameter` (Pulumi-managed
-    # resource) where the other entries are `GetParameterResult` (sync
-    # data lookups). Both expose `.arn` and `.name`, and the consuming
-    # IAM policy at lambda_service.py:104 already wraps the list in
-    # `Output.all(...).apply()`, so Output[str] arns resolve correctly.
+    # cf_secret.ssm_parameter is `aws.ssm.Parameter` (Pulumi resource)
+    # while the others are `GetParameterResult` (sync data lookup). Both
+    # expose `.arn` and `.name`, and the consuming IAM policy in
+    # lambda_service already wraps the arn list in `Output.all(...).apply()`,
+    # so Output[str] arns resolve correctly. Issue #235 tracks tightening
+    # the type contract via a structural Protocol.
     extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter],
     # NOTE: DD extension is BAKED into the Lambda container image
     # (services/webhook/Dockerfile.lambda copies from

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -117,12 +117,9 @@ _iam_propagation_wait = _deploy_role_bundle.iam_propagation_wait
 grug_main_table = ddb_table.create("grug-main")
 grug_tokens_cmk = kms_cmk.create("grug-tokens")
 
-# CF→AWS auth boundary (issue #231 / parent #173). SSM SecureString
-# holding the shared secret CF Workers inject as X-Grug-CF-Secret. Both
-# Lambdas receive the param name as an env var and the IAM grant via
-# extra_ssm_secrets — middleware (sibling #233) reads at cold start. Safe
-# to deploy alone: until #232 + #233 land, the env var is loaded but
-# nothing validates against it. Production traffic unchanged.
+# CF→AWS auth boundary (parent #173). Provisioned before the Lambdas so
+# both can receive the SSM param name via env var on first creation —
+# avoids a second `pulumi up` to wire the env var after the secret lands.
 cf_secret = cf_shared_secret.create()
 
 # ECR repo for the webhook Lambda image. Lifecycle: untagged images expire
@@ -154,11 +151,11 @@ webhook = lambda_service.create(
     ecr_repo=webhook_ecr,
     image_tag=webhook_image_tag,
     secrets=secrets,
-    # The CF-shared-secret SSM param is a Pulumi-managed resource (not a
-    # pre-loaded GetParameterResult) but lambda_service only accesses
-    # `.arn` / `.name`, both of which the Parameter resource exposes
-    # directly. Duck-typed pass-through avoids a circular get_parameter
-    # lookup that would fail on the first `pulumi up`.
+    # cf_secret.ssm_parameter is `aws.ssm.Parameter` (Pulumi-managed
+    # resource) where the other entries are `GetParameterResult` (sync
+    # data lookups). Both expose `.arn` and `.name`, and the consuming
+    # IAM policy at lambda_service.py:104 already wraps the list in
+    # `Output.all(...).apply()`, so Output[str] arns resolve correctly.
     extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter],
     # NOTE: DD extension is BAKED into the Lambda container image
     # (services/webhook/Dockerfile.lambda copies from
@@ -177,10 +174,7 @@ webhook = lambda_service.create(
         # DDB allowlist gate (Slice 5 #26). Webhook reads INST# + USER#
         # rows directly (no KMS — token blobs are api-Lambda-only).
         "GRUG_DDB_TABLE": grug_main_table.name,
-        # CF→AWS auth boundary (issue #231 / parent #173). Middleware
-        # (sibling #233) reads this env var to locate the SSM param.
-        # Until sibling slices land, the env var is loaded but no path
-        # validates against it — safe rollout.
+        # CF→AWS auth boundary — middleware reads at cold start (#173).
         "GRUG_CF_SHARED_SECRET_SSM": cf_secret.ssm_parameter.name,
         # Datadog APM (datadog_lambda wrapper finds real handler via
         # DD_LAMBDA_HANDLER; layer adds the trace agent + log forwarder).
@@ -289,8 +283,6 @@ api_lambda = lambda_service.create(
     ecr_repo=api_ecr,
     image_tag=api_image_tag,
     secrets=secrets,
-    # See webhook above for the cf_secret.ssm_parameter duck-typed
-    # pass-through rationale (issue #231 / parent #173).
     extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter],
     env_vars={
         "GRUG_ENV": env,
@@ -299,7 +291,6 @@ api_lambda = lambda_service.create(
         "GRUG_DOMAIN": domain,
         "GRUG_DDB_TABLE": grug_main_table.name,
         "GRUG_KMS_CMK_ARN": grug_tokens_cmk.arn,
-        # CF→AWS auth boundary — see webhook block above (issue #231).
         "GRUG_CF_SHARED_SECRET_SSM": cf_secret.ssm_parameter.name,
         "GITHUB_APP_WEBHOOK_SECRET_SSM": secrets["github-app-webhook-secret"].name,
         # OAuth (Slice 3 #24 consumes)

--- a/infra/pulumi/components/cf_shared_secret.py
+++ b/infra/pulumi/components/cf_shared_secret.py
@@ -1,20 +1,10 @@
-"""Cloudflare → AWS shared-secret provisioning (per spec 0014 / issue #173).
+"""Cloudflare → AWS shared-secret provisioning (parent #173).
 
-Provisions the random secret value the CF Worker injects on every upstream
-request and the Lambda middleware validates at the handler entry. Sourcing
-both sides from the same SSM SecureString makes the rotation story trivial:
-bump `keepers["version"]` and run `pulumi up`, then re-run
-`infra/cloudflare/deploy.sh` to sync the new value into the CF Worker
-secret bindings.
-
-Acceptance criteria gate (issue #231):
-  * SecureString param exists at `/grug/cf-shared-secret`
-  * Value is 64 lowercase alphanumeric chars (random.RandomPassword)
-  * Lambda IAM grant via the existing lambda_service.extra_ssm_secrets path
-
-The Lambda middleware is sibling work (#233); the CF Worker injection is
-sibling work (#232). This component is safe to deploy alone — until #233
-ships, the env var is loaded but no path validates against it.
+Generates a random SSM SecureString that both the CF Worker (sibling
+slice #232) and the Lambda middleware (sibling slice #233) consume.
+Sourcing both sides from one SSM param means rotation = bump
+`keepers["version"]` then `pulumi up` + re-run
+`infra/cloudflare/deploy.sh`.
 """
 from __future__ import annotations
 
@@ -27,16 +17,10 @@ import pulumi_random as random
 
 @dataclass
 class CfSharedSecretBundle:
-    """Outputs from `cf_shared_secret.create()`.
-
-    `ssm_parameter` is the SSM SecureString resource — its `.arn` and
-    `.name` are duck-compatible with the `GetParameterResult` shape used
-    by lambda_service.extra_ssm_secrets, so the caller can pass it
-    directly into both Lambda definitions.
-
-    `secret_value` is the raw random string, marked secret. Surfaced so
-    the deploy.sh flow can publish it as a CF Worker secret binding via
-    the Pulumi → SSM → deploy.sh chain (sibling slice #232).
+    """`ssm_parameter` duck-types as `GetParameterResult` for
+    lambda_service.extra_ssm_secrets (both expose `.arn` + `.name`).
+    `secret_value` is the raw random string, marked secret — surfaced so
+    sibling slice #232's deploy.sh can publish it as a CF Worker binding.
     """
     ssm_parameter: aws.ssm.Parameter
     secret_value: pulumi.Output[str]
@@ -44,18 +28,15 @@ class CfSharedSecretBundle:
 
 def create(*, name: str = "grug-cf-shared-secret") -> CfSharedSecretBundle:
     """Provision the SSM SecureString backing the CF→AWS auth boundary."""
-    # 64-char lowercase alphanumeric. ~380 bits of entropy — overkill for
-    # a constant-time header compare but cheap. Excluding upper + special
-    # keeps the value safe to inline in CF Worker secret binding HTTP
-    # bodies and round-trip through SSM without any escaping concerns.
+    # Excluding upper + special keeps the value round-trippable through
+    # SSM + CF Worker secret-binding HTTP bodies without escaping.
     random_value = random.RandomPassword(
         f"{name}-value",
         length=64,
         special=False,
         upper=False,
-        # Rotate by bumping `version` and `pulumi up` — random provider
-        # replaces the resource. We don't rotate on every up; only when
-        # an operator deliberately retires the value.
+        # Bump version + pulumi up = the random provider replaces the
+        # resource. Without `keepers`, every up would re-roll the value.
         keepers={"version": "v1"},
     )
 
@@ -63,10 +44,9 @@ def create(*, name: str = "grug-cf-shared-secret") -> CfSharedSecretBundle:
         f"{name}-ssm",
         name="/grug/cf-shared-secret",
         type="SecureString",
-        # Output.secret-wrap so the value never appears in `pulumi preview`
-        # diffs. The random provider's `.result` is already marked secret
-        # but the extra wrap is defense-in-depth per the leak-guard memory
-        # from PR #164's RUM credentials rollout.
+        # Defense-in-depth re-wrap. RandomPassword.result is already
+        # secret-marked but the explicit wrap survived a leak incident
+        # on PR #164's RUM credentials rollout (preview output drift).
         value=pulumi.Output.secret(random_value.result),
         description=(
             "CF→AWS auth-boundary shared secret. CF Workers inject the "

--- a/infra/pulumi/components/cf_shared_secret.py
+++ b/infra/pulumi/components/cf_shared_secret.py
@@ -5,6 +5,12 @@ slice #232) and the Lambda middleware (sibling slice #233) consume.
 Sourcing both sides from one SSM param means rotation = bump
 `keepers["version"]` then `pulumi up` + re-run
 `infra/cloudflare/deploy.sh`.
+
+**Rotation ordering trap:** `pulumi up` updates the SSM value
+immediately. Lambdas re-read at next cold start (often within seconds
+of a deploy). The CF Worker binding only updates when deploy.sh runs.
+Run deploy.sh BEFORE forcing a Lambda cold-start to avoid a 401 window.
+Sibling slice #233 documents the full runbook.
 """
 from __future__ import annotations
 

--- a/infra/pulumi/components/cf_shared_secret.py
+++ b/infra/pulumi/components/cf_shared_secret.py
@@ -1,0 +1,87 @@
+"""Cloudflare → AWS shared-secret provisioning (per spec 0014 / issue #173).
+
+Provisions the random secret value the CF Worker injects on every upstream
+request and the Lambda middleware validates at the handler entry. Sourcing
+both sides from the same SSM SecureString makes the rotation story trivial:
+bump `keepers["version"]` and run `pulumi up`, then re-run
+`infra/cloudflare/deploy.sh` to sync the new value into the CF Worker
+secret bindings.
+
+Acceptance criteria gate (issue #231):
+  * SecureString param exists at `/grug/cf-shared-secret`
+  * Value is 64 lowercase alphanumeric chars (random.RandomPassword)
+  * Lambda IAM grant via the existing lambda_service.extra_ssm_secrets path
+
+The Lambda middleware is sibling work (#233); the CF Worker injection is
+sibling work (#232). This component is safe to deploy alone — until #233
+ships, the env var is loaded but no path validates against it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_aws as aws
+import pulumi_random as random
+
+
+@dataclass
+class CfSharedSecretBundle:
+    """Outputs from `cf_shared_secret.create()`.
+
+    `ssm_parameter` is the SSM SecureString resource — its `.arn` and
+    `.name` are duck-compatible with the `GetParameterResult` shape used
+    by lambda_service.extra_ssm_secrets, so the caller can pass it
+    directly into both Lambda definitions.
+
+    `secret_value` is the raw random string, marked secret. Surfaced so
+    the deploy.sh flow can publish it as a CF Worker secret binding via
+    the Pulumi → SSM → deploy.sh chain (sibling slice #232).
+    """
+    ssm_parameter: aws.ssm.Parameter
+    secret_value: pulumi.Output[str]
+
+
+def create(*, name: str = "grug-cf-shared-secret") -> CfSharedSecretBundle:
+    """Provision the SSM SecureString backing the CF→AWS auth boundary."""
+    # 64-char lowercase alphanumeric. ~380 bits of entropy — overkill for
+    # a constant-time header compare but cheap. Excluding upper + special
+    # keeps the value safe to inline in CF Worker secret binding HTTP
+    # bodies and round-trip through SSM without any escaping concerns.
+    random_value = random.RandomPassword(
+        f"{name}-value",
+        length=64,
+        special=False,
+        upper=False,
+        # Rotate by bumping `version` and `pulumi up` — random provider
+        # replaces the resource. We don't rotate on every up; only when
+        # an operator deliberately retires the value.
+        keepers={"version": "v1"},
+    )
+
+    param = aws.ssm.Parameter(
+        f"{name}-ssm",
+        name="/grug/cf-shared-secret",
+        type="SecureString",
+        # Output.secret-wrap so the value never appears in `pulumi preview`
+        # diffs. The random provider's `.result` is already marked secret
+        # but the extra wrap is defense-in-depth per the leak-guard memory
+        # from PR #164's RUM credentials rollout.
+        value=pulumi.Output.secret(random_value.result),
+        description=(
+            "CF→AWS auth-boundary shared secret. CF Workers inject the "
+            "value as X-Grug-CF-Secret; both Lambdas validate it via "
+            "middleware. Rotation: bump RandomPassword.keepers.version, "
+            "pulumi up, then re-run infra/cloudflare/deploy.sh."
+        ),
+        tags={
+            "managed_by": "pulumi",
+            "scope": "grug",
+            "purpose": "cf-auth-boundary",
+        },
+    )
+
+    return CfSharedSecretBundle(
+        ssm_parameter=param,
+        secret_value=random_value.result,
+    )

--- a/infra/pulumi/components/cf_shared_secret.py
+++ b/infra/pulumi/components/cf_shared_secret.py
@@ -21,7 +21,7 @@ import pulumi_aws as aws
 import pulumi_random as random
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class CfSharedSecretBundle:
     """`ssm_parameter` duck-types as `GetParameterResult` for
     lambda_service.extra_ssm_secrets (both expose `.arn` + `.name`).
@@ -50,9 +50,9 @@ def create(*, name: str = "grug-cf-shared-secret") -> CfSharedSecretBundle:
         f"{name}-ssm",
         name="/grug/cf-shared-secret",
         type="SecureString",
-        # Defense-in-depth re-wrap. RandomPassword.result is already
-        # secret-marked but the explicit wrap survived a leak incident
-        # on PR #164's RUM credentials rollout (preview output drift).
+        # Explicit Output.secret wrap guarantees secret-marking on the
+        # Parameter value even if a future provider version drops the
+        # marker from RandomPassword.result.
         value=pulumi.Output.secret(random_value.result),
         description=(
             "CF→AWS auth-boundary shared secret. CF Workers inject the "

--- a/infra/pulumi/pyproject.toml
+++ b/infra/pulumi/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pulumi-aws>=6.50.0,<7.0.0",
     "pulumi-cloudflare>=5.0.0,<6.0.0",
     "pulumi-datadog>=5.0.0,<6.0.0",
+    "pulumi-random>=4.0.0,<5.0.0",
     "pulumiverse-time>=0.1.1",
 ]
 


### PR DESCRIPTION
## Summary

First sub-slice of the CF→AWS auth-boundary epic (parent #173, sub-slice #231). Provisions the random secret value the upcoming CF Worker (sibling #232) will inject as \`X-Grug-CF-Secret\` and the upcoming Lambda middleware (sibling #233) will validate. Adds a new \`components/cf_shared_secret.py\` Pulumi component that creates an SSM SecureString at \`/grug/cf-shared-secret\` backed by a 64-char lowercase alphanumeric \`random.RandomPassword\`, then wires the param into both Lambdas (IAM grant + \`GRUG_CF_SHARED_SECRET_SSM\` env var) and exports the SSM name as a stack output so the sibling deploy.sh slice can locate it.

Safe to deploy alone — until siblings land, the env var is loaded but no path validates against it. Production traffic unchanged on rollout.

## Test plan

- [ ] \`pulumi preview\` clean on \`dev\` stack — shows one new SSM Parameter + one new RandomPassword + two Lambda env-var diffs
- [ ] After \`pulumi up\`: \`aws ssm get-parameter --name /grug/cf-shared-secret --with-decryption\` returns 64-char alphanumeric value
- [ ] Both Lambda execution roles include \`ssm:GetParameter\` on the new param ARN (verify via \`aws iam get-role-policy\`)
- [ ] Both Lambda configurations include \`GRUG_CF_SHARED_SECRET_SSM=/grug/cf-shared-secret\` env var
- [ ] Stack output \`cf_shared_secret_ssm_name\` returns \`/grug/cf-shared-secret\`

## Out of scope

- CF Worker header injection — sibling slice #232
- Service middleware validation + spec 0014 + attester — sibling slice #233
- DD monitor for 401 rate — covered by sibling #233
- Rotation procedure documentation — defer to RUNBOOK update when middleware lands

## HITL post-merge

- Operator runs \`pulumi up\` on the \`dev\` stack to apply
- No CF or service changes yet, no traffic impact

Size: S

closes #231