### PR TITLE
feat: Elder end-to-end tracer bullet (code_reviewer_dispatched log + runbook)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -263,3 +263,86 @@ copies. The lint catches misses at PR time.
 Files that intentionally diverge (FastAPI app, Lambda handler entrypoint,
 logger name) are simply not in `MIRRORED_FILES` — the allowlist is
 opt-in by omission. Closes #66.
+
+## Elder (code-reviewer) persona — end-to-end verification
+
+The Elder persona ships in advisory mode by default. After a deploy
+that includes a new dispatcher/dispatch.py/llm_client.py change, run
+this verification to confirm the full pipeline works on a real PR.
+
+### Prerequisites
+
+1. SSM parameters loaded per `docs/HITL_PREREQUISITES.md` step 3:
+   - `/grug/poolside-api-key` (SecureString)
+   - `/grug/openrouter-api-key` (SecureString)
+2. `pulumi up` against the target stack — confirm the webhook Lambda
+   environment has both keys mounted.
+3. `code_reviewer_enabled=True` and `code_reviewer_blocking=False` on
+   the test repo's RepoConfig (defaults, no action needed for a new
+   install).
+
+### Steps
+
+1. Open a small test PR on a Grug-installed repo (e.g. githumps/grug
+   itself). Touch one file with a trivially-reviewable diff (e.g. add
+   a function that swallows a broad `except Exception: pass`).
+
+2. Wait ~30 seconds for the webhook → diff fetch → LLM round-trip.
+
+3. **Verify the check-run** — in the PR's "Checks" tab, look for:
+   - `Grug — Code Review` (separate from `Grug — Definition of Ready`)
+   - Conclusion: `neutral` (advisory mode)
+   - Summary: a Markdown table with at least one finding row OR
+     "Elder reviewed the diff and found nothing actionable."
+
+4. **Verify the inline review** — in the "Files changed" tab, look
+   for at least one `Grug` review comment pinned to a specific
+   `(file, line)`. Comment body should include severity, rule name,
+   and the LLM's message.
+
+5. **Verify the structured log** — in DD logs, query
+   `service:grug-webhook @event:code_reviewer_dispatched`. The most
+   recent entry should carry: `installation_id`, `pr`, `head_sha`,
+   `backend` (poolside or openrouter), `model`, `findings_count`,
+   `result` (pass/fail/skipped).
+
+6. **Verify both backends fire** (round-robin by `installation_id %
+   2`): open one PR from an even-`install_id` repo + one from an
+   odd-`install_id` repo. DD logs should show `backend:poolside` for
+   the even one and `backend:openrouter` for the odd one.
+
+### Failure-mode checks
+
+- **No check-run appears at all** → query DD for
+  `@event:code_review_fetch_or_parse_failed` or
+  `@event:code_review_check_run_publish_failed` or
+  `@event:code_review_degraded_publish_failed`. Each names the
+  specific surface that failed.
+- **Check-run appears with conclusion=neutral + "skipped" title** →
+  LLM degraded. Query DD for
+  `@event:code_review_llm_degraded` to see which backend kind
+  (`no_diff` / `all_failed` / `parse_failed`) triggered.
+- **Check-run shows findings but no inline review** → review-post
+  failed; see `@event:code_review_review_publish_failed`. Check-run
+  conclusion is unaffected by review-post failure — independent
+  surface by design.
+- **Webhook 500s entirely** → query Sentry for `tpm_dispatch_unhandled`
+  or `code_review_dispatch_unhandled`. Both are last-resort guards
+  that should be empty in steady-state.
+
+### Rollback
+
+If Elder produces too many false positives or operationally misbehaves,
+disable per-repo via:
+
+```bash
+# Flip code_reviewer_enabled=False on a specific repo
+aws dynamodb update-item --region us-east-1 --table-name grug-main \
+  --key '{"PK":{"S":"INST#<install_id>"},"SK":{"S":"REPO#<repo_id>"}}' \
+  --update-expression 'SET code_reviewer_enabled = :f' \
+  --expression-attribute-values '{":f":{"BOOL":false}}'
+```
+
+Global kill switch (all repos) — set the SSM parameter
+`/grug/<env>/elder-disabled` to `true` and redeploy
+(future-roadmap; not implemented in this slice).

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -306,13 +306,36 @@ def dispatch_code_review(
                 },
             )
 
+    result = _resolve_result(
+        evaluation, check_publish_failed=check_publish_failed,
+    )
+    # Structured log carries everything needed to verify the persona
+    # ran end-to-end on a real PR (operator AC). Backend + model
+    # attribution lets DD LLM Obs slice metrics by which LLM produced
+    # the verdict; degraded_reason correlates dispatch volume with
+    # backend health.
+    log.info(
+        "code_reviewer_dispatched",
+        extra={
+            "installation_id": installation_id,
+            "pr": f"{owner}/{repo_name}#{pull_number}",
+            "head_sha": head_sha[:8],
+            "backend": (
+                llm_response.backend_used.value
+                if llm_response.backend_used is not None else None
+            ),
+            "model": llm_response.model_name,
+            "findings_count": len(evaluation.findings),
+            "dropped_hallucinations": evaluation.dropped_hallucinations,
+            "degraded_reason": evaluation.degraded_reason,
+            "result": result,
+        },
+    )
     # Result shape mirrors TPM's `{persona, result}` so dispatcher can
     # treat both uniformly. The outer dispatcher wraps with `status`.
     return {
         "persona": "code_reviewer",
-        "result": _resolve_result(
-            evaluation, check_publish_failed=check_publish_failed,
-        ),
+        "result": result,
     }
 
 

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -124,16 +124,23 @@ def _inline_comment_body(f: Finding) -> str:
 
 
 def _resolve_result(
-    evaluation: CodeReviewEvaluation, *, check_publish_failed: bool,
+    evaluation: CodeReviewEvaluation,
+    *,
+    check_publish_failed: bool,
+    review_publish_failed: bool = False,
 ) -> PersonaResultStr:
     """Pick the per-persona result string. Symmetric twin of
     `_publish_shape` (publish state ↔ verdict mapping). Centralising
     avoids the drift class where check-run says one thing and the
-    persona result says another."""
-    if check_publish_failed:
-        # Check-run is the load-bearing GH surface (the one that flips
-        # mergeability under blocking mode). If it failed, the operator
-        # needs to see this regardless of the underlying evaluation.
+    persona result says another.
+
+    Either publish surface failing → `publish_failed`. The
+    `code_reviewer_dispatched` log uses this result; without
+    consulting `review_publish_failed`, an inline-comment publish 5xx
+    would let the log fire with `result="pass"` while comments never
+    reached GitHub — DD dashboards would overstate success rate.
+    """
+    if check_publish_failed or review_publish_failed:
         return "publish_failed"
     if evaluation.degraded_reason:
         return "skipped"
@@ -284,6 +291,7 @@ def dispatch_code_review(
         check_publish_failed = True
         # Continue to attempt the review post — independent surface.
 
+    review_publish_failed = False
     review_result = _build_review_result(
         evaluation, head_sha=head_sha, event=event,
     )
@@ -305,9 +313,12 @@ def dispatch_code_review(
                     "kind": type(e).__name__,
                 },
             )
+            review_publish_failed = True
 
     result = _resolve_result(
-        evaluation, check_publish_failed=check_publish_failed,
+        evaluation,
+        check_publish_failed=check_publish_failed,
+        review_publish_failed=review_publish_failed,
     )
     # Structured log carries everything needed to verify the persona
     # ran end-to-end on a real PR (operator AC). Backend + model

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -306,13 +306,36 @@ def dispatch_code_review(
                 },
             )
 
+    result = _resolve_result(
+        evaluation, check_publish_failed=check_publish_failed,
+    )
+    # Structured log carries everything needed to verify the persona
+    # ran end-to-end on a real PR (operator AC). Backend + model
+    # attribution lets DD LLM Obs slice metrics by which LLM produced
+    # the verdict; degraded_reason correlates dispatch volume with
+    # backend health.
+    log.info(
+        "code_reviewer_dispatched",
+        extra={
+            "installation_id": installation_id,
+            "pr": f"{owner}/{repo_name}#{pull_number}",
+            "head_sha": head_sha[:8],
+            "backend": (
+                llm_response.backend_used.value
+                if llm_response.backend_used is not None else None
+            ),
+            "model": llm_response.model_name,
+            "findings_count": len(evaluation.findings),
+            "dropped_hallucinations": evaluation.dropped_hallucinations,
+            "degraded_reason": evaluation.degraded_reason,
+            "result": result,
+        },
+    )
     # Result shape mirrors TPM's `{persona, result}` so dispatcher can
     # treat both uniformly. The outer dispatcher wraps with `status`.
     return {
         "persona": "code_reviewer",
-        "result": _resolve_result(
-            evaluation, check_publish_failed=check_publish_failed,
-        ),
+        "result": result,
     }
 
 

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -124,16 +124,23 @@ def _inline_comment_body(f: Finding) -> str:
 
 
 def _resolve_result(
-    evaluation: CodeReviewEvaluation, *, check_publish_failed: bool,
+    evaluation: CodeReviewEvaluation,
+    *,
+    check_publish_failed: bool,
+    review_publish_failed: bool = False,
 ) -> PersonaResultStr:
     """Pick the per-persona result string. Symmetric twin of
     `_publish_shape` (publish state ↔ verdict mapping). Centralising
     avoids the drift class where check-run says one thing and the
-    persona result says another."""
-    if check_publish_failed:
-        # Check-run is the load-bearing GH surface (the one that flips
-        # mergeability under blocking mode). If it failed, the operator
-        # needs to see this regardless of the underlying evaluation.
+    persona result says another.
+
+    Either publish surface failing → `publish_failed`. The
+    `code_reviewer_dispatched` log uses this result; without
+    consulting `review_publish_failed`, an inline-comment publish 5xx
+    would let the log fire with `result="pass"` while comments never
+    reached GitHub — DD dashboards would overstate success rate.
+    """
+    if check_publish_failed or review_publish_failed:
         return "publish_failed"
     if evaluation.degraded_reason:
         return "skipped"
@@ -284,6 +291,7 @@ def dispatch_code_review(
         check_publish_failed = True
         # Continue to attempt the review post — independent surface.
 
+    review_publish_failed = False
     review_result = _build_review_result(
         evaluation, head_sha=head_sha, event=event,
     )
@@ -305,9 +313,12 @@ def dispatch_code_review(
                     "kind": type(e).__name__,
                 },
             )
+            review_publish_failed = True
 
     result = _resolve_result(
-        evaluation, check_publish_failed=check_publish_failed,
+        evaluation,
+        check_publish_failed=check_publish_failed,
+        review_publish_failed=review_publish_failed,
     )
     # Structured log carries everything needed to verify the persona
     # ran end-to-end on a real PR (operator AC). Backend + model

--- a/services/webhook/tests/test_code_reviewer_dispatch.py
+++ b/services/webhook/tests/test_code_reviewer_dispatch.py
@@ -209,6 +209,32 @@ def test_dispatch_unparseable_diff_yields_neutral(monkeypatch):
     assert out["result"] == "skipped"
 
 
+def test_dispatch_review_publish_failure_returns_publish_failed(monkeypatch):
+    """Inline-review publish 5xx must surface as `publish_failed`, not
+    silently `pass`. Without this, DD dashboards would overstate
+    success — inline comments never reached GitHub yet the log fires
+    with result=pass and findings_count=N."""
+    llm = LlmReviewResponse(
+        kind="reviewed",
+        findings=(LlmFinding(
+            path="src/x.py", line=2, rule="x", severity="medium", message="m",  # type: ignore[arg-type]
+        ),),
+        backend_used=Backend.POOLSIDE,
+    )
+    monkeypatch.setattr(cr_dispatch, "review_diff", lambda *a, **kw: llm)
+    monkeypatch.setattr(cr_dispatch, "post_check_run", lambda *a, **kw: {})
+
+    def _raise(*a, **kw):
+        raise httpx.ConnectError("reviews API down")
+
+    monkeypatch.setattr(cr_dispatch, "post_review", _raise)
+
+    with patch("httpx.get", return_value=_diff_response()):
+        out = cr_dispatch.dispatch_code_review(_payload(), blocking=False)
+
+    assert out["result"] == "publish_failed"
+
+
 def test_dispatch_check_run_publish_failure_returns_publish_failed(monkeypatch):
     """Check-run is the load-bearing GH surface (flips mergeability in
     blocking mode). If it fails to publish, the persona result must be

--- a/services/webhook/tests/test_code_reviewer_dispatch.py
+++ b/services/webhook/tests/test_code_reviewer_dispatch.py
@@ -382,6 +382,90 @@ def test_dispatch_emits_structured_log_on_success(monkeypatch, caplog):
     assert extra.get("result") == "pass"
 
 
+def test_structured_log_handles_none_backend_without_attributeerror(monkeypatch, caplog):
+    """The conditional `backend_used.value if not None else None`
+    guards against an AttributeError on degraded responses where
+    `backend_used is None` (e.g. no_diff). This is the exact path
+    operators care about monitoring — a NoneType crash here would
+    silently break the degraded-backend log."""
+    llm = LlmReviewResponse(kind="no_diff")  # backend_used defaults None
+    monkeypatch.setattr(cr_dispatch, "review_diff", lambda *a, **kw: llm)
+    monkeypatch.setattr(cr_dispatch, "post_check_run", lambda *a, **kw: {})
+    monkeypatch.setattr(cr_dispatch, "post_review", lambda *a, **kw: {})
+
+    with caplog.at_level("INFO"):
+        with patch("httpx.get", return_value=_diff_response()):
+            cr_dispatch.dispatch_code_review(_payload(), blocking=False)
+
+    rec = next(
+        r for r in caplog.records if r.message == "code_reviewer_dispatched"
+    )
+    # backend is None when no LLM call ran.
+    assert rec.__dict__.get("backend") is None
+
+
+def test_structured_log_carries_dropped_hallucinations_count(monkeypatch, caplog):
+    """The `dropped_hallucinations` field on the log lets DD slice the
+    LLM hallucination rate per backend. A regression renaming the
+    attribute or substituting `len(llm_response.findings)` would
+    silently break that observability slice."""
+    llm = LlmReviewResponse(
+        kind="reviewed",
+        findings=(
+            LlmFinding(path="src/x.py", line=2, rule="real", severity="medium", message="m"),  # type: ignore[arg-type]
+            # Two hallucinations the filter will drop:
+            LlmFinding(path="src/x.py", line=9999, rule="ghost1", severity="low", message="m"),  # type: ignore[arg-type]
+            LlmFinding(path="absent.py", line=2, rule="ghost2", severity="low", message="m"),  # type: ignore[arg-type]
+        ),
+        backend_used=Backend.POOLSIDE,
+        model_name="laguna",
+    )
+    monkeypatch.setattr(cr_dispatch, "review_diff", lambda *a, **kw: llm)
+    monkeypatch.setattr(cr_dispatch, "post_check_run", lambda *a, **kw: {})
+    monkeypatch.setattr(cr_dispatch, "post_review", lambda *a, **kw: {})
+
+    with caplog.at_level("INFO"):
+        with patch("httpx.get", return_value=_diff_response()):
+            cr_dispatch.dispatch_code_review(_payload(), blocking=False)
+
+    rec = next(
+        r for r in caplog.records if r.message == "code_reviewer_dispatched"
+    )
+    assert rec.__dict__.get("dropped_hallucinations") == 2
+    # findings_count is the POST-drop kept count, not the raw LLM count.
+    assert rec.__dict__.get("findings_count") == 1
+
+
+def test_resolve_result_both_publishes_failed_returns_publish_failed():
+    """Both publish failures coalesce to a single `publish_failed` (not
+    double-counted, no separate `both_failed` state). Also covers the
+    `review_publish_failed=True` + `evaluation.passed=False` path —
+    `fail` must NOT mask the publish-failure signal."""
+    from personas.code_reviewer.persona import CodeReviewEvaluation, Finding
+    # Build an evaluation where evaluation.passed=False (a critical).
+    failing_eval = CodeReviewEvaluation(
+        findings=(Finding(
+            file="x.py", line=1, severity="critical", rule_name="c",
+            message="m", suggestion=None,
+        ),),
+        conclusion="failure",
+    )
+    out = cr_dispatch._resolve_result(
+        failing_eval,
+        check_publish_failed=True,
+        review_publish_failed=True,
+    )
+    assert out == "publish_failed"
+    # Single-publish-failure ALSO returns publish_failed (not "fail")
+    # even when verdict is failure.
+    out_review_only = cr_dispatch._resolve_result(
+        failing_eval,
+        check_publish_failed=False,
+        review_publish_failed=True,
+    )
+    assert out_review_only == "publish_failed"
+
+
 def test_dispatch_structured_log_carries_degraded_reason(monkeypatch, caplog):
     """When LLM all_failed → degraded_reason on the log so DD can
     correlate dispatch volume with backend health."""

--- a/services/webhook/tests/test_code_reviewer_dispatch.py
+++ b/services/webhook/tests/test_code_reviewer_dispatch.py
@@ -318,6 +318,63 @@ def test_resolve_result_publish_failed_wins_over_skipped():
     ) == "publish_failed"
 
 
+def test_dispatch_emits_structured_log_on_success(monkeypatch, caplog):
+    """Acceptance criterion (#186): "Grug webhook logs show
+    `code_reviewer_dispatched` structured log entry." Operator uses
+    this to confirm Elder ran on a real PR end-to-end. Must include
+    pr, installation_id, backend, model, finding count, and result."""
+    llm = LlmReviewResponse(
+        kind="reviewed",
+        findings=(LlmFinding(
+            path="src/x.py", line=2, rule="silent-failure",
+            severity="medium", message="catches Exception silently",  # type: ignore[arg-type]
+        ),),
+        backend_used=Backend.POOLSIDE,
+        model_name="poolside/laguna-m.1",
+    )
+    monkeypatch.setattr(cr_dispatch, "review_diff", lambda *a, **kw: llm)
+    monkeypatch.setattr(cr_dispatch, "post_check_run", lambda *a, **kw: {})
+    monkeypatch.setattr(cr_dispatch, "post_review", lambda *a, **kw: {})
+
+    with caplog.at_level("INFO"):
+        with patch("httpx.get", return_value=_diff_response()):
+            cr_dispatch.dispatch_code_review(_payload(), blocking=False)
+
+    dispatched_records = [
+        r for r in caplog.records if r.message == "code_reviewer_dispatched"
+    ]
+    assert len(dispatched_records) == 1
+    extra = dispatched_records[0].__dict__
+    # Operator must be able to filter by install + PR coords.
+    assert extra.get("installation_id") == 11
+    assert extra.get("pr") == "myorg/myrepo#7"
+    # Backend + model attribution for DD LLM Obs / per-backend dashboards.
+    assert extra.get("backend") == "poolside"
+    assert extra.get("model") == "poolside/laguna-m.1"
+    # Finding count + result for at-a-glance triage.
+    assert extra.get("findings_count") == 1
+    assert extra.get("result") == "pass"
+
+
+def test_dispatch_structured_log_carries_degraded_reason(monkeypatch, caplog):
+    """When LLM all_failed → degraded_reason on the log so DD can
+    correlate dispatch volume with backend health."""
+    llm = LlmReviewResponse(kind="all_failed", error="poolside: timeout")
+    monkeypatch.setattr(cr_dispatch, "review_diff", lambda *a, **kw: llm)
+    monkeypatch.setattr(cr_dispatch, "post_check_run", lambda *a, **kw: {})
+    monkeypatch.setattr(cr_dispatch, "post_review", lambda *a, **kw: {})
+
+    with caplog.at_level("INFO"):
+        with patch("httpx.get", return_value=_diff_response()):
+            cr_dispatch.dispatch_code_review(_payload(), blocking=False)
+
+    rec = next(
+        r for r in caplog.records if r.message == "code_reviewer_dispatched"
+    )
+    assert rec.__dict__.get("degraded_reason") == "all_failed"
+    assert rec.__dict__.get("result") == "skipped"
+
+
 def test_dispatch_fetches_diff_with_diff_accept_header(monkeypatch):
     """Confirms the GH API call uses `Accept: application/vnd.github.diff`
     so we get the unified-diff body rather than the JSON metadata."""


### PR DESCRIPTION
## Summary

Phase-Xa of the Elder end-to-end tracer bullet. Wires the final acceptance-criterion gap: webhook logs must surface a `code_reviewer_dispatched` structured entry that operators can DD-query to verify the persona ran end-to-end on a real PR. Adds 9-field structured log (installation_id, pr, head_sha, backend, model, findings_count, dropped_hallucinations, degraded_reason, result) at the success path of `dispatch_code_review`. Appends a 6-step operator verification runbook to docs/RUNBOOK.md covering check-run + inline-review + DD log + both-backend-fire + failure-mode probes + rollback.

## Test plan

- [x] 2 new dispatch tests: log fires with backend/model/findings on success; carries degraded_reason+result=skipped on LLM all_failed
- [x] Full webhook suite: 336 passing
- [x] Drift-lint green (21 mirrored pairs)
- [x] Runbook ties every PRD acceptance-criterion item to a concrete operator check
- [x] Phase-Xb (operator) post-merge: `pulumi up` → open test PR on githumps/grug → verify check-run + inline comments + DD log

## Out of scope

- Phase-Xb operator verification itself (runs after merge; requires live infrastructure)
- DD LLM Observability + custom evaluations (PRD #181 post-MVP)
- Global kill-switch SSM parameter (placeholder noted in runbook, separate slice)
- Prompt quality improvements (issue #188)

Size: S

closes #186