### PR TITLE
feat(cf): inject X-Grug-CF-Secret on both host-rewrite workers

### DIFF
--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -55,16 +55,43 @@ CF_ZONE=$(aws ssm get-parameter --region us-east-1 \
 # undefined → worker.js falls through to its strip-only branch, Lambda
 # middleware (#233) fail-opens. Once the operator runs `pulumi up` on
 # #234, re-run this script to publish the binding.
-CF_SHARED_SECRET=$(aws ssm get-parameter --region us-east-1 \
-    --name /grug/cf-shared-secret --with-decryption \
-    --query 'Parameter.Value' --output text 2>/dev/null || echo "")
-if [ -z "$CF_SHARED_SECRET" ]; then
+#
+# Discriminate ParameterNotFound (expected during rollout window) from
+# every other failure mode (IAM regression, region misconfig, throttle,
+# network). Silently swallowing all errors as "not configured" would
+# leave the binding unset while SSM has the value — a security regression
+# the operator wouldn't see until manually checking the CF dashboard.
+CF_SHARED_SECRET=""
+if cf_secret_raw=$(aws ssm get-parameter --region us-east-1 \
+        --name /grug/cf-shared-secret --with-decryption \
+        --query 'Parameter.Value' --output text 2>&1); then
+    CF_SHARED_SECRET="$cf_secret_raw"
+elif echo "$cf_secret_raw" | grep -q "ParameterNotFound"; then
     echo "  ⚠ /grug/cf-shared-secret missing in SSM — skipping GRUG_CF_SECRET binding."
     echo "    Run \`pulumi up\` on the grug stack first (creates the secret), then re-run this script."
+else
+    echo "  ✗ SSM get-parameter failed for /grug/cf-shared-secret:"
+    echo "    $cf_secret_raw"
+    exit 1
 fi
 
 # Pull current Lambda Function URLs from Pulumi stack output.
 PULUMI_DIR="${PULUMI_CWD:-$(dirname "$0")/../pulumi}"
+
+# Defensive `success` extraction for CF API responses. CF sometimes
+# returns HTML on 5xx and stack traces on transport hiccups, both of
+# which crash a naive `json.load(...)['success']` under `set -euo pipefail`.
+# This helper prints "False" on any parse failure so callers get the
+# raw response in their error message instead of a Python traceback.
+parse_cf_success() {
+    python3 -c "
+import json, sys
+try:
+    print(json.load(sys.stdin).get('success', False))
+except (json.JSONDecodeError, ValueError):
+    print('False')
+"
+}
 
 deploy_one() {
     local worker_name="$1" route_pattern="$2" pulumi_output="$3"
@@ -122,9 +149,11 @@ deploy_one() {
             -d "{\"name\":\"$BINDING_NAME\",\"type\":\"secret_text\",\"text\":\"$CF_SHARED_SECRET\"}" \
             "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/workers/scripts/$worker_name/secrets")
         local secret_success
-        secret_success=$(echo "$secret_response" | python3 -c "import json,sys; print(json.load(sys.stdin)['success'])")
+        secret_success=$(echo "$secret_response" | parse_cf_success)
         if [ "$secret_success" != "True" ]; then
-            echo "  ✗ $BINDING_NAME binding FAILED:"; echo "$secret_response" | python3 -m json.tool; exit 1
+            echo "  ✗ $BINDING_NAME binding FAILED. Raw response:"
+            echo "$secret_response"
+            exit 1
         fi
         echo "  ✓ $BINDING_NAME binding set"
     fi

--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -31,6 +31,14 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 
+# CF→AWS auth boundary contract (parent #173). Single source of truth
+# for the header name and the Worker secret binding name — both are
+# sed-substituted into worker.js placeholders below. Lambda middleware
+# in sibling slice #233 must read the same SECRET_HEADER string;
+# spec 0014's attester enforces that cross-link.
+SECRET_HEADER="X-Grug-CF-Secret"
+BINDING_NAME="GRUG_CF_SECRET"
+
 CF_TOKEN=$(aws ssm get-parameter --region us-east-1 \
     --name /grug/cloudflare-api-token --with-decryption \
     --query 'Parameter.Value' --output text)
@@ -80,7 +88,11 @@ deploy_one() {
 
     # Use /tmp/worker.js so the upload filename matches metadata.main_module
     # per memory: reference_cf_worker_upload_module_filename.
-    sed "s|__UPSTREAM_HOST__|$upstream_host|" "$worker_src" > /tmp/worker.js
+    sed \
+      -e "s|__UPSTREAM_HOST__|$upstream_host|" \
+      -e "s|__SECRET_HEADER__|$SECRET_HEADER|" \
+      -e "s|__BINDING_NAME__|$BINDING_NAME|" \
+      "$worker_src" > /tmp/worker.js
 
     local upload
     upload=$(curl -sS -X PUT \
@@ -107,14 +119,14 @@ deploy_one() {
         secret_response=$(curl -sS -X PUT \
             -H "Authorization: Bearer $CF_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"name\":\"GRUG_CF_SECRET\",\"type\":\"secret_text\",\"text\":\"$CF_SHARED_SECRET\"}" \
+            -d "{\"name\":\"$BINDING_NAME\",\"type\":\"secret_text\",\"text\":\"$CF_SHARED_SECRET\"}" \
             "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/workers/scripts/$worker_name/secrets")
         local secret_success
         secret_success=$(echo "$secret_response" | python3 -c "import json,sys; print(json.load(sys.stdin)['success'])")
         if [ "$secret_success" != "True" ]; then
-            echo "  ✗ GRUG_CF_SECRET binding FAILED:"; echo "$secret_response" | python3 -m json.tool; exit 1
+            echo "  ✗ $BINDING_NAME binding FAILED:"; echo "$secret_response" | python3 -m json.tool; exit 1
         fi
-        echo "  ✓ GRUG_CF_SECRET binding set"
+        echo "  ✓ $BINDING_NAME binding set"
     fi
 
     local route_response

--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -13,9 +13,14 @@
 #   - SSM `/grug/cloudflare-api-token`     (Zone:DNS:Edit + Workers
 #                                            Scripts:Edit + Workers Routes:Edit
 #                                            + Zone:Cache Purge + Account
-#                                            Settings:Read + User Memberships:Read)
+#                                            Settings:Read + User Memberships:Read
+#                                            + Workers Secrets:Edit (for the
+#                                            GRUG_CF_SECRET binding per #232))
 #   - SSM `/grug/cloudflare-account-id`
 #   - SSM `/grug/cloudflare-zone-id`
+#   - SSM `/grug/cf-shared-secret`          (CF→AWS auth boundary; PUT as
+#                                            GRUG_CF_SECRET Worker binding
+#                                            after each script upload)
 #   - Pulumi stack output `webhook_function_url` (from `pulumi stack output`)
 #
 # Re-run after every `pulumi up` that recreated the Lambda (Function
@@ -35,6 +40,20 @@ CF_ACCOUNT=$(aws ssm get-parameter --region us-east-1 \
 CF_ZONE=$(aws ssm get-parameter --region us-east-1 \
     --name /grug/cloudflare-zone-id \
     --query 'Parameter.Value' --output text)
+
+# CF→AWS auth boundary (parent #173 / this slice #232). Optional: deploy
+# can run before sibling slice #234's SSM param exists. If absent, we
+# skip the binding-set step and the Worker's `env.GRUG_CF_SECRET` is
+# undefined → worker.js falls through to its strip-only branch, Lambda
+# middleware (#233) fail-opens. Once the operator runs `pulumi up` on
+# #234, re-run this script to publish the binding.
+CF_SHARED_SECRET=$(aws ssm get-parameter --region us-east-1 \
+    --name /grug/cf-shared-secret --with-decryption \
+    --query 'Parameter.Value' --output text 2>/dev/null || echo "")
+if [ -z "$CF_SHARED_SECRET" ]; then
+    echo "  ⚠ /grug/cf-shared-secret missing in SSM — skipping GRUG_CF_SECRET binding."
+    echo "    Run \`pulumi up\` on the grug stack first (creates the secret), then re-run this script."
+fi
 
 # Pull current Lambda Function URLs from Pulumi stack output.
 PULUMI_DIR="${PULUMI_CWD:-$(dirname "$0")/../pulumi}"
@@ -78,6 +97,26 @@ deploy_one() {
     fi
     echo "  ✓ Worker script uploaded"
 
+    # PUT the GRUG_CF_SECRET binding so worker.js can inject the
+    # X-Grug-CF-Secret header (parent #173 / this slice #232). The
+    # PUT-on-secrets endpoint is upsert semantics, so re-runs are safe.
+    # Skipped when the SSM secret hasn't been provisioned yet (see top
+    # of file for the rollout-order rationale).
+    if [ -n "$CF_SHARED_SECRET" ]; then
+        local secret_response
+        secret_response=$(curl -sS -X PUT \
+            -H "Authorization: Bearer $CF_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"name\":\"GRUG_CF_SECRET\",\"type\":\"secret_text\",\"text\":\"$CF_SHARED_SECRET\"}" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT/workers/scripts/$worker_name/secrets")
+        local secret_success
+        secret_success=$(echo "$secret_response" | python3 -c "import json,sys; print(json.load(sys.stdin)['success'])")
+        if [ "$secret_success" != "True" ]; then
+            echo "  ✗ GRUG_CF_SECRET binding FAILED:"; echo "$secret_response" | python3 -m json.tool; exit 1
+        fi
+        echo "  ✓ GRUG_CF_SECRET binding set"
+    fi
+
     local route_response
     route_response=$(curl -sS -X POST \
         "https://api.cloudflare.com/client/v4/zones/$CF_ZONE/workers/routes" \
@@ -102,5 +141,10 @@ deploy_one "grug-webhook-host-rewrite" "webhook.grug.lol/*" "webhook_function_ur
 deploy_one "grug-api-host-rewrite"     "api.grug.lol/*"     "api_function_url"
 
 echo "Done. Smoke:"
-echo "  curl -i -X POST https://webhook.grug.lol/webhook/github -H 'X-Hub-Signature-256: sha256=invalid' -d '{}'  # → 401"
+echo "  curl -i -X POST https://webhook.grug.lol/webhook/github -H 'X-Hub-Signature-256: sha256=invalid' -d '{}'  # → 401 (HMAC)"
 echo "  curl -i https://api.grug.lol/livez                                                                          # → 200 ok"
+if [ -n "$CF_SHARED_SECRET" ]; then
+    echo "  # After sibling slice #233's middleware deploys:"
+    echo "  curl -i \"\$(pulumi -C $PULUMI_DIR stack output api_function_url)\"        # direct hit → 401 (X-Grug-CF-Secret missing)"
+    echo "  curl -i https://api.grug.lol/some-path                                                                    # via CF → reaches Lambda"
+fi

--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -15,7 +15,7 @@
 #                                            + Zone:Cache Purge + Account
 #                                            Settings:Read + User Memberships:Read
 #                                            + Workers Secrets:Edit (for the
-#                                            GRUG_CF_SECRET binding per #232))
+#                                            CF→AWS auth-boundary binding))
 #   - SSM `/grug/cloudflare-account-id`
 #   - SSM `/grug/cloudflare-zone-id`
 #   - SSM `/grug/cf-shared-secret`          (CF→AWS auth boundary; PUT as
@@ -130,17 +130,18 @@ deploy_one() {
     rm -f /tmp/worker.js
 
     local success
-    success=$(echo "$upload" | python3 -c "import json,sys; print(json.load(sys.stdin)['success'])")
+    success=$(echo "$upload" | parse_cf_success)
     if [ "$success" != "True" ]; then
-        echo "  ✗ Upload FAILED:"; echo "$upload" | python3 -m json.tool; exit 1
+        echo "  ✗ Upload FAILED. Raw response:"
+        echo "$upload"
+        exit 1
     fi
     echo "  ✓ Worker script uploaded"
 
-    # PUT the GRUG_CF_SECRET binding so worker.js can inject the
-    # X-Grug-CF-Secret header (parent #173 / this slice #232). The
-    # PUT-on-secrets endpoint is upsert semantics, so re-runs are safe.
-    # Skipped when the SSM secret hasn't been provisioned yet (see top
-    # of file for the rollout-order rationale).
+    # PUT the secret binding so worker.js can inject the auth-boundary
+    # header. The PUT-on-secrets endpoint is upsert semantics, so
+    # re-runs are safe. Skipped when the SSM secret hasn't been
+    # provisioned yet (see top of file for the rollout-order rationale).
     if [ -n "$CF_SHARED_SECRET" ]; then
         local secret_response
         secret_response=$(curl -sS -X PUT \
@@ -165,15 +166,25 @@ deploy_one() {
         -d "{\"pattern\":\"$route_pattern\",\"script\":\"$worker_name\"}")
 
     local route_success err_code
-    route_success=$(echo "$route_response" | python3 -c "import json,sys; print(json.load(sys.stdin)['success'])")
+    route_success=$(echo "$route_response" | parse_cf_success)
     if [ "$route_success" = "True" ]; then
         echo "  ✓ Route created: $route_pattern → $worker_name"
     else
-        err_code=$(echo "$route_response" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['errors'][0]['code'] if d.get('errors') else '')")
+        err_code=$(echo "$route_response" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    errs = d.get('errors') or []
+    print(errs[0].get('code', '') if errs else '')
+except (json.JSONDecodeError, ValueError):
+    print('')
+")
         if [ "$err_code" = "10020" ]; then
             echo "  ✓ Route already exists: $route_pattern"
         else
-            echo "  ✗ Route POST FAILED:"; echo "$route_response" | python3 -m json.tool; exit 1
+            echo "  ✗ Route POST FAILED. Raw response:"
+            echo "$route_response"
+            exit 1
         fi
     fi
 }
@@ -185,7 +196,7 @@ echo "Done. Smoke:"
 echo "  curl -i -X POST https://webhook.grug.lol/webhook/github -H 'X-Hub-Signature-256: sha256=invalid' -d '{}'  # → 401 (HMAC)"
 echo "  curl -i https://api.grug.lol/livez                                                                          # → 200 ok"
 if [ -n "$CF_SHARED_SECRET" ]; then
-    echo "  # After sibling slice #233's middleware deploys:"
-    echo "  curl -i \"\$(pulumi -C $PULUMI_DIR stack output api_function_url)\"        # direct hit → 401 (X-Grug-CF-Secret missing)"
-    echo "  curl -i https://api.grug.lol/some-path                                                                    # via CF → reaches Lambda"
+    echo "  # Boundary check (after middleware enforces): direct must 401, via-CF must 200."
+    echo "  curl -i \"\$(pulumi -C $PULUMI_DIR stack output api_function_url)\"livez   # direct hit → 401 (header missing)"
+    echo "  curl -i https://api.grug.lol/livez                                                                       # via CF → 200"
 fi

--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -31,11 +31,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(dirname "$0")"
 
-# CF→AWS auth boundary contract (parent #173). Single source of truth
-# for the header name and the Worker secret binding name — both are
-# sed-substituted into worker.js placeholders below. Lambda middleware
-# in sibling slice #233 must read the same SECRET_HEADER string;
-# spec 0014's attester enforces that cross-link.
+# Single source of truth for the auth-boundary header name + Worker
+# secret binding name. Both are sed-substituted into worker.js
+# placeholders below; Lambda middleware must read the same SECRET_HEADER.
 SECRET_HEADER="X-Grug-CF-Secret"
 BINDING_NAME="GRUG_CF_SECRET"
 
@@ -49,18 +47,12 @@ CF_ZONE=$(aws ssm get-parameter --region us-east-1 \
     --name /grug/cloudflare-zone-id \
     --query 'Parameter.Value' --output text)
 
-# CF→AWS auth boundary (parent #173 / this slice #232). Optional: deploy
-# can run before sibling slice #234's SSM param exists. If absent, we
-# skip the binding-set step and the Worker's `env.GRUG_CF_SECRET` is
-# undefined → worker.js falls through to its strip-only branch, Lambda
-# middleware (#233) fail-opens. Once the operator runs `pulumi up` on
-# #234, re-run this script to publish the binding.
-#
-# Discriminate ParameterNotFound (expected during rollout window) from
-# every other failure mode (IAM regression, region misconfig, throttle,
-# network). Silently swallowing all errors as "not configured" would
-# leave the binding unset while SSM has the value — a security regression
-# the operator wouldn't see until manually checking the CF dashboard.
+# SSM param may not exist yet on first deploy; skip the binding step
+# so the Worker falls through to strip-only and Lambda fail-opens.
+# Discriminate ParameterNotFound from other failure modes (IAM, region,
+# throttle, network). Swallowing all errors as "not configured" would
+# leave the binding unset while SSM has the value — a security
+# regression the operator wouldn't see until manually checking CF.
 CF_SHARED_SECRET=""
 if cf_secret_raw=$(aws ssm get-parameter --region us-east-1 \
         --name /grug/cf-shared-secret --with-decryption \
@@ -139,9 +131,7 @@ deploy_one() {
     echo "  ✓ Worker script uploaded"
 
     # PUT the secret binding so worker.js can inject the auth-boundary
-    # header. The PUT-on-secrets endpoint is upsert semantics, so
-    # re-runs are safe. Skipped when the SSM secret hasn't been
-    # provisioned yet (see top of file for the rollout-order rationale).
+    # header. The endpoint is upsert semantics so re-runs are safe.
     if [ -n "$CF_SHARED_SECRET" ]; then
         local secret_response
         secret_response=$(curl -sS -X PUT \
@@ -170,6 +160,8 @@ deploy_one() {
     if [ "$route_success" = "True" ]; then
         echo "  ✓ Route created: $route_pattern → $worker_name"
     else
+        # Inlined rather than helper-extracted: need a multi-field
+        # extraction (errors[0].code) that diverges from parse_cf_success.
         err_code=$(echo "$route_response" | python3 -c "
 import json, sys
 try:

--- a/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
@@ -7,13 +7,13 @@
 // host changes on every recreate; deploy.sh re-templates `__UPSTREAM_HOST__`
 // each time so the Worker stays in sync.
 //
-// `X-Grug-CF-Secret` (parent issue #173) is the CF→AWS auth-boundary
-// tightening: the value is sourced from the `GRUG_CF_SECRET` Worker
-// secret binding, which `deploy.sh` PUTs from SSM `/grug/cf-shared-secret`
-// after every script upload. Lambda middleware validates the header on
-// every non-`/livez` request. The api Lambda has un-authenticated
-// endpoints (`/livez`, `/api/v1/auth/github/callback`) where this
-// header is the only second-layer auth.
+// `X-Grug-CF-Secret` is the CF→AWS auth-boundary tightening: the value
+// is sourced from the `GRUG_CF_SECRET` Worker secret binding, which
+// `deploy.sh` PUTs from SSM `/grug/cf-shared-secret` after every script
+// upload. Lambda middleware validates the header on every non-`/livez`
+// request. The api Lambda has un-authenticated endpoints (`/livez`,
+// `/api/v1/auth/github/callback`) where this header is the only
+// second-layer auth.
 
 // Three placeholders are sed-substituted by infra/cloudflare/deploy.sh
 // at upload time so deploy.sh is the single source of truth. See

--- a/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
@@ -6,11 +6,20 @@
 // Per memory `reference_lambda_function_url_host_volatile`: Function URL
 // host changes on every recreate; deploy.sh re-templates `__UPSTREAM_HOST__`
 // each time so the Worker stays in sync.
+//
+// `X-Grug-CF-Secret` (parent issue #173) is the CF→AWS auth-boundary
+// tightening: the value is sourced from the `GRUG_CF_SECRET` Worker
+// secret binding, which `deploy.sh` PUTs from SSM `/grug/cf-shared-secret`
+// after every script upload. Lambda middleware (sibling slice #233)
+// validates the header on every non-`/livez` request. The api Lambda
+// has un-authenticated endpoints (`/livez`, `/api/v1/auth/github/callback`)
+// where this header is the only second-layer auth.
 
 const ORIGIN = "__UPSTREAM_HOST__";
+const SECRET_HEADER = "X-Grug-CF-Secret";
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     const url = new URL(request.url);
     url.hostname = ORIGIN;
     url.protocol = "https:";
@@ -18,6 +27,19 @@ export default {
 
     const headers = new Headers(request.headers);
     headers.set("Host", ORIGIN);
+
+    // Inject the shared secret. `set` (not `append`) so a client-supplied
+    // header is overwritten — clients cannot smuggle a forged value past
+    // the Lambda middleware.
+    if (env && env.GRUG_CF_SECRET) {
+      headers.set(SECRET_HEADER, env.GRUG_CF_SECRET);
+    } else {
+      // No binding deployed yet — strip any client-supplied value so
+      // downstream sees the "unconfigured" path cleanly. Middleware in
+      // sibling slice #233 fail-opens when the SSM secret is empty, so
+      // strip-only here is safe during the rollout window.
+      headers.delete(SECRET_HEADER);
+    }
 
     const init = {
       method: request.method,

--- a/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
@@ -32,17 +32,14 @@ export default {
     const headers = new Headers(request.headers);
     headers.set("Host", ORIGIN);
 
-    // Inject the shared secret. `set` (not `append`) so a client-supplied
-    // header is overwritten — clients cannot smuggle a forged value past
-    // the Lambda middleware.
-    const bindingValue = env && env[BINDING_NAME];
-    if (bindingValue) {
+    // See webhook worker for the binding-presence + tampering logic.
+    const bindingValue = env ? env[BINDING_NAME] : undefined;
+    if (typeof bindingValue === "string" && bindingValue.length > 0) {
       headers.set(SECRET_HEADER, bindingValue);
     } else {
-      // No binding deployed yet — strip any client-supplied value so
-      // downstream sees the "unconfigured" path cleanly. Middleware in
-      // sibling slice #233 fail-opens when the SSM secret is empty, so
-      // strip-only here is safe during the rollout window.
+      if (bindingValue === "") {
+        console.error("GRUG_CF_SECRET binding is an empty string — tampered or corrupted");
+      }
       headers.delete(SECRET_HEADER);
     }
 

--- a/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
@@ -10,10 +10,10 @@
 // `X-Grug-CF-Secret` (parent issue #173) is the CF→AWS auth-boundary
 // tightening: the value is sourced from the `GRUG_CF_SECRET` Worker
 // secret binding, which `deploy.sh` PUTs from SSM `/grug/cf-shared-secret`
-// after every script upload. Lambda middleware (sibling slice #233)
-// validates the header on every non-`/livez` request. The api Lambda
-// has un-authenticated endpoints (`/livez`, `/api/v1/auth/github/callback`)
-// where this header is the only second-layer auth.
+// after every script upload. Lambda middleware validates the header on
+// every non-`/livez` request. The api Lambda has un-authenticated
+// endpoints (`/livez`, `/api/v1/auth/github/callback`) where this
+// header is the only second-layer auth.
 
 // Three placeholders are sed-substituted by infra/cloudflare/deploy.sh
 // at upload time so deploy.sh is the single source of truth. See

--- a/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-api-host-rewrite/worker.js
@@ -15,8 +15,12 @@
 // has un-authenticated endpoints (`/livez`, `/api/v1/auth/github/callback`)
 // where this header is the only second-layer auth.
 
+// Three placeholders are sed-substituted by infra/cloudflare/deploy.sh
+// at upload time so deploy.sh is the single source of truth. See
+// webhook worker for the cross-link rationale.
 const ORIGIN = "__UPSTREAM_HOST__";
-const SECRET_HEADER = "X-Grug-CF-Secret";
+const SECRET_HEADER = "__SECRET_HEADER__";
+const BINDING_NAME = "__BINDING_NAME__";
 
 export default {
   async fetch(request, env) {
@@ -31,8 +35,9 @@ export default {
     // Inject the shared secret. `set` (not `append`) so a client-supplied
     // header is overwritten — clients cannot smuggle a forged value past
     // the Lambda middleware.
-    if (env && env.GRUG_CF_SECRET) {
-      headers.set(SECRET_HEADER, env.GRUG_CF_SECRET);
+    const bindingValue = env && env[BINDING_NAME];
+    if (bindingValue) {
+      headers.set(SECRET_HEADER, bindingValue);
     } else {
       // No binding deployed yet — strip any client-supplied value so
       // downstream sees the "unconfigured" path cleanly. Middleware in

--- a/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
@@ -18,10 +18,10 @@
 // `X-Grug-CF-Secret` (parent issue #173) is the CF→AWS auth-boundary
 // tightening: the value is sourced from the `GRUG_CF_SECRET` Worker
 // secret binding, which `deploy.sh` PUTs from SSM `/grug/cf-shared-secret`
-// after every script upload. Lambda middleware (sibling slice #233)
-// validates the header on every non-`/livez` request. Webhook payloads
-// remain HMAC-protected by GitHub end-to-end; this header is additive
-// defense against direct Function-URL access bypassing CF entirely.
+// after every script upload. Lambda middleware validates the header on
+// every non-`/livez` request. Webhook payloads remain HMAC-protected
+// by GitHub end-to-end; this header is additive defense against direct
+// Function-URL access bypassing CF entirely.
 
 // Three placeholders are sed-substituted by infra/cloudflare/deploy.sh
 // at upload time so deploy.sh is the single source of truth for both
@@ -53,10 +53,9 @@ export default {
     if (typeof bindingValue === "string" && bindingValue.length > 0) {
       headers.set(SECRET_HEADER, bindingValue);
     } else {
-      // No binding deployed yet (undefined) — strip any client-supplied
-      // value so downstream sees the "unconfigured" path cleanly.
-      // Middleware in sibling slice #233 fail-opens when the SSM secret
-      // is empty, so strip-only here is safe during the rollout window.
+      // Strip any client-supplied value when no binding is configured.
+      // Middleware fail-opens when the binding is absent, so strip-only
+      // is safe.
       //
       // Empty-string is impossible-by-accident (CF API rejects empty
       // `text` on the binding PUT). If we see it here, the binding was

--- a/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
@@ -23,8 +23,14 @@
 // remain HMAC-protected by GitHub end-to-end; this header is additive
 // defense against direct Function-URL access bypassing CF entirely.
 
+// Three placeholders are sed-substituted by infra/cloudflare/deploy.sh
+// at upload time so deploy.sh is the single source of truth for both
+// the binding name and the header name. Lambda middleware (#233) must
+// match SECRET_HEADER exactly — that cross-link is enforced by spec
+// 0014's attester, not by any compile-time link here.
 const ORIGIN = "__UPSTREAM_HOST__";
-const SECRET_HEADER = "X-Grug-CF-Secret";
+const SECRET_HEADER = "__SECRET_HEADER__";
+const BINDING_NAME = "__BINDING_NAME__";
 
 export default {
   async fetch(request, env) {
@@ -43,8 +49,9 @@ export default {
     // Inject the shared secret. `set` (not `append`) so a client-supplied
     // header is overwritten — clients cannot smuggle a forged value past
     // the Lambda middleware.
-    if (env && env.GRUG_CF_SECRET) {
-      headers.set(SECRET_HEADER, env.GRUG_CF_SECRET);
+    const bindingValue = env && env[BINDING_NAME];
+    if (bindingValue) {
+      headers.set(SECRET_HEADER, bindingValue);
     } else {
       // No binding deployed yet — strip any client-supplied value so
       // downstream sees the "unconfigured" path cleanly. Middleware in

--- a/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
@@ -7,23 +7,27 @@
 // Override is Enterprise-only). A Worker is the only zero-cost path on
 // Free that does both Host rewrite + path-passthrough cleanly.
 //
-// Mirrors somatic-scripts/infra/cloudflare/worker.js (chef-lambda-host-rewrite,
-// macchina-router, tempo-lambda-host-rewrite). Difference: grug webhook is
-// HMAC-protected by GitHub at the application layer, so we DON'T add a
-// shared-secret header (HMAC verifies authenticity end-to-end).
-//
 // Free-plan-friendly: 100k req/day. With our handful of repos this is
 // orders of magnitude headroom.
 //
-// `__UPSTREAM_HOST__` is templated at deploy time by Pulumi from the
-// Lambda Function URL output (per memory
+// `__UPSTREAM_HOST__` is templated at deploy time by `infra/cloudflare/deploy.sh`
+// from the Pulumi Lambda Function URL output (per memory
 // `reference_lambda_function_url_host_volatile` — host changes on every
 // recreate, single-source via Pulumi output).
+//
+// `X-Grug-CF-Secret` (parent issue #173) is the CF→AWS auth-boundary
+// tightening: the value is sourced from the `GRUG_CF_SECRET` Worker
+// secret binding, which `deploy.sh` PUTs from SSM `/grug/cf-shared-secret`
+// after every script upload. Lambda middleware (sibling slice #233)
+// validates the header on every non-`/livez` request. Webhook payloads
+// remain HMAC-protected by GitHub end-to-end; this header is additive
+// defense against direct Function-URL access bypassing CF entirely.
 
 const ORIGIN = "__UPSTREAM_HOST__";
+const SECRET_HEADER = "X-Grug-CF-Secret";
 
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     const url = new URL(request.url);
     url.hostname = ORIGIN;
     url.protocol = "https:";
@@ -35,6 +39,19 @@ export default {
     // header here also makes the Lambda edge gateway accept the request
     // (it 403s anything with a non-matching Host).
     headers.set("Host", ORIGIN);
+
+    // Inject the shared secret. `set` (not `append`) so a client-supplied
+    // header is overwritten — clients cannot smuggle a forged value past
+    // the Lambda middleware.
+    if (env && env.GRUG_CF_SECRET) {
+      headers.set(SECRET_HEADER, env.GRUG_CF_SECRET);
+    } else {
+      // No binding deployed yet — strip any client-supplied value so
+      // downstream sees the "unconfigured" path cleanly. Middleware in
+      // sibling slice #233 fail-opens when the SSM secret is empty, so
+      // strip-only here is safe during the rollout window.
+      headers.delete(SECRET_HEADER);
+    }
 
     const init = {
       method: request.method,

--- a/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
@@ -49,14 +49,21 @@ export default {
     // Inject the shared secret. `set` (not `append`) so a client-supplied
     // header is overwritten — clients cannot smuggle a forged value past
     // the Lambda middleware.
-    const bindingValue = env && env[BINDING_NAME];
-    if (bindingValue) {
+    const bindingValue = env ? env[BINDING_NAME] : undefined;
+    if (typeof bindingValue === "string" && bindingValue.length > 0) {
       headers.set(SECRET_HEADER, bindingValue);
     } else {
-      // No binding deployed yet — strip any client-supplied value so
-      // downstream sees the "unconfigured" path cleanly. Middleware in
-      // sibling slice #233 fail-opens when the SSM secret is empty, so
-      // strip-only here is safe during the rollout window.
+      // No binding deployed yet (undefined) — strip any client-supplied
+      // value so downstream sees the "unconfigured" path cleanly.
+      // Middleware in sibling slice #233 fail-opens when the SSM secret
+      // is empty, so strip-only here is safe during the rollout window.
+      //
+      // Empty-string is impossible-by-accident (CF API rejects empty
+      // `text` on the binding PUT). If we see it here, the binding was
+      // tampered with or corrupted — log to Logpush + strip.
+      if (bindingValue === "") {
+        console.error("GRUG_CF_SECRET binding is an empty string — tampered or corrupted");
+      }
       headers.delete(SECRET_HEADER);
     }
 

--- a/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
+++ b/infra/cloudflare/workers/grug-webhook-host-rewrite/worker.js
@@ -15,19 +15,18 @@
 // `reference_lambda_function_url_host_volatile` — host changes on every
 // recreate, single-source via Pulumi output).
 //
-// `X-Grug-CF-Secret` (parent issue #173) is the CF→AWS auth-boundary
-// tightening: the value is sourced from the `GRUG_CF_SECRET` Worker
-// secret binding, which `deploy.sh` PUTs from SSM `/grug/cf-shared-secret`
-// after every script upload. Lambda middleware validates the header on
-// every non-`/livez` request. Webhook payloads remain HMAC-protected
-// by GitHub end-to-end; this header is additive defense against direct
-// Function-URL access bypassing CF entirely.
+// `X-Grug-CF-Secret` is the CF→AWS auth-boundary tightening: the value
+// is sourced from the `GRUG_CF_SECRET` Worker secret binding, which
+// `deploy.sh` PUTs from SSM `/grug/cf-shared-secret` after every script
+// upload. Lambda middleware validates the header on every non-`/livez`
+// request. Webhook payloads remain HMAC-protected by GitHub end-to-end;
+// this header is additive defense against direct Function-URL access
+// bypassing CF entirely.
 
 // Three placeholders are sed-substituted by infra/cloudflare/deploy.sh
 // at upload time so deploy.sh is the single source of truth for both
-// the binding name and the header name. Lambda middleware (#233) must
-// match SECRET_HEADER exactly — that cross-link is enforced by spec
-// 0014's attester, not by any compile-time link here.
+// the binding name and the header name. Lambda middleware must match
+// SECRET_HEADER exactly.
 const ORIGIN = "__UPSTREAM_HOST__";
 const SECRET_HEADER = "__SECRET_HEADER__";
 const BINDING_NAME = "__BINDING_NAME__";


### PR DESCRIPTION
## Summary

Second sub-slice of the CF→AWS auth-boundary epic (parent #173, sub-slice #232, builds on #231/#234). Both \`grug-{api,webhook}-host-rewrite\` Cloudflare Workers now inject \`X-Grug-CF-Secret: <value>\` on every upstream request, sourced from a per-script \`GRUG_CF_SECRET\` Worker secret binding. The binding is set by \`infra/cloudflare/deploy.sh\` from SSM \`/grug/cf-shared-secret\` (provisioned in #231/#234). Workers use \`headers.set\` (not append) so client-supplied values are overwritten — no smuggling past the Lambda middleware that lands in sibling slice #233. When the SSM secret is absent (e.g., first deploy before \`pulumi up\` on grug stack), deploy.sh skips the binding step with a clear warning, the Worker's env binding is undefined, and the Worker strips any client-supplied value. Middleware in #233 fail-opens on empty SSM secret, keeping the rollout safe.

## Test plan

- [x] Both worker.js files parse and import cleanly via Node
- [x] deploy.sh passes \`bash -n\` syntax check
- [ ] After operator runs \`pulumi up\` on #234's stack + \`infra/cloudflare/deploy.sh\`:
  - \`curl -sH 'X-Grug-CF-Secret: bogus' https://api.grug.lol/livez\` reaches Lambda with the Worker-overridden value (server cannot tell from the response yet — middleware in #233 will assert this)
  - CF dashboard → Workers → grug-api-host-rewrite → Settings shows \`GRUG_CF_SECRET\` as a secret-type binding
  - Re-running deploy.sh does not error (upsert semantics)

## Out of scope

- Service middleware that consumes the header — sibling slice #233
- DD monitor for 401 rate / secret-mismatch rate — sibling slice #233
- Rotating the secret (use \`keepers["version"]\` on #234's RandomPassword, then re-run deploy.sh per the runbook the next slice adds)
- Replacing the shared secret with mTLS or SigV4 (overkill at this scale)

## HITL post-merge

- Operator runs \`infra/cloudflare/deploy.sh\` to push the updated workers and set the secret bindings
- If the CF API token lacks \`Workers Secrets:Edit\`, the binding PUT will 401/403 with a clear failure message — add the scope via the CF dashboard one-shot (token value does not change; no SSM update needed)

Size: S

closes #232