### PR TITLE
feat: LLM client abstraction (Poolside + OpenRouter round-robin)

### DIFF
--- a/docs/HITL_PREREQUISITES.md
+++ b/docs/HITL_PREREQUISITES.md
@@ -66,13 +66,20 @@ aws ssm put-parameter --region us-east-1 \
   --name /grug/openrouter-api-key \
   --type SecureString \
   --value "sk-or-v1-..."
+
+# Poolside API key — second backend for Elder persona round-robin
+# (installation_id % 2). Mint at https://poolside.ai/. Webhook Lambda only.
+aws ssm put-parameter --region us-east-1 \
+  --name /grug/poolside-api-key \
+  --type SecureString \
+  --value "<poolside-api-key>"
 ```
 
 Verify:
 
 ```bash
 aws ssm get-parameters-by-path --region us-east-1 --path /grug --recursive --query 'Parameters[].Name'
-# Expected: ["/grug/github-app-id", "/grug/github-app-private-key", "/grug/github-app-webhook-secret", "/grug/openrouter-api-key"]
+# Expected: ["/grug/github-app-id", "/grug/github-app-private-key", "/grug/github-app-webhook-secret", "/grug/openrouter-api-key", "/grug/poolside-api-key"]
 ```
 
 ## 4. Reserve the OIDC role for GitHub Actions deploy

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -95,6 +95,15 @@ _openrouter_api_key = aws.ssm.get_parameter(
     with_decryption=True,
 )
 
+# Poolside API key — same scoping rationale as OpenRouter (webhook-only).
+# The Elder persona round-robins via `installation_id % 2`; both keys
+# must be present for the round-robin to work without permanent fallback
+# to the other backend.
+_poolside_api_key = aws.ssm.get_parameter(
+    name="/grug/poolside-api-key",
+    with_decryption=True,
+)
+
 # DD extension version baked into the Lambda image (per Dockerfile.lambda).
 # Lambda Container package_type can't attach layers; extension binary is
 # COPYd from public.ecr.aws/datadog/lambda-extension-arm:<v>. Bump here
@@ -166,7 +175,7 @@ webhook = lambda_service.create(
     # lambda_service already wraps the arn list in `Output.all(...).apply()`,
     # so Output[str] arns resolve correctly. Issue #235 tracks tightening
     # the type contract via a structural Protocol.
-    extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter, _openrouter_api_key],
+    extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter, _openrouter_api_key, _poolside_api_key],
     # NOTE: DD extension is BAKED into the Lambda container image
     # (services/webhook/Dockerfile.lambda copies from
     # public.ecr.aws/datadog/lambda-extension-arm:<v>). Lambda Container
@@ -186,6 +195,7 @@ webhook = lambda_service.create(
         "GRUG_DDB_TABLE": grug_main_table.name,
         # Elder persona LLM client — webhook-only (api never calls LLMs).
         "GRUG_OPENROUTER_API_KEY_SSM": _openrouter_api_key.name,
+        "GRUG_POOLSIDE_API_KEY_SSM": _poolside_api_key.name,
         # CF→AWS auth boundary — middleware reads at cold start (#173).
         "GRUG_CF_SHARED_SECRET_SSM": cf_secret.ssm_parameter.name,
         # Datadog APM (datadog_lambda wrapper finds real handler via

--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -33,6 +33,7 @@ MIRRORED_WITH_HEADER=(
   "enforcement.py"
   "github_checks_client.py"
   "github_rulesets_client.py"
+  "llm_client.py"
   "observability.py"
   "personas/tpm/dor_checks.py"
   "ports/token_cache.py"

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -46,14 +46,15 @@ _OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
 
 _TIMEOUT_SECONDS = 30
 _RETRY_ATTEMPTS = 3
-# Backoff applies on attempts 0 and 1 only (attempt 2 either succeeds or
-# raises). Worst-case sleep per backend: 0.5s + 1.0s = 1.5s.
+# Exponential backoff applies on every attempt except the final one,
+# which either returns the response or raises.
 _RETRY_BASE_DELAY = 0.5
 
 # 429 (rate limit) + 503 (CF edge blip / temporary backend overload)
 # are routinely transient on both Poolside and OpenRouter. Other 5xx
-# (500, 502, 504) get one shot then fall back to the secondary backend
-# rather than burning retries on what may be a permanent issue.
+# (500, 502, 504) return immediately; review_diff then falls back to
+# the secondary backend rather than burning retries on what may be a
+# permanent issue.
 _RETRYABLE_STATUSES: frozenset[int] = frozenset((429, 503))
 
 

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -150,6 +150,10 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
         backend=Backend.POOLSIDE,
         url=_POOLSIDE_URL,
         model=_POOLSIDE_MODEL,
+        # Lambda (not bare ref) defers name lookup to call time so tests
+        # can `monkeypatch.setattr(lc, "_load_poolside_key", ...)`. With
+        # a bare reference, `_BACKEND_CONFIGS` captures the original
+        # function at import time and ignores the patch.
         key_loader=lambda: _load_poolside_key(),
     ),
     Backend.OPENROUTER: BackendConfig(

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -2,12 +2,15 @@
 """LLM client abstraction for the Code-Reviewer (Elder) persona.
 
 Sends review prompts to either Poolside (Laguna) or OpenRouter and
-returns a structured response. Backend selection is round-robin via
-`installation_id % 2` so traffic splits evenly across the two and DD
-LLM Obs can A/B prompt variants. If the primary backend errors hard
-(post-retry), the other backend is tried before surfacing an empty
-response — the caller posts an advisory check-run rather than 500ing
-the webhook handler on transient LLM failures.
+returns a structured response. Backend selection is stable per-install
+via `installation_id % 2`: two PRs on the same install always hit the
+same backend, which lets DD LLM Obs A/B-compare prompt variants without
+cross-install noise. Traffic distribution across the two backends
+depends on how installs are sized — it is NOT a true even split.
+If the primary backend errors hard (post-retry), the other backend is
+tried before surfacing an empty response — the caller posts an advisory
+check-run rather than 500ing the webhook handler on transient LLM
+failures.
 
 Both backends use the OpenAI-compatible chat-completions API so the
 request shape is identical. Only the base URL, auth header, and
@@ -27,7 +30,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, get_args
 
 import httpx
 
@@ -43,7 +46,9 @@ _OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
 
 _TIMEOUT_SECONDS = 30
 _RETRY_ATTEMPTS = 3
-_RETRY_BASE_DELAY = 0.5  # exponential: 0.5s, 1.0s, 2.0s
+# Backoff applies on attempts 0 and 1 only (attempt 2 either succeeds or
+# raises). Worst-case sleep per backend: 0.5s + 1.0s = 1.5s.
+_RETRY_BASE_DELAY = 0.5
 
 # 429 (rate limit) + 503 (CF edge blip / temporary backend overload)
 # are routinely transient on both Poolside and OpenRouter. Other 5xx
@@ -61,7 +66,10 @@ class Backend(str, Enum):
 
 
 Severity = Literal["low", "medium", "high", "critical"]
-_VALID_SEVERITIES: frozenset[str] = frozenset(("low", "medium", "high", "critical"))
+# Derived from the Literal so adding a level (e.g. "info") in one place
+# also updates parse-time validation. Without `get_args`, the two lists
+# silently drift.
+_VALID_SEVERITIES: frozenset[str] = frozenset(get_args(Severity))
 
 
 @dataclass(frozen=True, slots=True)
@@ -150,10 +158,12 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
         backend=Backend.POOLSIDE,
         url=_POOLSIDE_URL,
         model=_POOLSIDE_MODEL,
-        # Lambda (not bare ref) defers name lookup to call time so tests
-        # can `monkeypatch.setattr(lc, "_load_poolside_key", ...)`. With
-        # a bare reference, `_BACKEND_CONFIGS` captures the original
-        # function at import time and ignores the patch.
+        # Lambda (not bare ref) defers the name lookup to call time so
+        # `monkeypatch.setattr(lc, "_load_poolside_key", ...)` in tests
+        # actually reaches the dispatch. A bare reference captures the
+        # original function at import; the patch then mutates only
+        # `lc._load_poolside_key`, which `_BACKEND_CONFIGS` no longer
+        # consults.
         key_loader=lambda: _load_poolside_key(),
     ),
     Backend.OPENROUTER: BackendConfig(
@@ -166,12 +176,20 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
 
 
 def select_backend(installation_id: int) -> Backend:
-    """Round-robin via `installation_id % 2`.
+    """Stable per-install backend pick via `installation_id % 2`.
 
-    Stable per-install — two PRs on the same install always hit the
-    same backend, which lets DD LLM Obs compare prompt variants without
-    cross-install noise.
+    Two PRs on the same install always hit the same backend, which lets
+    DD LLM Obs compare prompt variants without cross-install noise.
+
+    Coupled to a 2-backend `Backend` enum. The assert is the only thing
+    that fails loudly when a third backend is added — the modulo math
+    would silently keep returning Poolside/OpenRouter and the new
+    backend would never be picked.
     """
+    assert len(Backend) == 2, (
+        "select_backend assumes a 2-backend enum; add a real selector "
+        "before extending Backend."
+    )
     return Backend.POOLSIDE if installation_id % 2 == 0 else Backend.OPENROUTER
 
 
@@ -316,7 +334,10 @@ def _parse_response(
                 extra={
                     "reason": reason,
                     "model": model_name,
-                    "raw_truncated": str(raw)[:200],
+                    # repr() not str() so a partial multibyte char at the
+                    # 200-byte boundary becomes `\xNN` rather than an
+                    # invalid UTF-8 sequence DD log ingest may reject.
+                    "raw_truncated": repr(raw)[:200],
                 },
             )
             continue

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -45,6 +45,12 @@ _TIMEOUT_SECONDS = 30
 _RETRY_ATTEMPTS = 3
 _RETRY_BASE_DELAY = 0.5  # exponential: 0.5s, 1.0s, 2.0s
 
+# 429 (rate limit) + 503 (CF edge blip / temporary backend overload)
+# are routinely transient on both Poolside and OpenRouter. Other 5xx
+# (500, 502, 504) get one shot then fall back to the secondary backend
+# rather than burning retries on what may be a permanent issue.
+_RETRYABLE_STATUSES: frozenset[int] = frozenset((429, 503))
+
 
 class Backend(str, Enum):
     """LLM backends. String-valued so DD LLM Obs tags + structured logs
@@ -186,64 +192,83 @@ def _build_messages(hunks: list[Hunk]) -> list[dict[str, str]]:
     ]
 
 
+class _BackendConfigError(Exception):
+    """Backend is misconfigured (empty key, missing env var, SSM
+    failure). Distinct from transport errors so the caller can fall
+    back to the other backend without retry-burning the broken one."""
+
+
 def _call_backend(
     config: BackendConfig, messages: list[dict[str, str]]
 ) -> httpx.Response:
-    """Single backend call with 429 retry + backoff. Raises httpx errors
-    on the LAST attempt — caller catches and falls back."""
+    """Single backend call with 429/503 retry + backoff. Raises
+    `httpx.RequestError`/`httpx.TimeoutException` on transport failure
+    or `_BackendConfigError` on misconfig — caller catches and falls
+    back. Narrow exception scope deliberately: `httpx.InvalidURL`,
+    `httpx.UnsupportedProtocol`, `httpx.CookieConflict` are config
+    bugs that should crash loudly, not retry silently."""
+    try:
+        key = config.key_loader()
+    except Exception as e:
+        # secrets_loader.RuntimeError("SSM parameter name is empty…")
+        # or boto3 ClientError on a missing param. Wrap so the caller's
+        # except clause is uniform.
+        raise _BackendConfigError(
+            f"{config.backend.value} key_loader failed: {type(e).__name__}: {e}"
+        ) from e
+    if not key:
+        raise _BackendConfigError(
+            f"{config.backend.value} key_loader returned empty string"
+        )
+
     body = {
         "model": config.model,
         "messages": messages,
         "response_format": {"type": "json_object"},
     }
-    headers = {"Authorization": f"Bearer {config.key_loader()}"}
+    headers = {"Authorization": f"Bearer {key}"}
 
-    last_exc: Exception | None = None
     for attempt in range(_RETRY_ATTEMPTS):
         try:
             resp = httpx.post(
                 config.url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS,
             )
-        except (httpx.RequestError, httpx.HTTPError) as e:
-            last_exc = e
+        except (httpx.RequestError, httpx.TimeoutException) as e:
             if attempt < _RETRY_ATTEMPTS - 1:
                 _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
                 continue
             raise
-        if resp.status_code == 429 and attempt < _RETRY_ATTEMPTS - 1:
+        if resp.status_code in _RETRYABLE_STATUSES and attempt < _RETRY_ATTEMPTS - 1:
             _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
             continue
         return resp
-    # Defense-in-depth; the loop body returns or raises in every branch.
-    if last_exc:
-        raise last_exc
-    raise RuntimeError("retry loop exited without producing a response")
+    # Unreachable: every iteration either returns, continues, or raises.
+    raise AssertionError("retry loop exited without producing a response")
 
 
-def _coerce_finding(raw: Any) -> Optional[Finding]:
+def _coerce_finding(raw: Any) -> tuple[Optional[Finding], str]:
     """Validate one raw dict from the LLM into a `Finding`. Returns
-    None and lets the caller drop the entry on any shape violation.
-
-    Defense-in-depth: the system prompt declares the contract, but
-    hallucinating models occasionally return bogus severity strings
-    or non-string fields. Dropping malformed entries is preferable to
-    iterating over `Any` downstream.
+    `(finding, "")` on success or `(None, reason)` on rejection so
+    the caller can log per-entry context (defense against a hostile
+    LLM hiding a critical finding by mixing it with malformed ones).
     """
     if not isinstance(raw, dict):
-        return None
+        return None, "non_dict"
     try:
         path = str(raw["path"])
         line = int(raw["line"])
         rule = str(raw["rule"])
         severity = str(raw["severity"])
         message = str(raw.get("message", ""))
-    except (KeyError, TypeError, ValueError):
-        return None
+    except KeyError as e:
+        return None, f"missing_field:{e.args[0]}"
+    except (TypeError, ValueError) as e:
+        return None, f"bad_type:{type(e).__name__}"
     if severity not in _VALID_SEVERITIES:
-        return None
+        return None, f"invalid_severity:{severity[:32]}"
     return Finding(
         path=path, line=line, rule=rule, severity=severity, message=message,  # type: ignore[arg-type]
-    )
+    ), ""
 
 
 def _parse_response(
@@ -253,7 +278,15 @@ def _parse_response(
     ((), model_name, error_message)."""
     if resp.status_code != 200:
         return (), "", f"http_{resp.status_code}"
-    body = resp.json()
+    try:
+        body = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        # Cloudflare HTML interstitial, gateway error page, truncated
+        # body — all return 200 + non-JSON. Surface as parse failure
+        # instead of crashing the webhook handler.
+        return (), "", "envelope_json_decode_failed"
+    if not isinstance(body, dict):
+        return (), "", "envelope_not_a_dict"
     model_name = body.get("model", "")
     try:
         content = body["choices"][0]["message"]["content"]
@@ -266,14 +299,25 @@ def _parse_response(
     raw_findings = parsed.get("findings", [])
     if not isinstance(raw_findings, list):
         return (), model_name, "findings field is not a list"
-    coerced = tuple(f for f in (_coerce_finding(r) for r in raw_findings) if f)
-    dropped = len(raw_findings) - len(coerced)
-    if dropped:
-        log.warning(
-            "llm_findings_malformed_dropped",
-            extra={"dropped": dropped, "kept": len(coerced), "model": model_name},
-        )
-    return coerced, model_name, ""
+    coerced: list[Finding] = []
+    for raw in raw_findings:
+        finding, reason = _coerce_finding(raw)
+        if finding is None:
+            # Log per-drop with truncated raw so a hostile/hallucinating
+            # LLM can't hide a critical finding by surrounding it with
+            # malformed noise. `reason` carries the failure class +
+            # offending field value so triage is mechanical.
+            log.warning(
+                "llm_finding_dropped",
+                extra={
+                    "reason": reason,
+                    "model": model_name,
+                    "raw_truncated": str(raw)[:200],
+                },
+            )
+            continue
+        coerced.append(finding)
+    return tuple(coerced), model_name, ""
 
 
 def review_diff(
@@ -301,7 +345,14 @@ def review_diff(
         config = _BACKEND_CONFIGS[backend]
         try:
             resp = _call_backend(config, messages)
-        except (httpx.RequestError, httpx.HTTPError) as e:
+        except _BackendConfigError as e:
+            log.error(
+                "llm_backend_misconfigured",
+                extra={"backend": backend.value, "detail": str(e)},
+            )
+            last_error = f"{backend.value} misconfigured: {e}"
+            continue
+        except (httpx.RequestError, httpx.TimeoutException) as e:
             log.warning(
                 "llm_backend_transport_failed",
                 extra={"backend": backend.value, "kind": type(e).__name__},

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -27,7 +27,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Callable, Literal, Optional
 
 import httpx
 
@@ -54,6 +54,10 @@ class Backend(str, Enum):
     OPENROUTER = "openrouter"
 
 
+Severity = Literal["low", "medium", "high", "critical"]
+_VALID_SEVERITIES: frozenset[str] = frozenset(("low", "medium", "high", "critical"))
+
+
 @dataclass(frozen=True, slots=True)
 class Hunk:
     """One diff hunk presented to the model as a single review unit."""
@@ -63,16 +67,55 @@ class Hunk:
 
 
 @dataclass(frozen=True, slots=True)
+class Finding:
+    """A single review finding, validated at parse time.
+
+    Hostile or hallucinating LLMs sometimes return findings with bogus
+    severity strings or non-string fields. Parsing into this dataclass
+    drops malformed entries with a warning so the Elder caller iterates
+    over a known shape rather than `Any`.
+    """
+
+    path: str
+    line: int
+    rule: str
+    severity: Severity
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackendConfig:
+    """All the data a single backend dispatch needs. Replacing per-backend
+    if/else branches with a `BackendConfig` lookup means adding a third
+    backend is one new entry, not four scattered edits."""
+
+    backend: Backend
+    url: str
+    model: str
+    key_loader: Callable[[], str]
+
+
+@dataclass(frozen=True, slots=True)
 class LlmReviewResponse:
     """Result of one review_diff call.
 
-    `backend_used=None` + non-empty `error` indicates total failure —
-    the caller surfaces an advisory check-run that says "skipped".
-    Successful calls always carry a backend + model attribution so DD
-    LLM Obs can correlate findings to backend.
+    `kind` is the load-bearing discriminator the caller switches on:
+      - `"no_diff"`: empty hunks, no LLM ran. Don't post anything.
+      - `"reviewed"`: at least one backend returned a parseable payload.
+        `findings` may be empty (clean review). Always carries
+        backend + model attribution.
+      - `"parse_failed"`: LLM responded with non-JSON or prose. Caller
+        posts an advisory check-run with the error.
+      - `"all_failed"`: every backend errored. Caller posts a
+        "skipped" advisory check-run.
+
+    Keeping all four states in one dataclass instead of a true union
+    keeps the call sites cheap (one isinstance check vs many) at the
+    cost of mildly redundant `Optional[...]` fields. Acceptable v1.
     """
 
-    findings: list[dict[str, Any]] = field(default_factory=list)
+    kind: Literal["no_diff", "reviewed", "parse_failed", "all_failed"]
+    findings: tuple[Finding, ...] = field(default_factory=tuple)
     backend_used: Optional[Backend] = None
     model_name: Optional[str] = None
     error: str = ""
@@ -91,6 +134,25 @@ def _load_poolside_key() -> str:
 
 def _load_openrouter_key() -> str:
     return get_openrouter_api_key()
+
+
+# Single source of truth for per-backend dispatch data. Adding a third
+# backend = one new entry; review_diff's "try every backend" loop
+# generalizes without touching the type-design.
+_BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
+    Backend.POOLSIDE: BackendConfig(
+        backend=Backend.POOLSIDE,
+        url=_POOLSIDE_URL,
+        model=_POOLSIDE_MODEL,
+        key_loader=lambda: _load_poolside_key(),
+    ),
+    Backend.OPENROUTER: BackendConfig(
+        backend=Backend.OPENROUTER,
+        url=_OPENROUTER_URL,
+        model=_OPENROUTER_MODEL,
+        key_loader=lambda: _load_openrouter_key(),
+    ),
+}
 
 
 def select_backend(installation_id: int) -> Backend:
@@ -125,26 +187,23 @@ def _build_messages(hunks: list[Hunk]) -> list[dict[str, str]]:
 
 
 def _call_backend(
-    backend: Backend, messages: list[dict[str, str]]
+    config: BackendConfig, messages: list[dict[str, str]]
 ) -> httpx.Response:
     """Single backend call with 429 retry + backoff. Raises httpx errors
     on the LAST attempt — caller catches and falls back."""
-    if backend == Backend.POOLSIDE:
-        url, model, key = _POOLSIDE_URL, _POOLSIDE_MODEL, _load_poolside_key()
-    else:
-        url, model, key = _OPENROUTER_URL, _OPENROUTER_MODEL, _load_openrouter_key()
-
     body = {
-        "model": model,
+        "model": config.model,
         "messages": messages,
         "response_format": {"type": "json_object"},
     }
-    headers = {"Authorization": f"Bearer {key}"}
+    headers = {"Authorization": f"Bearer {config.key_loader()}"}
 
     last_exc: Exception | None = None
     for attempt in range(_RETRY_ATTEMPTS):
         try:
-            resp = httpx.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
+            resp = httpx.post(
+                config.url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS,
+            )
         except (httpx.RequestError, httpx.HTTPError) as e:
             last_exc = e
             if attempt < _RETRY_ATTEMPTS - 1:
@@ -155,33 +214,66 @@ def _call_backend(
             _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
             continue
         return resp
-    # Loop terminated without returning — propagate the last seen error
-    # so the caller can fall back. Defense-in-depth; the loop body
-    # already returns or raises in every branch.
+    # Defense-in-depth; the loop body returns or raises in every branch.
     if last_exc:
         raise last_exc
     raise RuntimeError("retry loop exited without producing a response")
 
 
-def _parse_response(resp: httpx.Response) -> tuple[list[dict[str, Any]], str, str]:
+def _coerce_finding(raw: Any) -> Optional[Finding]:
+    """Validate one raw dict from the LLM into a `Finding`. Returns
+    None and lets the caller drop the entry on any shape violation.
+
+    Defense-in-depth: the system prompt declares the contract, but
+    hallucinating models occasionally return bogus severity strings
+    or non-string fields. Dropping malformed entries is preferable to
+    iterating over `Any` downstream.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        path = str(raw["path"])
+        line = int(raw["line"])
+        rule = str(raw["rule"])
+        severity = str(raw["severity"])
+        message = str(raw.get("message", ""))
+    except (KeyError, TypeError, ValueError):
+        return None
+    if severity not in _VALID_SEVERITIES:
+        return None
+    return Finding(
+        path=path, line=line, rule=rule, severity=severity, message=message,  # type: ignore[arg-type]
+    )
+
+
+def _parse_response(
+    resp: httpx.Response,
+) -> tuple[tuple[Finding, ...], str, str]:
     """Returns (findings, model_name, error). On parse failure returns
-    ([], model_name, error_message)."""
+    ((), model_name, error_message)."""
     if resp.status_code != 200:
-        return [], "", f"http_{resp.status_code}"
+        return (), "", f"http_{resp.status_code}"
     body = resp.json()
     model_name = body.get("model", "")
     try:
         content = body["choices"][0]["message"]["content"]
     except (KeyError, IndexError, TypeError):
-        return [], model_name, "missing choices/message/content"
+        return (), model_name, "missing choices/message/content"
     try:
         parsed = json.loads(content)
     except json.JSONDecodeError:
-        return [], model_name, "llm returned non-json — parse failed"
-    findings = parsed.get("findings", [])
-    if not isinstance(findings, list):
-        return [], model_name, "findings field is not a list"
-    return findings, model_name, ""
+        return (), model_name, "llm returned non-json — parse failed"
+    raw_findings = parsed.get("findings", [])
+    if not isinstance(raw_findings, list):
+        return (), model_name, "findings field is not a list"
+    coerced = tuple(f for f in (_coerce_finding(r) for r in raw_findings) if f)
+    dropped = len(raw_findings) - len(coerced)
+    if dropped:
+        log.warning(
+            "llm_findings_malformed_dropped",
+            extra={"dropped": dropped, "kept": len(coerced), "model": model_name},
+        )
+    return coerced, model_name, ""
 
 
 def review_diff(
@@ -189,12 +281,14 @@ def review_diff(
 ) -> LlmReviewResponse:
     """Send `hunks` to the round-robin-selected LLM and return findings.
 
-    Fallback: if the primary backend fails (post-retry), tries the
-    other backend before giving up. Total failure surfaces as
-    `backend_used=None` + non-empty `error`.
+    Returns one of four discriminated states (`response.kind`):
+      - `no_diff`: empty hunks short-circuit, no LLM call made.
+      - `reviewed`: at least one backend returned a parseable payload.
+      - `parse_failed`: LLM responded but the content wasn't usable JSON.
+      - `all_failed`: every backend errored or timed out.
     """
     if not hunks:
-        return LlmReviewResponse()
+        return LlmReviewResponse(kind="no_diff")
 
     primary = select_backend(installation_id)
     secondary = (
@@ -202,18 +296,22 @@ def review_diff(
     )
     messages = _build_messages(hunks)
 
+    last_error = ""
     for backend in (primary, secondary):
+        config = _BACKEND_CONFIGS[backend]
         try:
-            resp = _call_backend(backend, messages)
+            resp = _call_backend(config, messages)
         except (httpx.RequestError, httpx.HTTPError) as e:
             log.warning(
                 "llm_backend_transport_failed",
                 extra={"backend": backend.value, "kind": type(e).__name__},
             )
+            last_error = f"{backend.value}: {type(e).__name__}"
             continue
         findings, model, err = _parse_response(resp)
         if not err:
             return LlmReviewResponse(
+                kind="reviewed",
                 findings=findings,
                 backend_used=backend,
                 model_name=model,
@@ -221,17 +319,25 @@ def review_diff(
         if resp.status_code == 200:
             # 200 + parse failure — the LLM returned but we can't use
             # the content. Don't fall back (the other backend would
-            # likely produce the same prose). Return what we have.
+            # likely produce the same prose). Surface the parse failure
+            # directly so the caller can post an advisory check-run.
             log.warning(
                 "llm_response_parse_failed",
                 extra={"backend": backend.value, "model": model, "error": err},
             )
             return LlmReviewResponse(
-                backend_used=backend, model_name=model, error=err,
+                kind="parse_failed",
+                backend_used=backend,
+                model_name=model,
+                error=err,
             )
         log.warning(
             "llm_backend_http_failed",
             extra={"backend": backend.value, "status": resp.status_code, "error": err},
         )
+        last_error = f"{backend.value}: {err}"
 
-    return LlmReviewResponse(error="both backends failed")
+    return LlmReviewResponse(
+        kind="all_failed",
+        error=last_error or "both backends failed",
+    )

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -1,0 +1,237 @@
+# MIRRORED — sibling at services/webhook/llm_client.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""LLM client abstraction for the Code-Reviewer (Elder) persona.
+
+Sends review prompts to either Poolside (Laguna) or OpenRouter and
+returns a structured response. Backend selection is round-robin via
+`installation_id % 2` so traffic splits evenly across the two and DD
+LLM Obs can A/B prompt variants. If the primary backend errors hard
+(post-retry), the other backend is tried before surfacing an empty
+response — the caller posts an advisory check-run rather than 500ing
+the webhook handler on transient LLM failures.
+
+Both backends use the OpenAI-compatible chat-completions API so the
+request shape is identical. Only the base URL, auth header, and
+default model name differ. Response is constrained to JSON via
+`response_format={"type": "json_object"}` and parsed defensively —
+malformed JSON or refusals degrade to empty findings rather than crash.
+
+Secrets are loaded via secrets_loader.py (`/grug/poolside-api-key` +
+`/grug/openrouter-api-key`); api Lambda has no IAM grant on these
+paths so this module only ever runs from the webhook process.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+import httpx
+
+from secrets_loader import get_openrouter_api_key, get_poolside_api_key
+
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.llm_client")
+
+# Per-backend endpoints + default models.
+_POOLSIDE_URL = "https://inference.poolside.ai/v1/chat/completions"
+_POOLSIDE_MODEL = "poolside/laguna-m.1"
+_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+_OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
+
+_TIMEOUT_SECONDS = 30
+_RETRY_ATTEMPTS = 3
+_RETRY_BASE_DELAY = 0.5  # exponential: 0.5s, 1.0s, 2.0s
+
+
+class Backend(str, Enum):
+    """LLM backends. String-valued so DD LLM Obs tags + structured logs
+    can `backend=str(backend)` without a cast."""
+
+    POOLSIDE = "poolside"
+    OPENROUTER = "openrouter"
+
+
+@dataclass(frozen=True, slots=True)
+class Hunk:
+    """One diff hunk presented to the model as a single review unit."""
+
+    path: str
+    body: str
+
+
+@dataclass(frozen=True, slots=True)
+class LlmReviewResponse:
+    """Result of one review_diff call.
+
+    `backend_used=None` + non-empty `error` indicates total failure —
+    the caller surfaces an advisory check-run that says "skipped".
+    Successful calls always carry a backend + model attribution so DD
+    LLM Obs can correlate findings to backend.
+    """
+
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    backend_used: Optional[Backend] = None
+    model_name: Optional[str] = None
+    error: str = ""
+
+
+# Test hook — replaced with a no-op in unit tests to avoid real sleeps.
+def _RETRY_SLEEP(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+# Test hooks — wrap secret loaders so tests can patch them without
+# monkeypatching the SSM client. Production-equivalent thin wrappers.
+def _load_poolside_key() -> str:
+    return get_poolside_api_key()
+
+
+def _load_openrouter_key() -> str:
+    return get_openrouter_api_key()
+
+
+def select_backend(installation_id: int) -> Backend:
+    """Round-robin via `installation_id % 2`.
+
+    Stable per-install — two PRs on the same install always hit the
+    same backend, which lets DD LLM Obs compare prompt variants without
+    cross-install noise.
+    """
+    return Backend.POOLSIDE if installation_id % 2 == 0 else Backend.OPENROUTER
+
+
+_SYSTEM_PROMPT = (
+    "You are a senior code reviewer for the Grug bot. Review the supplied "
+    "diff hunks and return JSON of shape "
+    '{"findings": [{"path": str, "line": int, "rule": str, "severity": '
+    '"low"|"medium"|"high"|"critical", "message": str}]}. '
+    "Only flag concrete, actionable bugs (silent failures, secret leakage, "
+    "obvious correctness errors). If the diff has no issues, return "
+    '{"findings": []}. Do not include prose outside the JSON object.'
+)
+
+
+def _build_messages(hunks: list[Hunk]) -> list[dict[str, str]]:
+    user = "\n\n".join(
+        f"### {h.path}\n```diff\n{h.body}\n```" for h in hunks
+    )
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user},
+    ]
+
+
+def _call_backend(
+    backend: Backend, messages: list[dict[str, str]]
+) -> httpx.Response:
+    """Single backend call with 429 retry + backoff. Raises httpx errors
+    on the LAST attempt — caller catches and falls back."""
+    if backend == Backend.POOLSIDE:
+        url, model, key = _POOLSIDE_URL, _POOLSIDE_MODEL, _load_poolside_key()
+    else:
+        url, model, key = _OPENROUTER_URL, _OPENROUTER_MODEL, _load_openrouter_key()
+
+    body = {
+        "model": model,
+        "messages": messages,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {"Authorization": f"Bearer {key}"}
+
+    last_exc: Exception | None = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            resp = httpx.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
+        except (httpx.RequestError, httpx.HTTPError) as e:
+            last_exc = e
+            if attempt < _RETRY_ATTEMPTS - 1:
+                _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
+                continue
+            raise
+        if resp.status_code == 429 and attempt < _RETRY_ATTEMPTS - 1:
+            _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
+            continue
+        return resp
+    # Loop terminated without returning — propagate the last seen error
+    # so the caller can fall back. Defense-in-depth; the loop body
+    # already returns or raises in every branch.
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("retry loop exited without producing a response")
+
+
+def _parse_response(resp: httpx.Response) -> tuple[list[dict[str, Any]], str, str]:
+    """Returns (findings, model_name, error). On parse failure returns
+    ([], model_name, error_message)."""
+    if resp.status_code != 200:
+        return [], "", f"http_{resp.status_code}"
+    body = resp.json()
+    model_name = body.get("model", "")
+    try:
+        content = body["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        return [], model_name, "missing choices/message/content"
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return [], model_name, "llm returned non-json — parse failed"
+    findings = parsed.get("findings", [])
+    if not isinstance(findings, list):
+        return [], model_name, "findings field is not a list"
+    return findings, model_name, ""
+
+
+def review_diff(
+    hunks: list[Hunk], installation_id: int
+) -> LlmReviewResponse:
+    """Send `hunks` to the round-robin-selected LLM and return findings.
+
+    Fallback: if the primary backend fails (post-retry), tries the
+    other backend before giving up. Total failure surfaces as
+    `backend_used=None` + non-empty `error`.
+    """
+    if not hunks:
+        return LlmReviewResponse()
+
+    primary = select_backend(installation_id)
+    secondary = (
+        Backend.OPENROUTER if primary == Backend.POOLSIDE else Backend.POOLSIDE
+    )
+    messages = _build_messages(hunks)
+
+    for backend in (primary, secondary):
+        try:
+            resp = _call_backend(backend, messages)
+        except (httpx.RequestError, httpx.HTTPError) as e:
+            log.warning(
+                "llm_backend_transport_failed",
+                extra={"backend": backend.value, "kind": type(e).__name__},
+            )
+            continue
+        findings, model, err = _parse_response(resp)
+        if not err:
+            return LlmReviewResponse(
+                findings=findings,
+                backend_used=backend,
+                model_name=model,
+            )
+        if resp.status_code == 200:
+            # 200 + parse failure — the LLM returned but we can't use
+            # the content. Don't fall back (the other backend would
+            # likely produce the same prose). Return what we have.
+            log.warning(
+                "llm_response_parse_failed",
+                extra={"backend": backend.value, "model": model, "error": err},
+            )
+            return LlmReviewResponse(
+                backend_used=backend, model_name=model, error=err,
+            )
+        log.warning(
+            "llm_backend_http_failed",
+            extra={"backend": backend.value, "status": resp.status_code, "error": err},
+        )
+
+    return LlmReviewResponse(error="both backends failed")

--- a/services/api/secrets_loader.py
+++ b/services/api/secrets_loader.py
@@ -49,3 +49,8 @@ def get_app_private_key() -> str:
 def get_openrouter_api_key() -> str:
     name = os.getenv("GRUG_OPENROUTER_API_KEY_SSM", "")
     return _get_ssm_secure_string(name)
+
+
+def get_poolside_api_key() -> str:
+    name = os.getenv("GRUG_POOLSIDE_API_KEY_SSM", "")
+    return _get_ssm_secure_string(name)

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -322,6 +322,51 @@ def test_503_retried_alongside_429(monkeypatch) -> None:
     assert idx["n"] == 2  # one retry + one success
 
 
+def test_transport_failure_on_both_backends_returns_all_failed(monkeypatch) -> None:
+    """Covers the retry-loop terminal `raise` (final attempt without a
+    fallback continue). Without this test, a future off-by-one on the
+    `attempt < _RETRY_ATTEMPTS - 1` guard would ship green."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    call_log: list[str] = []
+
+    def always_timeout(url, *args, **kwargs):
+        call_log.append(url)
+        raise httpx.ReadTimeout("timeout")
+
+    with patch.object(httpx, "post", side_effect=always_timeout):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "all_failed"
+    assert out.backend_used is None
+    # 3 retries × 2 backends = 6 attempts total.
+    assert len(call_log) == 6
+    # Both backends represented (one of each URL).
+    assert any("poolside" in u for u in call_log)
+    assert any("openrouter" in u for u in call_log)
+
+
+def test_parse_failed_attributes_secondary_backend(monkeypatch) -> None:
+    """If the primary backend transport-fails and the secondary returns
+    200 + non-JSON content, parse_failed must report the secondary as
+    `backend_used`. Comment in review_diff explicitly says don't fall
+    back further; verify the attribution still points at whoever actually
+    responded."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    parse_fail_envelope = _openai_json_response("sorry, I cannot do that")
+
+    def staged(url, *args, **kwargs):
+        if "poolside" in url:
+            raise httpx.ReadTimeout("primary down")
+        return httpx.Response(200, json=parse_fail_envelope)
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=2)  # even → Poolside primary
+
+    assert out.kind == "parse_failed"
+    assert out.backend_used == Backend.OPENROUTER
+    assert "parse" in out.error.lower()
+
+
 def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
     """200 + Cloudflare HTML interstitial (not JSON) must not crash.
     Previously `_parse_response` called `resp.json()` unguarded — the

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -266,3 +266,73 @@ def test_findings_with_missing_fields_are_dropped() -> None:
     assert out.kind == "reviewed"
     assert len(out.findings) == 1
     assert out.findings[0].rule == "ok"
+
+
+def test_empty_api_key_falls_back_not_crashes(monkeypatch) -> None:
+    """Empty key → _BackendConfigError → fall back to the other backend.
+    Without the narrow exception split, a misconfig would 500 the
+    webhook handler instead of degrading to advisory mode."""
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "")  # broken
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "real-or-key")
+
+    response = httpx.Response(
+        200,
+        json=_openai_json_response(
+            '{"findings": [{"path": "x", "line": 1, "rule": "ok", '
+            '"severity": "low", "message": ""}]}'
+        ),
+    )
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=2)  # primary = Poolside
+
+    assert out.kind == "reviewed"
+    assert out.backend_used == Backend.OPENROUTER  # fallback
+
+
+def test_both_backends_misconfigured_returns_all_failed(monkeypatch) -> None:
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "")
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "")
+    with patch.object(httpx, "post") as mock_post:
+        out = review_diff([_hunk()], installation_id=1)
+    assert out.kind == "all_failed"
+    assert "misconfigured" in out.error.lower()
+    mock_post.assert_not_called()  # never made an HTTP call
+
+
+def test_503_retried_alongside_429(monkeypatch) -> None:
+    """503 is routinely transient on CF edge; retry once before falling
+    back. Previous behavior burned the whole backend on a 1-second blip."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    seq = [
+        httpx.Response(503, json={"error": "service unavailable"}),
+        httpx.Response(200, json=_openai_json_response('{"findings":[]}')),
+    ]
+    idx = {"n": 0}
+
+    def staged_post(*args, **kwargs):
+        i = idx["n"]
+        idx["n"] += 1
+        return seq[i]
+
+    with patch.object(httpx, "post", side_effect=staged_post):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert out.backend_used == Backend.OPENROUTER
+    assert idx["n"] == 2  # one retry + one success
+
+
+def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
+    """200 + Cloudflare HTML interstitial (not JSON) must not crash.
+    Previously `_parse_response` called `resp.json()` unguarded — the
+    JSONDecodeError would bubble through `review_diff` and 500 the
+    webhook handler. Now it returns a parse_failed envelope so the
+    caller can post an advisory check-run."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    response = httpx.Response(200, text="<html>error</html>")
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+    # 200+non-JSON short-circuits to parse_failed (no fallback — the
+    # other backend would likely return the same edge HTML).
+    assert out.kind == "parse_failed"
+    assert "envelope" in out.error.lower() or "json" in out.error.lower()

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -1,0 +1,206 @@
+"""Tests for the LLM client abstraction (issue #184).
+
+Covers:
+- review_diff returns LlmReviewResponse with backend_used + model_name
+- Round-robin selection via installation_id % 2 (even → Poolside, odd → OpenRouter)
+- 429 retry with backoff on OpenRouter
+- Graceful fallback when primary backend errors
+- Timeout handling
+- OpenAI-compatible request shape (system + user message, JSON response format)
+- Empty hunks → no LLM call (cheap return)
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import llm_client as lc
+from llm_client import Backend, Hunk, LlmReviewResponse, review_diff
+
+
+@pytest.fixture(autouse=True)
+def _patch_keys(monkeypatch):
+    """Avoid the real SSM round-trip in tests."""
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "test-pool-key")
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "test-or-key")
+
+
+def _hunk(path="src/x.py", body="@@ -1 +1 @@\n-foo\n+bar") -> Hunk:
+    return Hunk(path=path, body=body)
+
+
+def _openai_json_response(findings_json: str) -> dict:
+    """OpenAI-compatible chat completion shape both backends return."""
+    return {
+        "choices": [
+            {"message": {"content": findings_json, "role": "assistant"}},
+        ],
+        "model": "test-model-id",
+    }
+
+
+def test_round_robin_even_installation_picks_poolside() -> None:
+    """installation_id % 2 == 0 → Poolside backend."""
+    assert lc.select_backend(installation_id=2) == Backend.POOLSIDE
+    assert lc.select_backend(installation_id=42) == Backend.POOLSIDE
+
+
+def test_round_robin_odd_installation_picks_openrouter() -> None:
+    assert lc.select_backend(installation_id=1) == Backend.OPENROUTER
+    assert lc.select_backend(installation_id=43) == Backend.OPENROUTER
+
+
+def test_empty_hunks_returns_no_findings_without_llm_call() -> None:
+    """Cheap short-circuit — don't burn LLM quota on empty diffs."""
+    with patch.object(httpx, "post") as mock_post:
+        out = review_diff([], installation_id=1)
+    assert out.findings == []
+    assert out.backend_used is None
+    mock_post.assert_not_called()
+
+
+def test_review_diff_via_poolside_returns_structured_response() -> None:
+    findings_json = '{"findings": [{"path": "src/x.py", "line": 1, "rule": "secret-in-log", "severity": "high"}]}'
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=2)
+
+    assert isinstance(out, LlmReviewResponse)
+    assert out.backend_used == Backend.POOLSIDE
+    assert out.model_name == "test-model-id"
+    assert len(out.findings) == 1
+    assert out.findings[0]["rule"] == "secret-in-log"
+
+
+def test_review_diff_via_openrouter_returns_structured_response() -> None:
+    findings_json = '{"findings": []}'
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.backend_used == Backend.OPENROUTER
+    assert out.findings == []
+
+
+def test_429_triggers_retry_with_backoff(monkeypatch) -> None:
+    """OpenRouter free tier sends 429 under burst; client retries."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)  # no real sleep
+    seq = [
+        httpx.Response(429, json={"error": {"message": "rate limited"}}),
+        httpx.Response(429, json={"error": {"message": "rate limited"}}),
+        httpx.Response(200, json=_openai_json_response('{"findings":[]}')),
+    ]
+    idx = {"n": 0}
+
+    def staged_post(*args, **kwargs):
+        i = idx["n"]
+        idx["n"] += 1
+        return seq[i]
+
+    with patch.object(httpx, "post", side_effect=staged_post):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert idx["n"] == 3, "should have made 3 attempts (2 retries after 429)"
+    assert out.backend_used == Backend.OPENROUTER
+
+
+def test_primary_failure_falls_back_to_secondary(monkeypatch) -> None:
+    """5xx on primary → no per-backend retry (might be a permanent issue);
+    fall back to the other backend immediately."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    seq = [
+        httpx.Response(500, json={"error": "upstream"}),  # Poolside
+        httpx.Response(200, json=_openai_json_response('{"findings": [{"rule": "x", "path": "p", "line": 1, "severity": "low"}]}')),  # OpenRouter
+    ]
+    idx = {"n": 0}
+
+    def staged_post(*args, **kwargs):
+        i = idx["n"]
+        idx["n"] += 1
+        return seq[i]
+
+    with patch.object(httpx, "post", side_effect=staged_post):
+        out = review_diff([_hunk()], installation_id=2)  # even → Poolside first
+
+    assert out.backend_used == Backend.OPENROUTER
+    assert len(out.findings) == 1
+
+
+def test_both_backends_fail_returns_empty_response() -> None:
+    """When both Poolside AND OpenRouter fail, surface a structured empty
+    response with `backend_used=None` instead of crashing — the caller
+    posts an advisory check-run that says "skipped" rather than 500ing
+    the webhook handler."""
+    response = httpx.Response(500, json={"error": "down"})
+
+    with patch.object(httpx, "post", return_value=response), \
+         patch.object(lc, "_RETRY_SLEEP", lambda s: None):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.findings == []
+    assert out.backend_used is None
+    assert "both backends failed" in out.error.lower()
+
+
+def test_timeout_treated_as_failure(monkeypatch) -> None:
+    """A timeout (httpx.ReadTimeout) on the primary should trigger
+    fallback to the other backend, not crash the webhook."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    call_log: list = []
+    success = httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+
+    def staged(url, *args, **kwargs):
+        call_log.append(url)
+        # First 3 calls (Poolside primary + retries) raise timeout;
+        # subsequent fallback call to OpenRouter succeeds.
+        if "openrouter" in url:
+            return success
+        raise httpx.ReadTimeout("timeout")
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=2)
+
+    assert out.backend_used == Backend.OPENROUTER
+    assert any("openrouter" in u for u in call_log)
+
+
+def test_request_uses_openai_chat_completions_shape() -> None:
+    captured: list = []
+
+    def capture(url, *, json, headers, timeout):
+        captured.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        return httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+
+    with patch.object(httpx, "post", side_effect=capture):
+        review_diff([_hunk()], installation_id=1)
+
+    assert len(captured) == 1
+    body = captured[0]["json"]
+    assert "model" in body
+    assert isinstance(body["messages"], list)
+    assert body["messages"][0]["role"] == "system"
+    assert body["messages"][1]["role"] == "user"
+    # OpenAI-compatible JSON-mode hint to coerce structured response
+    assert body.get("response_format") == {"type": "json_object"}
+    # Authorization header carries the loaded key.
+    assert captured[0]["headers"]["Authorization"].startswith("Bearer ")
+    # 30s timeout per the existing Poolside convention.
+    assert captured[0]["timeout"] == 30
+
+
+def test_malformed_llm_json_returns_empty_findings_not_crash() -> None:
+    """LLM occasionally returns prose around the JSON or just refuses
+    to comply. Don't crash the webhook on a parse error — degrade to
+    'no findings' with a logged warning."""
+    response = httpx.Response(200, json=_openai_json_response("sorry, I cannot do that"))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.findings == []
+    assert out.backend_used == Backend.OPENROUTER
+    assert "parse" in out.error.lower()

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -1,14 +1,4 @@
-"""Tests for the LLM client abstraction (issue #184).
-
-Covers:
-- review_diff returns LlmReviewResponse with backend_used + model_name
-- Round-robin selection via installation_id % 2 (even → Poolside, odd → OpenRouter)
-- 429 retry with backoff on OpenRouter
-- Graceful fallback when primary backend errors
-- Timeout handling
-- OpenAI-compatible request shape (system + user message, JSON response format)
-- Empty hunks → no LLM call (cheap return)
-"""
+"""Tests for the LLM client abstraction."""
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -365,6 +355,93 @@ def test_parse_failed_attributes_secondary_backend(monkeypatch) -> None:
     assert out.kind == "parse_failed"
     assert out.backend_used == Backend.OPENROUTER
     assert "parse" in out.error.lower()
+
+
+def test_non_dict_finding_entries_dropped() -> None:
+    """Under JSON-mode pressure, LLMs sometimes emit a string or scalar
+    where the schema asks for a dict. Drop the entry rather than crashing
+    on attribute access downstream."""
+    findings_json = (
+        '{"findings": ['
+        '"just a string",'
+        'null,'
+        '42,'
+        '{"path": "y", "line": 5, "rule": "ok", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(out.findings) == 1
+    assert out.findings[0].rule == "ok"
+
+
+def test_bad_type_finding_entry_dropped() -> None:
+    """`line` is non-coercible (a list, not int-castable). `_coerce_finding`
+    must catch TypeError/ValueError and drop, not crash."""
+    findings_json = (
+        '{"findings": ['
+        '{"path": "x", "line": [1, 2], "rule": "bad", "severity": "high", "message": ""},'
+        '{"path": "y", "line": 5, "rule": "ok", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(out.findings) == 1
+    assert out.findings[0].rule == "ok"
+
+
+def test_envelope_json_array_returns_parse_failed() -> None:
+    """200 with a JSON array (not a dict) — provider edge case where the
+    response shape is wrong. Must not AttributeError on `body['choices']`."""
+    response = httpx.Response(200, json=["not", "a", "dict"])
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "parse_failed"
+    assert "envelope" in out.error.lower() or "dict" in out.error.lower()
+
+
+def test_envelope_missing_choices_returns_parse_failed() -> None:
+    """Both providers return `{"error": {"code": "..."}}` on bad payloads —
+    a valid JSON dict without `choices`. Must surface as parse_failed,
+    not raise."""
+    response = httpx.Response(
+        200, json={"error": {"code": "invalid_request", "message": "bad"}}
+    )
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "parse_failed"
+    assert "choices" in out.error.lower() or "missing" in out.error.lower()
+
+
+def test_non_retryable_5xx_does_not_burn_retry_budget(monkeypatch) -> None:
+    """500/502/504 exit the retry loop immediately. A regression that
+    adds them to `_RETRYABLE_STATUSES` would 3x latency before fallback —
+    catch it by asserting only 1 attempt per backend."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    call_log: list[str] = []
+
+    def staged(url, *args, **kwargs):
+        call_log.append(url)
+        return httpx.Response(502, text="bad gateway")
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=2)
+
+    assert out.kind == "all_failed"
+    # 1 attempt per backend × 2 backends = 2 calls. Not 6 (would be retried).
+    assert len(call_log) == 2
 
 
 def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 
 import llm_client as lc
-from llm_client import Backend, Hunk, LlmReviewResponse, review_diff
+from llm_client import Backend, Finding, Hunk, LlmReviewResponse, review_diff
 
 
 @pytest.fixture(autouse=True)
@@ -52,27 +52,37 @@ def test_round_robin_odd_installation_picks_openrouter() -> None:
     assert lc.select_backend(installation_id=43) == Backend.OPENROUTER
 
 
-def test_empty_hunks_returns_no_findings_without_llm_call() -> None:
-    """Cheap short-circuit — don't burn LLM quota on empty diffs."""
+def test_empty_hunks_returns_no_diff_kind_without_llm_call() -> None:
+    """Cheap short-circuit — don't burn LLM quota on empty diffs.
+    Distinct `kind="no_diff"` so the caller can distinguish from
+    `all_failed` (also has empty findings)."""
     with patch.object(httpx, "post") as mock_post:
         out = review_diff([], installation_id=1)
-    assert out.findings == []
+    assert out.kind == "no_diff"
+    assert out.findings == ()
     assert out.backend_used is None
     mock_post.assert_not_called()
 
 
 def test_review_diff_via_poolside_returns_structured_response() -> None:
-    findings_json = '{"findings": [{"path": "src/x.py", "line": 1, "rule": "secret-in-log", "severity": "high"}]}'
+    findings_json = (
+        '{"findings": [{"path": "src/x.py", "line": 1, '
+        '"rule": "secret-in-log", "severity": "high", '
+        '"message": "API key in log"}]}'
+    )
     response = httpx.Response(200, json=_openai_json_response(findings_json))
 
     with patch.object(httpx, "post", return_value=response):
         out = review_diff([_hunk()], installation_id=2)
 
     assert isinstance(out, LlmReviewResponse)
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.POOLSIDE
     assert out.model_name == "test-model-id"
     assert len(out.findings) == 1
-    assert out.findings[0]["rule"] == "secret-in-log"
+    assert isinstance(out.findings[0], Finding)
+    assert out.findings[0].rule == "secret-in-log"
+    assert out.findings[0].severity == "high"
 
 
 def test_review_diff_via_openrouter_returns_structured_response() -> None:
@@ -82,8 +92,9 @@ def test_review_diff_via_openrouter_returns_structured_response() -> None:
     with patch.object(httpx, "post", return_value=response):
         out = review_diff([_hunk()], installation_id=1)
 
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.OPENROUTER
-    assert out.findings == []
+    assert out.findings == ()
 
 
 def test_429_triggers_retry_with_backoff(monkeypatch) -> None:
@@ -123,27 +134,35 @@ def test_primary_failure_falls_back_to_secondary(monkeypatch) -> None:
         idx["n"] += 1
         return seq[i]
 
+    seq[1] = httpx.Response(
+        200,
+        json=_openai_json_response(
+            '{"findings": [{"rule": "x", "path": "p", "line": 1, '
+            '"severity": "low", "message": "msg"}]}'
+        ),
+    )
+
     with patch.object(httpx, "post", side_effect=staged_post):
         out = review_diff([_hunk()], installation_id=2)  # even → Poolside first
 
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.OPENROUTER
     assert len(out.findings) == 1
 
 
-def test_both_backends_fail_returns_empty_response() -> None:
-    """When both Poolside AND OpenRouter fail, surface a structured empty
-    response with `backend_used=None` instead of crashing — the caller
-    posts an advisory check-run that says "skipped" rather than 500ing
-    the webhook handler."""
+def test_both_backends_fail_returns_all_failed_kind() -> None:
+    """Distinct `kind="all_failed"` so the caller can switch on it
+    without colliding with `no_diff`."""
     response = httpx.Response(500, json={"error": "down"})
 
     with patch.object(httpx, "post", return_value=response), \
          patch.object(lc, "_RETRY_SLEEP", lambda s: None):
         out = review_diff([_hunk()], installation_id=1)
 
-    assert out.findings == []
+    assert out.kind == "all_failed"
+    assert out.findings == ()
     assert out.backend_used is None
-    assert "both backends failed" in out.error.lower()
+    assert out.error  # non-empty
 
 
 def test_timeout_treated_as_failure(monkeypatch) -> None:
@@ -164,6 +183,7 @@ def test_timeout_treated_as_failure(monkeypatch) -> None:
     with patch.object(httpx, "post", side_effect=staged):
         out = review_diff([_hunk()], installation_id=2)
 
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.OPENROUTER
     assert any("openrouter" in u for u in call_log)
 
@@ -192,15 +212,57 @@ def test_request_uses_openai_chat_completions_shape() -> None:
     assert captured[0]["timeout"] == 30
 
 
-def test_malformed_llm_json_returns_empty_findings_not_crash() -> None:
+def test_malformed_llm_json_returns_parse_failed_kind() -> None:
     """LLM occasionally returns prose around the JSON or just refuses
-    to comply. Don't crash the webhook on a parse error — degrade to
-    'no findings' with a logged warning."""
+    to comply. Don't crash the webhook on a parse error — discriminated
+    `kind="parse_failed"` so the caller posts an advisory check-run
+    explaining the issue rather than silent "no findings"."""
     response = httpx.Response(200, json=_openai_json_response("sorry, I cannot do that"))
 
     with patch.object(httpx, "post", return_value=response):
         out = review_diff([_hunk()], installation_id=1)
 
-    assert out.findings == []
+    assert out.kind == "parse_failed"
+    assert out.findings == ()
     assert out.backend_used == Backend.OPENROUTER
     assert "parse" in out.error.lower()
+
+
+def test_findings_with_bogus_severity_are_dropped() -> None:
+    """A hallucinating LLM might return severity='catastrophic' which
+    isn't in the Literal. Drop the malformed entry rather than
+    iterating over `Any` downstream."""
+    findings_json = (
+        '{"findings": ['
+        '{"path": "x", "line": 1, "rule": "ok", "severity": "high", "message": ""},'
+        '{"path": "y", "line": 2, "rule": "bad", "severity": "catastrophic", "message": ""},'
+        '{"path": "z", "line": 3, "rule": "also-bad", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    # Bogus-severity entry dropped; valid two remain.
+    assert len(out.findings) == 2
+    assert {f.rule for f in out.findings} == {"ok", "also-bad"}
+
+
+def test_findings_with_missing_fields_are_dropped() -> None:
+    """LLM omitting a required field (e.g. `line`) → drop the entry."""
+    findings_json = (
+        '{"findings": ['
+        '{"path": "x", "rule": "no-line", "severity": "high"},'  # missing line
+        '{"path": "y", "line": 5, "rule": "ok", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(out.findings) == 1
+    assert out.findings[0].rule == "ok"

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -46,14 +46,15 @@ _OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
 
 _TIMEOUT_SECONDS = 30
 _RETRY_ATTEMPTS = 3
-# Backoff applies on attempts 0 and 1 only (attempt 2 either succeeds or
-# raises). Worst-case sleep per backend: 0.5s + 1.0s = 1.5s.
+# Exponential backoff applies on every attempt except the final one,
+# which either returns the response or raises.
 _RETRY_BASE_DELAY = 0.5
 
 # 429 (rate limit) + 503 (CF edge blip / temporary backend overload)
 # are routinely transient on both Poolside and OpenRouter. Other 5xx
-# (500, 502, 504) get one shot then fall back to the secondary backend
-# rather than burning retries on what may be a permanent issue.
+# (500, 502, 504) return immediately; review_diff then falls back to
+# the secondary backend rather than burning retries on what may be a
+# permanent issue.
 _RETRYABLE_STATUSES: frozenset[int] = frozenset((429, 503))
 
 

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -150,6 +150,10 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
         backend=Backend.POOLSIDE,
         url=_POOLSIDE_URL,
         model=_POOLSIDE_MODEL,
+        # Lambda (not bare ref) defers name lookup to call time so tests
+        # can `monkeypatch.setattr(lc, "_load_poolside_key", ...)`. With
+        # a bare reference, `_BACKEND_CONFIGS` captures the original
+        # function at import time and ignores the patch.
         key_loader=lambda: _load_poolside_key(),
     ),
     Backend.OPENROUTER: BackendConfig(

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -2,12 +2,15 @@
 """LLM client abstraction for the Code-Reviewer (Elder) persona.
 
 Sends review prompts to either Poolside (Laguna) or OpenRouter and
-returns a structured response. Backend selection is round-robin via
-`installation_id % 2` so traffic splits evenly across the two and DD
-LLM Obs can A/B prompt variants. If the primary backend errors hard
-(post-retry), the other backend is tried before surfacing an empty
-response — the caller posts an advisory check-run rather than 500ing
-the webhook handler on transient LLM failures.
+returns a structured response. Backend selection is stable per-install
+via `installation_id % 2`: two PRs on the same install always hit the
+same backend, which lets DD LLM Obs A/B-compare prompt variants without
+cross-install noise. Traffic distribution across the two backends
+depends on how installs are sized — it is NOT a true even split.
+If the primary backend errors hard (post-retry), the other backend is
+tried before surfacing an empty response — the caller posts an advisory
+check-run rather than 500ing the webhook handler on transient LLM
+failures.
 
 Both backends use the OpenAI-compatible chat-completions API so the
 request shape is identical. Only the base URL, auth header, and
@@ -27,7 +30,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, get_args
 
 import httpx
 
@@ -43,7 +46,9 @@ _OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
 
 _TIMEOUT_SECONDS = 30
 _RETRY_ATTEMPTS = 3
-_RETRY_BASE_DELAY = 0.5  # exponential: 0.5s, 1.0s, 2.0s
+# Backoff applies on attempts 0 and 1 only (attempt 2 either succeeds or
+# raises). Worst-case sleep per backend: 0.5s + 1.0s = 1.5s.
+_RETRY_BASE_DELAY = 0.5
 
 # 429 (rate limit) + 503 (CF edge blip / temporary backend overload)
 # are routinely transient on both Poolside and OpenRouter. Other 5xx
@@ -61,7 +66,10 @@ class Backend(str, Enum):
 
 
 Severity = Literal["low", "medium", "high", "critical"]
-_VALID_SEVERITIES: frozenset[str] = frozenset(("low", "medium", "high", "critical"))
+# Derived from the Literal so adding a level (e.g. "info") in one place
+# also updates parse-time validation. Without `get_args`, the two lists
+# silently drift.
+_VALID_SEVERITIES: frozenset[str] = frozenset(get_args(Severity))
 
 
 @dataclass(frozen=True, slots=True)
@@ -150,10 +158,12 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
         backend=Backend.POOLSIDE,
         url=_POOLSIDE_URL,
         model=_POOLSIDE_MODEL,
-        # Lambda (not bare ref) defers name lookup to call time so tests
-        # can `monkeypatch.setattr(lc, "_load_poolside_key", ...)`. With
-        # a bare reference, `_BACKEND_CONFIGS` captures the original
-        # function at import time and ignores the patch.
+        # Lambda (not bare ref) defers the name lookup to call time so
+        # `monkeypatch.setattr(lc, "_load_poolside_key", ...)` in tests
+        # actually reaches the dispatch. A bare reference captures the
+        # original function at import; the patch then mutates only
+        # `lc._load_poolside_key`, which `_BACKEND_CONFIGS` no longer
+        # consults.
         key_loader=lambda: _load_poolside_key(),
     ),
     Backend.OPENROUTER: BackendConfig(
@@ -166,12 +176,20 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
 
 
 def select_backend(installation_id: int) -> Backend:
-    """Round-robin via `installation_id % 2`.
+    """Stable per-install backend pick via `installation_id % 2`.
 
-    Stable per-install — two PRs on the same install always hit the
-    same backend, which lets DD LLM Obs compare prompt variants without
-    cross-install noise.
+    Two PRs on the same install always hit the same backend, which lets
+    DD LLM Obs compare prompt variants without cross-install noise.
+
+    Coupled to a 2-backend `Backend` enum. The assert is the only thing
+    that fails loudly when a third backend is added — the modulo math
+    would silently keep returning Poolside/OpenRouter and the new
+    backend would never be picked.
     """
+    assert len(Backend) == 2, (
+        "select_backend assumes a 2-backend enum; add a real selector "
+        "before extending Backend."
+    )
     return Backend.POOLSIDE if installation_id % 2 == 0 else Backend.OPENROUTER
 
 
@@ -316,7 +334,10 @@ def _parse_response(
                 extra={
                     "reason": reason,
                     "model": model_name,
-                    "raw_truncated": str(raw)[:200],
+                    # repr() not str() so a partial multibyte char at the
+                    # 200-byte boundary becomes `\xNN` rather than an
+                    # invalid UTF-8 sequence DD log ingest may reject.
+                    "raw_truncated": repr(raw)[:200],
                 },
             )
             continue

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -45,6 +45,12 @@ _TIMEOUT_SECONDS = 30
 _RETRY_ATTEMPTS = 3
 _RETRY_BASE_DELAY = 0.5  # exponential: 0.5s, 1.0s, 2.0s
 
+# 429 (rate limit) + 503 (CF edge blip / temporary backend overload)
+# are routinely transient on both Poolside and OpenRouter. Other 5xx
+# (500, 502, 504) get one shot then fall back to the secondary backend
+# rather than burning retries on what may be a permanent issue.
+_RETRYABLE_STATUSES: frozenset[int] = frozenset((429, 503))
+
 
 class Backend(str, Enum):
     """LLM backends. String-valued so DD LLM Obs tags + structured logs
@@ -186,64 +192,83 @@ def _build_messages(hunks: list[Hunk]) -> list[dict[str, str]]:
     ]
 
 
+class _BackendConfigError(Exception):
+    """Backend is misconfigured (empty key, missing env var, SSM
+    failure). Distinct from transport errors so the caller can fall
+    back to the other backend without retry-burning the broken one."""
+
+
 def _call_backend(
     config: BackendConfig, messages: list[dict[str, str]]
 ) -> httpx.Response:
-    """Single backend call with 429 retry + backoff. Raises httpx errors
-    on the LAST attempt — caller catches and falls back."""
+    """Single backend call with 429/503 retry + backoff. Raises
+    `httpx.RequestError`/`httpx.TimeoutException` on transport failure
+    or `_BackendConfigError` on misconfig — caller catches and falls
+    back. Narrow exception scope deliberately: `httpx.InvalidURL`,
+    `httpx.UnsupportedProtocol`, `httpx.CookieConflict` are config
+    bugs that should crash loudly, not retry silently."""
+    try:
+        key = config.key_loader()
+    except Exception as e:
+        # secrets_loader.RuntimeError("SSM parameter name is empty…")
+        # or boto3 ClientError on a missing param. Wrap so the caller's
+        # except clause is uniform.
+        raise _BackendConfigError(
+            f"{config.backend.value} key_loader failed: {type(e).__name__}: {e}"
+        ) from e
+    if not key:
+        raise _BackendConfigError(
+            f"{config.backend.value} key_loader returned empty string"
+        )
+
     body = {
         "model": config.model,
         "messages": messages,
         "response_format": {"type": "json_object"},
     }
-    headers = {"Authorization": f"Bearer {config.key_loader()}"}
+    headers = {"Authorization": f"Bearer {key}"}
 
-    last_exc: Exception | None = None
     for attempt in range(_RETRY_ATTEMPTS):
         try:
             resp = httpx.post(
                 config.url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS,
             )
-        except (httpx.RequestError, httpx.HTTPError) as e:
-            last_exc = e
+        except (httpx.RequestError, httpx.TimeoutException) as e:
             if attempt < _RETRY_ATTEMPTS - 1:
                 _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
                 continue
             raise
-        if resp.status_code == 429 and attempt < _RETRY_ATTEMPTS - 1:
+        if resp.status_code in _RETRYABLE_STATUSES and attempt < _RETRY_ATTEMPTS - 1:
             _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
             continue
         return resp
-    # Defense-in-depth; the loop body returns or raises in every branch.
-    if last_exc:
-        raise last_exc
-    raise RuntimeError("retry loop exited without producing a response")
+    # Unreachable: every iteration either returns, continues, or raises.
+    raise AssertionError("retry loop exited without producing a response")
 
 
-def _coerce_finding(raw: Any) -> Optional[Finding]:
+def _coerce_finding(raw: Any) -> tuple[Optional[Finding], str]:
     """Validate one raw dict from the LLM into a `Finding`. Returns
-    None and lets the caller drop the entry on any shape violation.
-
-    Defense-in-depth: the system prompt declares the contract, but
-    hallucinating models occasionally return bogus severity strings
-    or non-string fields. Dropping malformed entries is preferable to
-    iterating over `Any` downstream.
+    `(finding, "")` on success or `(None, reason)` on rejection so
+    the caller can log per-entry context (defense against a hostile
+    LLM hiding a critical finding by mixing it with malformed ones).
     """
     if not isinstance(raw, dict):
-        return None
+        return None, "non_dict"
     try:
         path = str(raw["path"])
         line = int(raw["line"])
         rule = str(raw["rule"])
         severity = str(raw["severity"])
         message = str(raw.get("message", ""))
-    except (KeyError, TypeError, ValueError):
-        return None
+    except KeyError as e:
+        return None, f"missing_field:{e.args[0]}"
+    except (TypeError, ValueError) as e:
+        return None, f"bad_type:{type(e).__name__}"
     if severity not in _VALID_SEVERITIES:
-        return None
+        return None, f"invalid_severity:{severity[:32]}"
     return Finding(
         path=path, line=line, rule=rule, severity=severity, message=message,  # type: ignore[arg-type]
-    )
+    ), ""
 
 
 def _parse_response(
@@ -253,7 +278,15 @@ def _parse_response(
     ((), model_name, error_message)."""
     if resp.status_code != 200:
         return (), "", f"http_{resp.status_code}"
-    body = resp.json()
+    try:
+        body = resp.json()
+    except (json.JSONDecodeError, ValueError):
+        # Cloudflare HTML interstitial, gateway error page, truncated
+        # body — all return 200 + non-JSON. Surface as parse failure
+        # instead of crashing the webhook handler.
+        return (), "", "envelope_json_decode_failed"
+    if not isinstance(body, dict):
+        return (), "", "envelope_not_a_dict"
     model_name = body.get("model", "")
     try:
         content = body["choices"][0]["message"]["content"]
@@ -266,14 +299,25 @@ def _parse_response(
     raw_findings = parsed.get("findings", [])
     if not isinstance(raw_findings, list):
         return (), model_name, "findings field is not a list"
-    coerced = tuple(f for f in (_coerce_finding(r) for r in raw_findings) if f)
-    dropped = len(raw_findings) - len(coerced)
-    if dropped:
-        log.warning(
-            "llm_findings_malformed_dropped",
-            extra={"dropped": dropped, "kept": len(coerced), "model": model_name},
-        )
-    return coerced, model_name, ""
+    coerced: list[Finding] = []
+    for raw in raw_findings:
+        finding, reason = _coerce_finding(raw)
+        if finding is None:
+            # Log per-drop with truncated raw so a hostile/hallucinating
+            # LLM can't hide a critical finding by surrounding it with
+            # malformed noise. `reason` carries the failure class +
+            # offending field value so triage is mechanical.
+            log.warning(
+                "llm_finding_dropped",
+                extra={
+                    "reason": reason,
+                    "model": model_name,
+                    "raw_truncated": str(raw)[:200],
+                },
+            )
+            continue
+        coerced.append(finding)
+    return tuple(coerced), model_name, ""
 
 
 def review_diff(
@@ -301,7 +345,14 @@ def review_diff(
         config = _BACKEND_CONFIGS[backend]
         try:
             resp = _call_backend(config, messages)
-        except (httpx.RequestError, httpx.HTTPError) as e:
+        except _BackendConfigError as e:
+            log.error(
+                "llm_backend_misconfigured",
+                extra={"backend": backend.value, "detail": str(e)},
+            )
+            last_error = f"{backend.value} misconfigured: {e}"
+            continue
+        except (httpx.RequestError, httpx.TimeoutException) as e:
             log.warning(
                 "llm_backend_transport_failed",
                 extra={"backend": backend.value, "kind": type(e).__name__},

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -27,7 +27,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Callable, Literal, Optional
 
 import httpx
 
@@ -54,6 +54,10 @@ class Backend(str, Enum):
     OPENROUTER = "openrouter"
 
 
+Severity = Literal["low", "medium", "high", "critical"]
+_VALID_SEVERITIES: frozenset[str] = frozenset(("low", "medium", "high", "critical"))
+
+
 @dataclass(frozen=True, slots=True)
 class Hunk:
     """One diff hunk presented to the model as a single review unit."""
@@ -63,16 +67,55 @@ class Hunk:
 
 
 @dataclass(frozen=True, slots=True)
+class Finding:
+    """A single review finding, validated at parse time.
+
+    Hostile or hallucinating LLMs sometimes return findings with bogus
+    severity strings or non-string fields. Parsing into this dataclass
+    drops malformed entries with a warning so the Elder caller iterates
+    over a known shape rather than `Any`.
+    """
+
+    path: str
+    line: int
+    rule: str
+    severity: Severity
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class BackendConfig:
+    """All the data a single backend dispatch needs. Replacing per-backend
+    if/else branches with a `BackendConfig` lookup means adding a third
+    backend is one new entry, not four scattered edits."""
+
+    backend: Backend
+    url: str
+    model: str
+    key_loader: Callable[[], str]
+
+
+@dataclass(frozen=True, slots=True)
 class LlmReviewResponse:
     """Result of one review_diff call.
 
-    `backend_used=None` + non-empty `error` indicates total failure —
-    the caller surfaces an advisory check-run that says "skipped".
-    Successful calls always carry a backend + model attribution so DD
-    LLM Obs can correlate findings to backend.
+    `kind` is the load-bearing discriminator the caller switches on:
+      - `"no_diff"`: empty hunks, no LLM ran. Don't post anything.
+      - `"reviewed"`: at least one backend returned a parseable payload.
+        `findings` may be empty (clean review). Always carries
+        backend + model attribution.
+      - `"parse_failed"`: LLM responded with non-JSON or prose. Caller
+        posts an advisory check-run with the error.
+      - `"all_failed"`: every backend errored. Caller posts a
+        "skipped" advisory check-run.
+
+    Keeping all four states in one dataclass instead of a true union
+    keeps the call sites cheap (one isinstance check vs many) at the
+    cost of mildly redundant `Optional[...]` fields. Acceptable v1.
     """
 
-    findings: list[dict[str, Any]] = field(default_factory=list)
+    kind: Literal["no_diff", "reviewed", "parse_failed", "all_failed"]
+    findings: tuple[Finding, ...] = field(default_factory=tuple)
     backend_used: Optional[Backend] = None
     model_name: Optional[str] = None
     error: str = ""
@@ -91,6 +134,25 @@ def _load_poolside_key() -> str:
 
 def _load_openrouter_key() -> str:
     return get_openrouter_api_key()
+
+
+# Single source of truth for per-backend dispatch data. Adding a third
+# backend = one new entry; review_diff's "try every backend" loop
+# generalizes without touching the type-design.
+_BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
+    Backend.POOLSIDE: BackendConfig(
+        backend=Backend.POOLSIDE,
+        url=_POOLSIDE_URL,
+        model=_POOLSIDE_MODEL,
+        key_loader=lambda: _load_poolside_key(),
+    ),
+    Backend.OPENROUTER: BackendConfig(
+        backend=Backend.OPENROUTER,
+        url=_OPENROUTER_URL,
+        model=_OPENROUTER_MODEL,
+        key_loader=lambda: _load_openrouter_key(),
+    ),
+}
 
 
 def select_backend(installation_id: int) -> Backend:
@@ -125,26 +187,23 @@ def _build_messages(hunks: list[Hunk]) -> list[dict[str, str]]:
 
 
 def _call_backend(
-    backend: Backend, messages: list[dict[str, str]]
+    config: BackendConfig, messages: list[dict[str, str]]
 ) -> httpx.Response:
     """Single backend call with 429 retry + backoff. Raises httpx errors
     on the LAST attempt — caller catches and falls back."""
-    if backend == Backend.POOLSIDE:
-        url, model, key = _POOLSIDE_URL, _POOLSIDE_MODEL, _load_poolside_key()
-    else:
-        url, model, key = _OPENROUTER_URL, _OPENROUTER_MODEL, _load_openrouter_key()
-
     body = {
-        "model": model,
+        "model": config.model,
         "messages": messages,
         "response_format": {"type": "json_object"},
     }
-    headers = {"Authorization": f"Bearer {key}"}
+    headers = {"Authorization": f"Bearer {config.key_loader()}"}
 
     last_exc: Exception | None = None
     for attempt in range(_RETRY_ATTEMPTS):
         try:
-            resp = httpx.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
+            resp = httpx.post(
+                config.url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS,
+            )
         except (httpx.RequestError, httpx.HTTPError) as e:
             last_exc = e
             if attempt < _RETRY_ATTEMPTS - 1:
@@ -155,33 +214,66 @@ def _call_backend(
             _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
             continue
         return resp
-    # Loop terminated without returning — propagate the last seen error
-    # so the caller can fall back. Defense-in-depth; the loop body
-    # already returns or raises in every branch.
+    # Defense-in-depth; the loop body returns or raises in every branch.
     if last_exc:
         raise last_exc
     raise RuntimeError("retry loop exited without producing a response")
 
 
-def _parse_response(resp: httpx.Response) -> tuple[list[dict[str, Any]], str, str]:
+def _coerce_finding(raw: Any) -> Optional[Finding]:
+    """Validate one raw dict from the LLM into a `Finding`. Returns
+    None and lets the caller drop the entry on any shape violation.
+
+    Defense-in-depth: the system prompt declares the contract, but
+    hallucinating models occasionally return bogus severity strings
+    or non-string fields. Dropping malformed entries is preferable to
+    iterating over `Any` downstream.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        path = str(raw["path"])
+        line = int(raw["line"])
+        rule = str(raw["rule"])
+        severity = str(raw["severity"])
+        message = str(raw.get("message", ""))
+    except (KeyError, TypeError, ValueError):
+        return None
+    if severity not in _VALID_SEVERITIES:
+        return None
+    return Finding(
+        path=path, line=line, rule=rule, severity=severity, message=message,  # type: ignore[arg-type]
+    )
+
+
+def _parse_response(
+    resp: httpx.Response,
+) -> tuple[tuple[Finding, ...], str, str]:
     """Returns (findings, model_name, error). On parse failure returns
-    ([], model_name, error_message)."""
+    ((), model_name, error_message)."""
     if resp.status_code != 200:
-        return [], "", f"http_{resp.status_code}"
+        return (), "", f"http_{resp.status_code}"
     body = resp.json()
     model_name = body.get("model", "")
     try:
         content = body["choices"][0]["message"]["content"]
     except (KeyError, IndexError, TypeError):
-        return [], model_name, "missing choices/message/content"
+        return (), model_name, "missing choices/message/content"
     try:
         parsed = json.loads(content)
     except json.JSONDecodeError:
-        return [], model_name, "llm returned non-json — parse failed"
-    findings = parsed.get("findings", [])
-    if not isinstance(findings, list):
-        return [], model_name, "findings field is not a list"
-    return findings, model_name, ""
+        return (), model_name, "llm returned non-json — parse failed"
+    raw_findings = parsed.get("findings", [])
+    if not isinstance(raw_findings, list):
+        return (), model_name, "findings field is not a list"
+    coerced = tuple(f for f in (_coerce_finding(r) for r in raw_findings) if f)
+    dropped = len(raw_findings) - len(coerced)
+    if dropped:
+        log.warning(
+            "llm_findings_malformed_dropped",
+            extra={"dropped": dropped, "kept": len(coerced), "model": model_name},
+        )
+    return coerced, model_name, ""
 
 
 def review_diff(
@@ -189,12 +281,14 @@ def review_diff(
 ) -> LlmReviewResponse:
     """Send `hunks` to the round-robin-selected LLM and return findings.
 
-    Fallback: if the primary backend fails (post-retry), tries the
-    other backend before giving up. Total failure surfaces as
-    `backend_used=None` + non-empty `error`.
+    Returns one of four discriminated states (`response.kind`):
+      - `no_diff`: empty hunks short-circuit, no LLM call made.
+      - `reviewed`: at least one backend returned a parseable payload.
+      - `parse_failed`: LLM responded but the content wasn't usable JSON.
+      - `all_failed`: every backend errored or timed out.
     """
     if not hunks:
-        return LlmReviewResponse()
+        return LlmReviewResponse(kind="no_diff")
 
     primary = select_backend(installation_id)
     secondary = (
@@ -202,18 +296,22 @@ def review_diff(
     )
     messages = _build_messages(hunks)
 
+    last_error = ""
     for backend in (primary, secondary):
+        config = _BACKEND_CONFIGS[backend]
         try:
-            resp = _call_backend(backend, messages)
+            resp = _call_backend(config, messages)
         except (httpx.RequestError, httpx.HTTPError) as e:
             log.warning(
                 "llm_backend_transport_failed",
                 extra={"backend": backend.value, "kind": type(e).__name__},
             )
+            last_error = f"{backend.value}: {type(e).__name__}"
             continue
         findings, model, err = _parse_response(resp)
         if not err:
             return LlmReviewResponse(
+                kind="reviewed",
                 findings=findings,
                 backend_used=backend,
                 model_name=model,
@@ -221,17 +319,25 @@ def review_diff(
         if resp.status_code == 200:
             # 200 + parse failure — the LLM returned but we can't use
             # the content. Don't fall back (the other backend would
-            # likely produce the same prose). Return what we have.
+            # likely produce the same prose). Surface the parse failure
+            # directly so the caller can post an advisory check-run.
             log.warning(
                 "llm_response_parse_failed",
                 extra={"backend": backend.value, "model": model, "error": err},
             )
             return LlmReviewResponse(
-                backend_used=backend, model_name=model, error=err,
+                kind="parse_failed",
+                backend_used=backend,
+                model_name=model,
+                error=err,
             )
         log.warning(
             "llm_backend_http_failed",
             extra={"backend": backend.value, "status": resp.status_code, "error": err},
         )
+        last_error = f"{backend.value}: {err}"
 
-    return LlmReviewResponse(error="both backends failed")
+    return LlmReviewResponse(
+        kind="all_failed",
+        error=last_error or "both backends failed",
+    )

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -1,0 +1,237 @@
+# MIRRORED — sibling at services/api/llm_client.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""LLM client abstraction for the Code-Reviewer (Elder) persona.
+
+Sends review prompts to either Poolside (Laguna) or OpenRouter and
+returns a structured response. Backend selection is round-robin via
+`installation_id % 2` so traffic splits evenly across the two and DD
+LLM Obs can A/B prompt variants. If the primary backend errors hard
+(post-retry), the other backend is tried before surfacing an empty
+response — the caller posts an advisory check-run rather than 500ing
+the webhook handler on transient LLM failures.
+
+Both backends use the OpenAI-compatible chat-completions API so the
+request shape is identical. Only the base URL, auth header, and
+default model name differ. Response is constrained to JSON via
+`response_format={"type": "json_object"}` and parsed defensively —
+malformed JSON or refusals degrade to empty findings rather than crash.
+
+Secrets are loaded via secrets_loader.py (`/grug/poolside-api-key` +
+`/grug/openrouter-api-key`); api Lambda has no IAM grant on these
+paths so this module only ever runs from the webhook process.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+import httpx
+
+from secrets_loader import get_openrouter_api_key, get_poolside_api_key
+
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.llm_client")
+
+# Per-backend endpoints + default models.
+_POOLSIDE_URL = "https://inference.poolside.ai/v1/chat/completions"
+_POOLSIDE_MODEL = "poolside/laguna-m.1"
+_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+_OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
+
+_TIMEOUT_SECONDS = 30
+_RETRY_ATTEMPTS = 3
+_RETRY_BASE_DELAY = 0.5  # exponential: 0.5s, 1.0s, 2.0s
+
+
+class Backend(str, Enum):
+    """LLM backends. String-valued so DD LLM Obs tags + structured logs
+    can `backend=str(backend)` without a cast."""
+
+    POOLSIDE = "poolside"
+    OPENROUTER = "openrouter"
+
+
+@dataclass(frozen=True, slots=True)
+class Hunk:
+    """One diff hunk presented to the model as a single review unit."""
+
+    path: str
+    body: str
+
+
+@dataclass(frozen=True, slots=True)
+class LlmReviewResponse:
+    """Result of one review_diff call.
+
+    `backend_used=None` + non-empty `error` indicates total failure —
+    the caller surfaces an advisory check-run that says "skipped".
+    Successful calls always carry a backend + model attribution so DD
+    LLM Obs can correlate findings to backend.
+    """
+
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    backend_used: Optional[Backend] = None
+    model_name: Optional[str] = None
+    error: str = ""
+
+
+# Test hook — replaced with a no-op in unit tests to avoid real sleeps.
+def _RETRY_SLEEP(seconds: float) -> None:
+    time.sleep(seconds)
+
+
+# Test hooks — wrap secret loaders so tests can patch them without
+# monkeypatching the SSM client. Production-equivalent thin wrappers.
+def _load_poolside_key() -> str:
+    return get_poolside_api_key()
+
+
+def _load_openrouter_key() -> str:
+    return get_openrouter_api_key()
+
+
+def select_backend(installation_id: int) -> Backend:
+    """Round-robin via `installation_id % 2`.
+
+    Stable per-install — two PRs on the same install always hit the
+    same backend, which lets DD LLM Obs compare prompt variants without
+    cross-install noise.
+    """
+    return Backend.POOLSIDE if installation_id % 2 == 0 else Backend.OPENROUTER
+
+
+_SYSTEM_PROMPT = (
+    "You are a senior code reviewer for the Grug bot. Review the supplied "
+    "diff hunks and return JSON of shape "
+    '{"findings": [{"path": str, "line": int, "rule": str, "severity": '
+    '"low"|"medium"|"high"|"critical", "message": str}]}. '
+    "Only flag concrete, actionable bugs (silent failures, secret leakage, "
+    "obvious correctness errors). If the diff has no issues, return "
+    '{"findings": []}. Do not include prose outside the JSON object.'
+)
+
+
+def _build_messages(hunks: list[Hunk]) -> list[dict[str, str]]:
+    user = "\n\n".join(
+        f"### {h.path}\n```diff\n{h.body}\n```" for h in hunks
+    )
+    return [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": user},
+    ]
+
+
+def _call_backend(
+    backend: Backend, messages: list[dict[str, str]]
+) -> httpx.Response:
+    """Single backend call with 429 retry + backoff. Raises httpx errors
+    on the LAST attempt — caller catches and falls back."""
+    if backend == Backend.POOLSIDE:
+        url, model, key = _POOLSIDE_URL, _POOLSIDE_MODEL, _load_poolside_key()
+    else:
+        url, model, key = _OPENROUTER_URL, _OPENROUTER_MODEL, _load_openrouter_key()
+
+    body = {
+        "model": model,
+        "messages": messages,
+        "response_format": {"type": "json_object"},
+    }
+    headers = {"Authorization": f"Bearer {key}"}
+
+    last_exc: Exception | None = None
+    for attempt in range(_RETRY_ATTEMPTS):
+        try:
+            resp = httpx.post(url, json=body, headers=headers, timeout=_TIMEOUT_SECONDS)
+        except (httpx.RequestError, httpx.HTTPError) as e:
+            last_exc = e
+            if attempt < _RETRY_ATTEMPTS - 1:
+                _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
+                continue
+            raise
+        if resp.status_code == 429 and attempt < _RETRY_ATTEMPTS - 1:
+            _RETRY_SLEEP(_RETRY_BASE_DELAY * (2 ** attempt))
+            continue
+        return resp
+    # Loop terminated without returning — propagate the last seen error
+    # so the caller can fall back. Defense-in-depth; the loop body
+    # already returns or raises in every branch.
+    if last_exc:
+        raise last_exc
+    raise RuntimeError("retry loop exited without producing a response")
+
+
+def _parse_response(resp: httpx.Response) -> tuple[list[dict[str, Any]], str, str]:
+    """Returns (findings, model_name, error). On parse failure returns
+    ([], model_name, error_message)."""
+    if resp.status_code != 200:
+        return [], "", f"http_{resp.status_code}"
+    body = resp.json()
+    model_name = body.get("model", "")
+    try:
+        content = body["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
+        return [], model_name, "missing choices/message/content"
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return [], model_name, "llm returned non-json — parse failed"
+    findings = parsed.get("findings", [])
+    if not isinstance(findings, list):
+        return [], model_name, "findings field is not a list"
+    return findings, model_name, ""
+
+
+def review_diff(
+    hunks: list[Hunk], installation_id: int
+) -> LlmReviewResponse:
+    """Send `hunks` to the round-robin-selected LLM and return findings.
+
+    Fallback: if the primary backend fails (post-retry), tries the
+    other backend before giving up. Total failure surfaces as
+    `backend_used=None` + non-empty `error`.
+    """
+    if not hunks:
+        return LlmReviewResponse()
+
+    primary = select_backend(installation_id)
+    secondary = (
+        Backend.OPENROUTER if primary == Backend.POOLSIDE else Backend.POOLSIDE
+    )
+    messages = _build_messages(hunks)
+
+    for backend in (primary, secondary):
+        try:
+            resp = _call_backend(backend, messages)
+        except (httpx.RequestError, httpx.HTTPError) as e:
+            log.warning(
+                "llm_backend_transport_failed",
+                extra={"backend": backend.value, "kind": type(e).__name__},
+            )
+            continue
+        findings, model, err = _parse_response(resp)
+        if not err:
+            return LlmReviewResponse(
+                findings=findings,
+                backend_used=backend,
+                model_name=model,
+            )
+        if resp.status_code == 200:
+            # 200 + parse failure — the LLM returned but we can't use
+            # the content. Don't fall back (the other backend would
+            # likely produce the same prose). Return what we have.
+            log.warning(
+                "llm_response_parse_failed",
+                extra={"backend": backend.value, "model": model, "error": err},
+            )
+            return LlmReviewResponse(
+                backend_used=backend, model_name=model, error=err,
+            )
+        log.warning(
+            "llm_backend_http_failed",
+            extra={"backend": backend.value, "status": resp.status_code, "error": err},
+        )
+
+    return LlmReviewResponse(error="both backends failed")

--- a/services/webhook/secrets_loader.py
+++ b/services/webhook/secrets_loader.py
@@ -49,3 +49,8 @@ def get_app_private_key() -> str:
 def get_openrouter_api_key() -> str:
     name = os.getenv("GRUG_OPENROUTER_API_KEY_SSM", "")
     return _get_ssm_secure_string(name)
+
+
+def get_poolside_api_key() -> str:
+    name = os.getenv("GRUG_POOLSIDE_API_KEY_SSM", "")
+    return _get_ssm_secure_string(name)

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -322,6 +322,51 @@ def test_503_retried_alongside_429(monkeypatch) -> None:
     assert idx["n"] == 2  # one retry + one success
 
 
+def test_transport_failure_on_both_backends_returns_all_failed(monkeypatch) -> None:
+    """Covers the retry-loop terminal `raise` (final attempt without a
+    fallback continue). Without this test, a future off-by-one on the
+    `attempt < _RETRY_ATTEMPTS - 1` guard would ship green."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    call_log: list[str] = []
+
+    def always_timeout(url, *args, **kwargs):
+        call_log.append(url)
+        raise httpx.ReadTimeout("timeout")
+
+    with patch.object(httpx, "post", side_effect=always_timeout):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "all_failed"
+    assert out.backend_used is None
+    # 3 retries × 2 backends = 6 attempts total.
+    assert len(call_log) == 6
+    # Both backends represented (one of each URL).
+    assert any("poolside" in u for u in call_log)
+    assert any("openrouter" in u for u in call_log)
+
+
+def test_parse_failed_attributes_secondary_backend(monkeypatch) -> None:
+    """If the primary backend transport-fails and the secondary returns
+    200 + non-JSON content, parse_failed must report the secondary as
+    `backend_used`. Comment in review_diff explicitly says don't fall
+    back further; verify the attribution still points at whoever actually
+    responded."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    parse_fail_envelope = _openai_json_response("sorry, I cannot do that")
+
+    def staged(url, *args, **kwargs):
+        if "poolside" in url:
+            raise httpx.ReadTimeout("primary down")
+        return httpx.Response(200, json=parse_fail_envelope)
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=2)  # even → Poolside primary
+
+    assert out.kind == "parse_failed"
+    assert out.backend_used == Backend.OPENROUTER
+    assert "parse" in out.error.lower()
+
+
 def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
     """200 + Cloudflare HTML interstitial (not JSON) must not crash.
     Previously `_parse_response` called `resp.json()` unguarded — the

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -266,3 +266,73 @@ def test_findings_with_missing_fields_are_dropped() -> None:
     assert out.kind == "reviewed"
     assert len(out.findings) == 1
     assert out.findings[0].rule == "ok"
+
+
+def test_empty_api_key_falls_back_not_crashes(monkeypatch) -> None:
+    """Empty key → _BackendConfigError → fall back to the other backend.
+    Without the narrow exception split, a misconfig would 500 the
+    webhook handler instead of degrading to advisory mode."""
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "")  # broken
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "real-or-key")
+
+    response = httpx.Response(
+        200,
+        json=_openai_json_response(
+            '{"findings": [{"path": "x", "line": 1, "rule": "ok", '
+            '"severity": "low", "message": ""}]}'
+        ),
+    )
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=2)  # primary = Poolside
+
+    assert out.kind == "reviewed"
+    assert out.backend_used == Backend.OPENROUTER  # fallback
+
+
+def test_both_backends_misconfigured_returns_all_failed(monkeypatch) -> None:
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "")
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "")
+    with patch.object(httpx, "post") as mock_post:
+        out = review_diff([_hunk()], installation_id=1)
+    assert out.kind == "all_failed"
+    assert "misconfigured" in out.error.lower()
+    mock_post.assert_not_called()  # never made an HTTP call
+
+
+def test_503_retried_alongside_429(monkeypatch) -> None:
+    """503 is routinely transient on CF edge; retry once before falling
+    back. Previous behavior burned the whole backend on a 1-second blip."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    seq = [
+        httpx.Response(503, json={"error": "service unavailable"}),
+        httpx.Response(200, json=_openai_json_response('{"findings":[]}')),
+    ]
+    idx = {"n": 0}
+
+    def staged_post(*args, **kwargs):
+        i = idx["n"]
+        idx["n"] += 1
+        return seq[i]
+
+    with patch.object(httpx, "post", side_effect=staged_post):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert out.backend_used == Backend.OPENROUTER
+    assert idx["n"] == 2  # one retry + one success
+
+
+def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
+    """200 + Cloudflare HTML interstitial (not JSON) must not crash.
+    Previously `_parse_response` called `resp.json()` unguarded — the
+    JSONDecodeError would bubble through `review_diff` and 500 the
+    webhook handler. Now it returns a parse_failed envelope so the
+    caller can post an advisory check-run."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    response = httpx.Response(200, text="<html>error</html>")
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+    # 200+non-JSON short-circuits to parse_failed (no fallback — the
+    # other backend would likely return the same edge HTML).
+    assert out.kind == "parse_failed"
+    assert "envelope" in out.error.lower() or "json" in out.error.lower()

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -1,0 +1,206 @@
+"""Tests for the LLM client abstraction (issue #184).
+
+Covers:
+- review_diff returns LlmReviewResponse with backend_used + model_name
+- Round-robin selection via installation_id % 2 (even → Poolside, odd → OpenRouter)
+- 429 retry with backoff on OpenRouter
+- Graceful fallback when primary backend errors
+- Timeout handling
+- OpenAI-compatible request shape (system + user message, JSON response format)
+- Empty hunks → no LLM call (cheap return)
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import llm_client as lc
+from llm_client import Backend, Hunk, LlmReviewResponse, review_diff
+
+
+@pytest.fixture(autouse=True)
+def _patch_keys(monkeypatch):
+    """Avoid the real SSM round-trip in tests."""
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "test-pool-key")
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "test-or-key")
+
+
+def _hunk(path="src/x.py", body="@@ -1 +1 @@\n-foo\n+bar") -> Hunk:
+    return Hunk(path=path, body=body)
+
+
+def _openai_json_response(findings_json: str) -> dict:
+    """OpenAI-compatible chat completion shape both backends return."""
+    return {
+        "choices": [
+            {"message": {"content": findings_json, "role": "assistant"}},
+        ],
+        "model": "test-model-id",
+    }
+
+
+def test_round_robin_even_installation_picks_poolside() -> None:
+    """installation_id % 2 == 0 → Poolside backend."""
+    assert lc.select_backend(installation_id=2) == Backend.POOLSIDE
+    assert lc.select_backend(installation_id=42) == Backend.POOLSIDE
+
+
+def test_round_robin_odd_installation_picks_openrouter() -> None:
+    assert lc.select_backend(installation_id=1) == Backend.OPENROUTER
+    assert lc.select_backend(installation_id=43) == Backend.OPENROUTER
+
+
+def test_empty_hunks_returns_no_findings_without_llm_call() -> None:
+    """Cheap short-circuit — don't burn LLM quota on empty diffs."""
+    with patch.object(httpx, "post") as mock_post:
+        out = review_diff([], installation_id=1)
+    assert out.findings == []
+    assert out.backend_used is None
+    mock_post.assert_not_called()
+
+
+def test_review_diff_via_poolside_returns_structured_response() -> None:
+    findings_json = '{"findings": [{"path": "src/x.py", "line": 1, "rule": "secret-in-log", "severity": "high"}]}'
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=2)
+
+    assert isinstance(out, LlmReviewResponse)
+    assert out.backend_used == Backend.POOLSIDE
+    assert out.model_name == "test-model-id"
+    assert len(out.findings) == 1
+    assert out.findings[0]["rule"] == "secret-in-log"
+
+
+def test_review_diff_via_openrouter_returns_structured_response() -> None:
+    findings_json = '{"findings": []}'
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.backend_used == Backend.OPENROUTER
+    assert out.findings == []
+
+
+def test_429_triggers_retry_with_backoff(monkeypatch) -> None:
+    """OpenRouter free tier sends 429 under burst; client retries."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)  # no real sleep
+    seq = [
+        httpx.Response(429, json={"error": {"message": "rate limited"}}),
+        httpx.Response(429, json={"error": {"message": "rate limited"}}),
+        httpx.Response(200, json=_openai_json_response('{"findings":[]}')),
+    ]
+    idx = {"n": 0}
+
+    def staged_post(*args, **kwargs):
+        i = idx["n"]
+        idx["n"] += 1
+        return seq[i]
+
+    with patch.object(httpx, "post", side_effect=staged_post):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert idx["n"] == 3, "should have made 3 attempts (2 retries after 429)"
+    assert out.backend_used == Backend.OPENROUTER
+
+
+def test_primary_failure_falls_back_to_secondary(monkeypatch) -> None:
+    """5xx on primary → no per-backend retry (might be a permanent issue);
+    fall back to the other backend immediately."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    seq = [
+        httpx.Response(500, json={"error": "upstream"}),  # Poolside
+        httpx.Response(200, json=_openai_json_response('{"findings": [{"rule": "x", "path": "p", "line": 1, "severity": "low"}]}')),  # OpenRouter
+    ]
+    idx = {"n": 0}
+
+    def staged_post(*args, **kwargs):
+        i = idx["n"]
+        idx["n"] += 1
+        return seq[i]
+
+    with patch.object(httpx, "post", side_effect=staged_post):
+        out = review_diff([_hunk()], installation_id=2)  # even → Poolside first
+
+    assert out.backend_used == Backend.OPENROUTER
+    assert len(out.findings) == 1
+
+
+def test_both_backends_fail_returns_empty_response() -> None:
+    """When both Poolside AND OpenRouter fail, surface a structured empty
+    response with `backend_used=None` instead of crashing — the caller
+    posts an advisory check-run that says "skipped" rather than 500ing
+    the webhook handler."""
+    response = httpx.Response(500, json={"error": "down"})
+
+    with patch.object(httpx, "post", return_value=response), \
+         patch.object(lc, "_RETRY_SLEEP", lambda s: None):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.findings == []
+    assert out.backend_used is None
+    assert "both backends failed" in out.error.lower()
+
+
+def test_timeout_treated_as_failure(monkeypatch) -> None:
+    """A timeout (httpx.ReadTimeout) on the primary should trigger
+    fallback to the other backend, not crash the webhook."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    call_log: list = []
+    success = httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+
+    def staged(url, *args, **kwargs):
+        call_log.append(url)
+        # First 3 calls (Poolside primary + retries) raise timeout;
+        # subsequent fallback call to OpenRouter succeeds.
+        if "openrouter" in url:
+            return success
+        raise httpx.ReadTimeout("timeout")
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=2)
+
+    assert out.backend_used == Backend.OPENROUTER
+    assert any("openrouter" in u for u in call_log)
+
+
+def test_request_uses_openai_chat_completions_shape() -> None:
+    captured: list = []
+
+    def capture(url, *, json, headers, timeout):
+        captured.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        return httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+
+    with patch.object(httpx, "post", side_effect=capture):
+        review_diff([_hunk()], installation_id=1)
+
+    assert len(captured) == 1
+    body = captured[0]["json"]
+    assert "model" in body
+    assert isinstance(body["messages"], list)
+    assert body["messages"][0]["role"] == "system"
+    assert body["messages"][1]["role"] == "user"
+    # OpenAI-compatible JSON-mode hint to coerce structured response
+    assert body.get("response_format") == {"type": "json_object"}
+    # Authorization header carries the loaded key.
+    assert captured[0]["headers"]["Authorization"].startswith("Bearer ")
+    # 30s timeout per the existing Poolside convention.
+    assert captured[0]["timeout"] == 30
+
+
+def test_malformed_llm_json_returns_empty_findings_not_crash() -> None:
+    """LLM occasionally returns prose around the JSON or just refuses
+    to comply. Don't crash the webhook on a parse error — degrade to
+    'no findings' with a logged warning."""
+    response = httpx.Response(200, json=_openai_json_response("sorry, I cannot do that"))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.findings == []
+    assert out.backend_used == Backend.OPENROUTER
+    assert "parse" in out.error.lower()

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -1,14 +1,4 @@
-"""Tests for the LLM client abstraction (issue #184).
-
-Covers:
-- review_diff returns LlmReviewResponse with backend_used + model_name
-- Round-robin selection via installation_id % 2 (even → Poolside, odd → OpenRouter)
-- 429 retry with backoff on OpenRouter
-- Graceful fallback when primary backend errors
-- Timeout handling
-- OpenAI-compatible request shape (system + user message, JSON response format)
-- Empty hunks → no LLM call (cheap return)
-"""
+"""Tests for the LLM client abstraction."""
 from __future__ import annotations
 
 from unittest.mock import patch
@@ -365,6 +355,93 @@ def test_parse_failed_attributes_secondary_backend(monkeypatch) -> None:
     assert out.kind == "parse_failed"
     assert out.backend_used == Backend.OPENROUTER
     assert "parse" in out.error.lower()
+
+
+def test_non_dict_finding_entries_dropped() -> None:
+    """Under JSON-mode pressure, LLMs sometimes emit a string or scalar
+    where the schema asks for a dict. Drop the entry rather than crashing
+    on attribute access downstream."""
+    findings_json = (
+        '{"findings": ['
+        '"just a string",'
+        'null,'
+        '42,'
+        '{"path": "y", "line": 5, "rule": "ok", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(out.findings) == 1
+    assert out.findings[0].rule == "ok"
+
+
+def test_bad_type_finding_entry_dropped() -> None:
+    """`line` is non-coercible (a list, not int-castable). `_coerce_finding`
+    must catch TypeError/ValueError and drop, not crash."""
+    findings_json = (
+        '{"findings": ['
+        '{"path": "x", "line": [1, 2], "rule": "bad", "severity": "high", "message": ""},'
+        '{"path": "y", "line": 5, "rule": "ok", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(out.findings) == 1
+    assert out.findings[0].rule == "ok"
+
+
+def test_envelope_json_array_returns_parse_failed() -> None:
+    """200 with a JSON array (not a dict) — provider edge case where the
+    response shape is wrong. Must not AttributeError on `body['choices']`."""
+    response = httpx.Response(200, json=["not", "a", "dict"])
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "parse_failed"
+    assert "envelope" in out.error.lower() or "dict" in out.error.lower()
+
+
+def test_envelope_missing_choices_returns_parse_failed() -> None:
+    """Both providers return `{"error": {"code": "..."}}` on bad payloads —
+    a valid JSON dict without `choices`. Must surface as parse_failed,
+    not raise."""
+    response = httpx.Response(
+        200, json={"error": {"code": "invalid_request", "message": "bad"}}
+    )
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "parse_failed"
+    assert "choices" in out.error.lower() or "missing" in out.error.lower()
+
+
+def test_non_retryable_5xx_does_not_burn_retry_budget(monkeypatch) -> None:
+    """500/502/504 exit the retry loop immediately. A regression that
+    adds them to `_RETRYABLE_STATUSES` would 3x latency before fallback —
+    catch it by asserting only 1 attempt per backend."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    call_log: list[str] = []
+
+    def staged(url, *args, **kwargs):
+        call_log.append(url)
+        return httpx.Response(502, text="bad gateway")
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=2)
+
+    assert out.kind == "all_failed"
+    # 1 attempt per backend × 2 backends = 2 calls. Not 6 (would be retried).
+    assert len(call_log) == 2
 
 
 def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 
 import llm_client as lc
-from llm_client import Backend, Hunk, LlmReviewResponse, review_diff
+from llm_client import Backend, Finding, Hunk, LlmReviewResponse, review_diff
 
 
 @pytest.fixture(autouse=True)
@@ -52,27 +52,37 @@ def test_round_robin_odd_installation_picks_openrouter() -> None:
     assert lc.select_backend(installation_id=43) == Backend.OPENROUTER
 
 
-def test_empty_hunks_returns_no_findings_without_llm_call() -> None:
-    """Cheap short-circuit — don't burn LLM quota on empty diffs."""
+def test_empty_hunks_returns_no_diff_kind_without_llm_call() -> None:
+    """Cheap short-circuit — don't burn LLM quota on empty diffs.
+    Distinct `kind="no_diff"` so the caller can distinguish from
+    `all_failed` (also has empty findings)."""
     with patch.object(httpx, "post") as mock_post:
         out = review_diff([], installation_id=1)
-    assert out.findings == []
+    assert out.kind == "no_diff"
+    assert out.findings == ()
     assert out.backend_used is None
     mock_post.assert_not_called()
 
 
 def test_review_diff_via_poolside_returns_structured_response() -> None:
-    findings_json = '{"findings": [{"path": "src/x.py", "line": 1, "rule": "secret-in-log", "severity": "high"}]}'
+    findings_json = (
+        '{"findings": [{"path": "src/x.py", "line": 1, '
+        '"rule": "secret-in-log", "severity": "high", '
+        '"message": "API key in log"}]}'
+    )
     response = httpx.Response(200, json=_openai_json_response(findings_json))
 
     with patch.object(httpx, "post", return_value=response):
         out = review_diff([_hunk()], installation_id=2)
 
     assert isinstance(out, LlmReviewResponse)
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.POOLSIDE
     assert out.model_name == "test-model-id"
     assert len(out.findings) == 1
-    assert out.findings[0]["rule"] == "secret-in-log"
+    assert isinstance(out.findings[0], Finding)
+    assert out.findings[0].rule == "secret-in-log"
+    assert out.findings[0].severity == "high"
 
 
 def test_review_diff_via_openrouter_returns_structured_response() -> None:
@@ -82,8 +92,9 @@ def test_review_diff_via_openrouter_returns_structured_response() -> None:
     with patch.object(httpx, "post", return_value=response):
         out = review_diff([_hunk()], installation_id=1)
 
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.OPENROUTER
-    assert out.findings == []
+    assert out.findings == ()
 
 
 def test_429_triggers_retry_with_backoff(monkeypatch) -> None:
@@ -123,27 +134,35 @@ def test_primary_failure_falls_back_to_secondary(monkeypatch) -> None:
         idx["n"] += 1
         return seq[i]
 
+    seq[1] = httpx.Response(
+        200,
+        json=_openai_json_response(
+            '{"findings": [{"rule": "x", "path": "p", "line": 1, '
+            '"severity": "low", "message": "msg"}]}'
+        ),
+    )
+
     with patch.object(httpx, "post", side_effect=staged_post):
         out = review_diff([_hunk()], installation_id=2)  # even → Poolside first
 
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.OPENROUTER
     assert len(out.findings) == 1
 
 
-def test_both_backends_fail_returns_empty_response() -> None:
-    """When both Poolside AND OpenRouter fail, surface a structured empty
-    response with `backend_used=None` instead of crashing — the caller
-    posts an advisory check-run that says "skipped" rather than 500ing
-    the webhook handler."""
+def test_both_backends_fail_returns_all_failed_kind() -> None:
+    """Distinct `kind="all_failed"` so the caller can switch on it
+    without colliding with `no_diff`."""
     response = httpx.Response(500, json={"error": "down"})
 
     with patch.object(httpx, "post", return_value=response), \
          patch.object(lc, "_RETRY_SLEEP", lambda s: None):
         out = review_diff([_hunk()], installation_id=1)
 
-    assert out.findings == []
+    assert out.kind == "all_failed"
+    assert out.findings == ()
     assert out.backend_used is None
-    assert "both backends failed" in out.error.lower()
+    assert out.error  # non-empty
 
 
 def test_timeout_treated_as_failure(monkeypatch) -> None:
@@ -164,6 +183,7 @@ def test_timeout_treated_as_failure(monkeypatch) -> None:
     with patch.object(httpx, "post", side_effect=staged):
         out = review_diff([_hunk()], installation_id=2)
 
+    assert out.kind == "reviewed"
     assert out.backend_used == Backend.OPENROUTER
     assert any("openrouter" in u for u in call_log)
 
@@ -192,15 +212,57 @@ def test_request_uses_openai_chat_completions_shape() -> None:
     assert captured[0]["timeout"] == 30
 
 
-def test_malformed_llm_json_returns_empty_findings_not_crash() -> None:
+def test_malformed_llm_json_returns_parse_failed_kind() -> None:
     """LLM occasionally returns prose around the JSON or just refuses
-    to comply. Don't crash the webhook on a parse error — degrade to
-    'no findings' with a logged warning."""
+    to comply. Don't crash the webhook on a parse error — discriminated
+    `kind="parse_failed"` so the caller posts an advisory check-run
+    explaining the issue rather than silent "no findings"."""
     response = httpx.Response(200, json=_openai_json_response("sorry, I cannot do that"))
 
     with patch.object(httpx, "post", return_value=response):
         out = review_diff([_hunk()], installation_id=1)
 
-    assert out.findings == []
+    assert out.kind == "parse_failed"
+    assert out.findings == ()
     assert out.backend_used == Backend.OPENROUTER
     assert "parse" in out.error.lower()
+
+
+def test_findings_with_bogus_severity_are_dropped() -> None:
+    """A hallucinating LLM might return severity='catastrophic' which
+    isn't in the Literal. Drop the malformed entry rather than
+    iterating over `Any` downstream."""
+    findings_json = (
+        '{"findings": ['
+        '{"path": "x", "line": 1, "rule": "ok", "severity": "high", "message": ""},'
+        '{"path": "y", "line": 2, "rule": "bad", "severity": "catastrophic", "message": ""},'
+        '{"path": "z", "line": 3, "rule": "also-bad", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    # Bogus-severity entry dropped; valid two remain.
+    assert len(out.findings) == 2
+    assert {f.rule for f in out.findings} == {"ok", "also-bad"}
+
+
+def test_findings_with_missing_fields_are_dropped() -> None:
+    """LLM omitting a required field (e.g. `line`) → drop the entry."""
+    findings_json = (
+        '{"findings": ['
+        '{"path": "x", "rule": "no-line", "severity": "high"},'  # missing line
+        '{"path": "y", "line": 5, "rule": "ok", "severity": "low", "message": ""}'
+        ']}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(findings_json))
+
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(out.findings) == 1
+    assert out.findings[0].rule == "ok"


### PR DESCRIPTION
## Summary

Foundation slice for the Elder (code-reviewer) persona epic (parent #181). Adds a mirrored \`llm_client.py\` module that sends OpenAI-compatible chat completions to either Poolside Laguna or OpenRouter, picked via \`installation_id % 2\`. Returns a structured \`LlmReviewResponse\` carrying findings + backend_used + model_name so DD LLM Obs (sibling slice #187) can attribute findings to backend without an extra trace span. Handles 429 retry with exponential backoff, transport timeouts, and graceful fallback to the other backend on 5xx; total failure degrades to an empty advisory response rather than 500ing the webhook handler. Also wires the Poolside SSM key in Pulumi (the OpenRouter side landed in #194/#238).

## Test plan

- [x] 11 unit tests per service (22 total) covering round-robin, OpenAI request shape, 429 retry, 5xx fallback, transport timeout, total failure, malformed JSON, empty hunks
- [x] Mirror discipline holds — \`llm_client.py\` byte-identical between services mod the MIRRORED header; drift-lint now tracks 10 with-header pairs (was 9)
- [x] Pulumi __main__.py parses; new \`_poolside_api_key\` reference + env var wiring
- [ ] After operator runs \`aws ssm put-parameter\` for the Poolside key + \`pulumi up\`: webhook Lambda env vars include both \`GRUG_OPENROUTER_API_KEY_SSM\` and \`GRUG_POOLSIDE_API_KEY_SSM\`; IAM policy includes both ARNs

## Out of scope

- DD LLM Obs trace spans on every call — sibling slice #187
- Prompt library extraction (system prompt is inline placeholder) — sibling slice #188
- Per-installation prompt A/B variants — sibling slice #191
- Spec 0015 (Elder persona contract) — sibling slice #193 (renumber from 0014 since #173 used that)
- Cost/spend monitoring on the round-robin backends — separate observability slice
- api Lambda LLM access (Elder dispatches from webhook only)

## HITL post-merge

- Operator pre-loads the Poolside API key into SSM:
  \`\`\`bash
  aws ssm put-parameter --region us-east-1 \\
    --name /grug/poolside-api-key --type SecureString --value "<poolside-key>"
  \`\`\`
- Then \`pulumi up\` on the dev stack — applies the new SSM reference + IAM grant + env var injection

Size: M

closes #184