### PR TITLE
feat: DD LLM Obs tracing for every code-review LLM call

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -213,6 +213,14 @@ webhook = lambda_service.create(
         "DD_GIT_COMMIT_SHA": _full_commit_sha,
         "DD_TRACE_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
+        # DD LLM Observability for the Elder code-reviewer persona.
+        # Every review_diff() backend call emits a span with prompt,
+        # response, tokens, latency, and PR-context tags. ML app name
+        # `grug-elder` groups traces in the LLM Obs UI. Webhook-only:
+        # api Lambda never makes LLM calls so this env var is omitted
+        # from the api section below.
+        "DD_LLMOBS_ENABLED": "true",
+        "DD_LLMOBS_ML_APP": "grug-elder",
         # Disable noisy ASGI integration that collapses every FastAPI
         # request into a single "ASGI request" trace span (per memory
         # `reference_dd_apm_asgi_resource_grouping`).

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -214,11 +214,8 @@ webhook = lambda_service.create(
         "DD_TRACE_ENABLED": "true",
         "DD_LOGS_INJECTION": "true",
         # DD LLM Observability for the Elder code-reviewer persona.
-        # Every review_diff() backend call emits a span with prompt,
-        # response, tokens, latency, and PR-context tags. ML app name
-        # `grug-elder` groups traces in the LLM Obs UI. Webhook-only:
-        # api Lambda never makes LLM calls so this env var is omitted
-        # from the api section below.
+        # Webhook-only: api Lambda never makes LLM calls so these env
+        # vars are omitted from the api section below.
         "DD_LLMOBS_ENABLED": "true",
         "DD_LLMOBS_ML_APP": "grug-elder",
         # Disable noisy ASGI integration that collapses every FastAPI

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -38,6 +38,45 @@ from secrets_loader import get_openrouter_api_key, get_poolside_api_key
 
 log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.llm_client")
 
+# DD LLM Observability seams. Imported lazily and wrapped behind module-
+# level indirection so:
+#   1. Tests can monkeypatch `_llmobs_llm` / `_llmobs_annotate` without
+#      touching the real ddtrace.llmobs SDK.
+#   2. Cold-start cost of `ddtrace.llmobs` is paid once on first call,
+#      not at import time.
+#   3. If `DD_LLMOBS_ENABLED` is unset (local dev, tests), the span
+#      becomes a no-op rather than failing loudly.
+try:  # pragma: no cover — import-time guard
+    from ddtrace.llmobs import LLMObs as _LLMObs
+
+    def _llmobs_llm(**kwargs: Any) -> Any:
+        return _LLMObs.llm(**kwargs)
+
+    def _llmobs_annotate(**kwargs: Any) -> None:
+        _LLMObs.annotate(**kwargs)
+except ImportError:  # pragma: no cover — local dev without ddtrace
+
+    class _NoopSpan:
+        def __enter__(self) -> "_NoopSpan":
+            return self
+        def __exit__(self, *a: Any) -> bool:
+            return False
+
+    def _llmobs_llm(**kwargs: Any) -> Any:
+        return _NoopSpan()
+
+    def _llmobs_annotate(**kwargs: Any) -> None:
+        return None
+
+_LLMOBS_NAME = "elder_code_review"
+_LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
+
+
+def _elapsed_ms(start_ns: int) -> int:
+    """Wall-clock elapsed in ms since `start_ns` (monotonic). Used for
+    LLM Obs latency metrics — `time.monotonic_ns` avoids clock-skew."""
+    return (time.monotonic_ns() - start_ns) // 1_000_000
+
 # Per-backend endpoints + default models.
 _POOLSIDE_URL = "https://inference.poolside.ai/v1/chat/completions"
 _POOLSIDE_MODEL = "poolside/laguna-m.1"
@@ -346,8 +385,48 @@ def _parse_response(
     return tuple(coerced), model_name, ""
 
 
+def _llmobs_tags(pr_context: Optional[dict]) -> dict[str, str]:
+    """Build the tag dict for an LLM Obs span from `pr_context`.
+
+    Tags are stringified because DD facet types are inferred from the
+    first value seen — keeping all coords as strings prevents schema
+    drift if a future call passes an int where another passed a string.
+    `head_sha` is truncated to 8 chars so the tag-cardinality budget
+    isn't blown by full 40-char hashes.
+    """
+    if not pr_context:
+        return {}
+    tags: dict[str, str] = {}
+    if "installation_id" in pr_context:
+        tags["installation_id"] = str(pr_context["installation_id"])
+    if "repo" in pr_context:
+        tags["repo"] = str(pr_context["repo"])
+    if "pr_number" in pr_context:
+        tags["pr_number"] = str(pr_context["pr_number"])
+    if "head_sha" in pr_context:
+        tags["head_sha"] = str(pr_context["head_sha"])[:_LLMOBS_HEAD_SHA_TAG_LEN]
+    return tags
+
+
+def _extract_usage_metrics(body: Any) -> dict[str, Optional[int]]:
+    """Pull token counts from an OpenAI-compat response body. Missing
+    `usage` is normal (OpenRouter free-tier omits it sometimes) and
+    must not crash the span emission."""
+    if not isinstance(body, dict):
+        return {"input_tokens": None, "output_tokens": None}
+    usage = body.get("usage") or {}
+    if not isinstance(usage, dict):
+        return {"input_tokens": None, "output_tokens": None}
+    return {
+        "input_tokens": usage.get("prompt_tokens"),
+        "output_tokens": usage.get("completion_tokens"),
+    }
+
+
 def review_diff(
-    hunks: list[Hunk], installation_id: int
+    hunks: list[Hunk],
+    installation_id: int,
+    pr_context: Optional[dict] = None,
 ) -> LlmReviewResponse:
     """Send `hunks` to the round-robin-selected LLM and return findings.
 
@@ -356,6 +435,10 @@ def review_diff(
       - `reviewed`: at least one backend returned a parseable payload.
       - `parse_failed`: LLM responded but the content wasn't usable JSON.
       - `all_failed`: every backend errored or timed out.
+
+    `pr_context` (Optional dict) carries the PR coords for DD LLM Obs
+    tags. Keys consumed: installation_id, repo, pr_number, head_sha.
+    Omitted ⇒ traces still emit but without filterable PR tags.
     """
     if not hunks:
         return LlmReviewResponse(kind="no_diff")
@@ -365,27 +448,80 @@ def review_diff(
         Backend.OPENROUTER if primary == Backend.POOLSIDE else Backend.POOLSIDE
     )
     messages = _build_messages(hunks)
+    pr_tags = _llmobs_tags(pr_context)
 
     last_error = ""
     for backend in (primary, secondary):
         config = _BACKEND_CONFIGS[backend]
-        try:
-            resp = _call_backend(config, messages)
-        except _BackendConfigError as e:
-            log.error(
-                "llm_backend_misconfigured",
-                extra={"backend": backend.value, "detail": str(e)},
+        # Open one LLM Obs span per backend attempt. Annotate on every
+        # exit path (success + failures) so DD captures latency tails
+        # and error rates per-backend.
+        start_ns = time.monotonic_ns()
+        with _llmobs_llm(
+            model_name=config.model,
+            model_provider=backend.value,
+            name=_LLMOBS_NAME,
+        ) as span:
+            try:
+                resp = _call_backend(config, messages)
+            except _BackendConfigError as e:
+                log.error(
+                    "llm_backend_misconfigured",
+                    extra={"backend": backend.value, "detail": str(e)},
+                )
+                _llmobs_annotate(
+                    span=span, input_data=messages,
+                    metadata={"backend": backend.value, "error": "config"},
+                    metrics={"latency_ms": _elapsed_ms(start_ns)},
+                    tags=pr_tags,
+                )
+                last_error = f"{backend.value} misconfigured: {e}"
+                continue
+            except (httpx.RequestError, httpx.TimeoutException) as e:
+                log.warning(
+                    "llm_backend_transport_failed",
+                    extra={"backend": backend.value, "kind": type(e).__name__},
+                )
+                _llmobs_annotate(
+                    span=span, input_data=messages,
+                    metadata={"backend": backend.value, "error": type(e).__name__},
+                    metrics={"latency_ms": _elapsed_ms(start_ns)},
+                    tags=pr_tags,
+                )
+                last_error = f"{backend.value}: {type(e).__name__}"
+                continue
+            findings, model, err = _parse_response(resp)
+            # Annotate AFTER the response is parsed so we capture the
+            # raw content + token counts. resp.json() was already
+            # consumed inside _parse_response; re-call it here for the
+            # span input — httpx caches the parsed body so this is cheap.
+            try:
+                body = resp.json() if resp.status_code == 200 else {}
+            except (ValueError, json.JSONDecodeError):
+                body = {}
+            content = ""
+            if isinstance(body, dict):
+                choices = body.get("choices") or []
+                if choices and isinstance(choices[0], dict):
+                    content = (choices[0].get("message") or {}).get("content", "")
+            usage_metrics = _extract_usage_metrics(body)
+            _llmobs_annotate(
+                span=span,
+                input_data=messages,
+                output_data=content or None,
+                metadata={
+                    "backend": backend.value,
+                    "status_code": resp.status_code,
+                    "kind": "reviewed" if not err else (
+                        "parse_failed" if resp.status_code == 200 else "http_error"
+                    ),
+                },
+                metrics={
+                    "latency_ms": _elapsed_ms(start_ns),
+                    **usage_metrics,
+                },
+                tags=pr_tags,
             )
-            last_error = f"{backend.value} misconfigured: {e}"
-            continue
-        except (httpx.RequestError, httpx.TimeoutException) as e:
-            log.warning(
-                "llm_backend_transport_failed",
-                extra={"backend": backend.value, "kind": type(e).__name__},
-            )
-            last_error = f"{backend.value}: {type(e).__name__}"
-            continue
-        findings, model, err = _parse_response(resp)
         if not err:
             return LlmReviewResponse(
                 kind="reviewed",

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -68,6 +68,15 @@ except ImportError:  # pragma: no cover — local dev without ddtrace
     def _llmobs_annotate(**kwargs: Any) -> None:
         return None
 
+    # Loud signal so a layer-drift / partial-install in Lambda doesn't
+    # silently turn off DD LLM Obs. AWS_LAMBDA_FUNCTION_NAME is the
+    # canonical Lambda-environment marker; in local dev it's unset.
+    if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+        log.warning(
+            "llmobs_import_failed_falling_back_to_noop",
+            extra={"lambda_fn": os.environ["AWS_LAMBDA_FUNCTION_NAME"]},
+        )
+
 _LLMOBS_NAME = "elder_code_review"
 _LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
 
@@ -514,6 +523,19 @@ def review_diff(
             try:
                 body = resp.json() if resp.status_code == 200 else {}
             except (ValueError, json.JSONDecodeError):
+                # The first parse succeeded (otherwise err would be
+                # truthy and we'd skip the body fields); a re-parse
+                # failure here means httpx cache mutation or a real
+                # divergence. Log so DD can alert on the rate —
+                # silently emitting `kind=reviewed` with empty
+                # content would undercount token cost in dashboards.
+                log.warning(
+                    "llm_body_reparse_failed",
+                    extra={
+                        "backend": backend.value,
+                        "status_code": resp.status_code,
+                    },
+                )
                 body = {}
             content = ""
             if isinstance(body, dict):

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -518,8 +518,10 @@ def review_diff(
             findings, model, err = _parse_response(resp)
             # Annotate AFTER the response is parsed so we capture the
             # raw content + token counts. resp.json() was already
-            # consumed inside _parse_response; re-call it here for the
-            # span input — httpx caches the parsed body so this is cheap.
+            # consumed inside _parse_response; re-call here for the
+            # span input. httpx.Response.json() re-parses every call,
+            # but review response bodies are small — re-parse cost is
+            # negligible vs the LLM round-trip we just paid.
             try:
                 body = resp.json() if resp.status_code == 200 else {}
             except (ValueError, json.JSONDecodeError):

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -79,6 +80,63 @@ except ImportError:  # pragma: no cover — local dev without ddtrace
 
 _LLMOBS_NAME = "elder_code_review"
 _LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
+
+# Per-payload cap on input/output captured in LLM Obs spans. Bounded
+# because PR diffs can contain massive blobs (PEM files, lockfiles,
+# generated code) — without this, a single .env-touching PR could
+# persist KB of secrets in DD storage. 16 KB is large enough to keep
+# typical review context but small enough to bound exposure.
+_LLMOBS_PAYLOAD_TRUNC_BYTES = 16 * 1024
+
+# Best-effort redaction patterns applied BEFORE payloads leave the
+# process. Defense-in-depth atop DD's org-level sensitive data scanner
+# — the scanner runs on ingest, but we should not be shipping raw
+# secrets across the wire in the first place. Pattern order: anchored
+# format-specific first (AWS, GitHub, Slack), then the generic
+# "key=value" sweeps. False positives are acceptable; missing a real
+# secret is not.
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:aws-access-key]"),
+    (re.compile(r"ghp_[A-Za-z0-9]{36,}"), "[REDACTED:github-pat]"),
+    (re.compile(r"ghs_[A-Za-z0-9]{36,}"), "[REDACTED:github-app-token]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{82,}"), "[REDACTED:github-fine-grained-pat]"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "[REDACTED:slack-token]"),
+    (re.compile(r"sk-[A-Za-z0-9]{32,}"), "[REDACTED:openai-style-key]"),
+    (re.compile(r"sk-or-v1-[A-Za-z0-9]{32,}"), "[REDACTED:openrouter-key]"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"), "[REDACTED:pem-private-key]"),
+    # Generic `KEY=VALUE` env-var leak inside an added diff line.
+    # Min-length 8 catches `secret=hunter22` but not `key=42`; longer
+    # is too strict (real secrets like `secret12345` would slip).
+    (re.compile(
+        r'((?:password|passwd|secret|api[-_]?key|token|access[-_]?key)\s*[:=]\s*)["\']?[A-Za-z0-9_\-+/=]{8,}["\']?',
+        re.IGNORECASE,
+    ), r"\1[REDACTED:env-secret]"),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Apply best-effort secret-pattern redaction. False positives are
+    acceptable (an `AKIA...`-shaped string in code that isn't an AWS
+    key still gets masked); missing a real secret is not. Patterns
+    target shapes most likely to appear in a PR diff: AWS/GH tokens,
+    Slack bot tokens, PEM private keys, `KEY=VALUE` env lines."""
+    for pattern, repl in _SECRET_PATTERNS:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def _redact_payload(payload: Any) -> Any:
+    """Walk a payload (str | list-of-message-dicts | dict) and apply
+    `_redact_secrets` to every string value. Truncates each string to
+    `_LLMOBS_PAYLOAD_TRUNC_BYTES` AFTER redaction so a trailing PEM
+    fragment can't survive a mid-string cut."""
+    if isinstance(payload, str):
+        return _redact_secrets(payload)[:_LLMOBS_PAYLOAD_TRUNC_BYTES]
+    if isinstance(payload, list):
+        return [_redact_payload(item) for item in payload]
+    if isinstance(payload, dict):
+        return {k: _redact_payload(v) for k, v in payload.items()}
+    return payload
 
 
 class PrContext(TypedDict, total=False):
@@ -497,7 +555,7 @@ def review_diff(
                     extra={"backend": backend.value, "detail": str(e)},
                 )
                 _llmobs_annotate(
-                    span=span, input_data=messages,
+                    span=span, input_data=_redact_payload(messages),
                     metadata={"backend": backend.value, "error": "config"},
                     metrics={"latency_ms": _elapsed_ms(start_ns)},
                     tags=pr_tags,
@@ -510,7 +568,7 @@ def review_diff(
                     extra={"backend": backend.value, "kind": type(e).__name__},
                 )
                 _llmobs_annotate(
-                    span=span, input_data=messages,
+                    span=span, input_data=_redact_payload(messages),
                     metadata={"backend": backend.value, "error": type(e).__name__},
                     metrics={"latency_ms": _elapsed_ms(start_ns)},
                     tags=pr_tags,
@@ -547,8 +605,8 @@ def review_diff(
             usage_metrics = _extract_usage_metrics(body)
             _llmobs_annotate(
                 span=span,
-                input_data=messages,
-                output_data=content or None,
+                input_data=_redact_payload(messages),
+                output_data=_redact_payload(content) if content else None,
                 metadata={
                     "backend": backend.value,
                     "status_code": resp.status_code,

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -30,7 +30,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Literal, Optional, get_args
+from typing import Any, Callable, Literal, Optional, TypedDict, get_args
 
 import httpx
 
@@ -70,6 +70,22 @@ except ImportError:  # pragma: no cover — local dev without ddtrace
 
 _LLMOBS_NAME = "elder_code_review"
 _LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
+
+
+class PrContext(TypedDict, total=False):
+    """PR coords threaded into DD LLM Obs span tags.
+
+    `total=False` (every key optional) because callers without GH
+    coords (e.g. ad-hoc tests, future REPL probes) still need to be
+    able to call `review_diff` — they just get traces without
+    PR-filterable tags. Promoting from a bare `dict` makes typos like
+    `pr_num` fail at type-check time rather than silently dropping the
+    tag in DD.
+    """
+    installation_id: int
+    repo: str
+    pr_number: int
+    head_sha: str
 
 
 def _elapsed_ms(start_ns: int) -> int:
@@ -385,7 +401,7 @@ def _parse_response(
     return tuple(coerced), model_name, ""
 
 
-def _llmobs_tags(pr_context: Optional[dict]) -> dict[str, str]:
+def _llmobs_tags(pr_context: Optional[PrContext]) -> dict[str, str]:
     """Build the tag dict for an LLM Obs span from `pr_context`.
 
     Tags are stringified because DD facet types are inferred from the
@@ -426,7 +442,7 @@ def _extract_usage_metrics(body: Any) -> dict[str, Optional[int]]:
 def review_diff(
     hunks: list[Hunk],
     installation_id: int,
-    pr_context: Optional[dict] = None,
+    pr_context: Optional[PrContext] = None,
 ) -> LlmReviewResponse:
     """Send `hunks` to the round-robin-selected LLM and return findings.
 

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -98,8 +98,7 @@ class PrContext(TypedDict, total=False):
 
 
 def _elapsed_ms(start_ns: int) -> int:
-    """Wall-clock elapsed in ms since `start_ns` (monotonic). Used for
-    LLM Obs latency metrics — `time.monotonic_ns` avoids clock-skew."""
+    """`time.monotonic_ns` avoids clock-skew during the span."""
     return (time.monotonic_ns() - start_ns) // 1_000_000
 
 # Per-backend endpoints + default models.
@@ -479,8 +478,11 @@ def review_diff(
     for backend in (primary, secondary):
         config = _BACKEND_CONFIGS[backend]
         # Open one LLM Obs span per backend attempt. Annotate on every
-        # exit path (success + failures) so DD captures latency tails
-        # and error rates per-backend.
+        # CAUGHT exit path (success + the three explicit `except` arms)
+        # so DD captures latency tails and per-backend error rates. A
+        # surprise exception escaping `_call_backend` would propagate
+        # without annotation — that's intentional (it's a bug worth
+        # seeing in Sentry, not a routine signal).
         start_ns = time.monotonic_ns()
         with _llmobs_llm(
             model_name=config.model,
@@ -516,21 +518,19 @@ def review_diff(
                 last_error = f"{backend.value}: {type(e).__name__}"
                 continue
             findings, model, err = _parse_response(resp)
-            # Annotate AFTER the response is parsed so we capture the
-            # raw content + token counts. resp.json() was already
-            # consumed inside _parse_response; re-call here for the
-            # span input. httpx.Response.json() re-parses every call,
-            # but review response bodies are small — re-parse cost is
-            # negligible vs the LLM round-trip we just paid.
+            # Annotate AFTER the response so we capture the raw content
+            # + token counts. httpx.Response.json() re-parses from the
+            # cached .content bytes; review response bodies are small,
+            # so the cost is negligible vs the LLM round-trip.
             try:
                 body = resp.json() if resp.status_code == 200 else {}
             except (ValueError, json.JSONDecodeError):
-                # The first parse succeeded (otherwise err would be
-                # truthy and we'd skip the body fields); a re-parse
-                # failure here means httpx cache mutation or a real
-                # divergence. Log so DD can alert on the rate —
-                # silently emitting `kind=reviewed` with empty
-                # content would undercount token cost in dashboards.
+                # Triggered when the first parse also failed (CF HTML
+                # interstitial, truncated body) OR — rarely — when
+                # the cache diverges. Either way the LLM Obs span
+                # would otherwise silently emit kind=reviewed with
+                # empty content and undercount DD token-cost
+                # dashboards.
                 log.warning(
                     "llm_body_reparse_failed",
                     extra={

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -236,9 +236,7 @@ def dispatch_code_review(
             reason="fetch_or_parse_failed",
         )
 
-    # review_diff already swallows backend failures into discriminated
-    # `LlmReviewResponse.kind` values; no extra try needed. The
-    # `pr_context` dict flows into DD LLM Obs span tags so traces are
+    # `pr_context` flows into DD LLM Obs span tags so traces are
     # filterable by repo / PR / installation in the LLM Obs UI.
     llm_response: LlmReviewResponse = review_diff(
         _to_llm_hunks(hunks),

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -237,9 +237,18 @@ def dispatch_code_review(
         )
 
     # review_diff already swallows backend failures into discriminated
-    # `LlmReviewResponse.kind` values; no extra try needed.
+    # `LlmReviewResponse.kind` values; no extra try needed. The
+    # `pr_context` dict flows into DD LLM Obs span tags so traces are
+    # filterable by repo / PR / installation in the LLM Obs UI.
     llm_response: LlmReviewResponse = review_diff(
-        _to_llm_hunks(hunks), installation_id=installation_id,
+        _to_llm_hunks(hunks),
+        installation_id=installation_id,
+        pr_context={
+            "installation_id": installation_id,
+            "repo": f"{owner}/{repo_name}",
+            "pr_number": pull_number,
+            "head_sha": head_sha,
+        },
     )
     if llm_response.kind != "reviewed":
         # Without this log, a 100% LLM-outage rate looks identical to

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -38,6 +38,45 @@ from secrets_loader import get_openrouter_api_key, get_poolside_api_key
 
 log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.llm_client")
 
+# DD LLM Observability seams. Imported lazily and wrapped behind module-
+# level indirection so:
+#   1. Tests can monkeypatch `_llmobs_llm` / `_llmobs_annotate` without
+#      touching the real ddtrace.llmobs SDK.
+#   2. Cold-start cost of `ddtrace.llmobs` is paid once on first call,
+#      not at import time.
+#   3. If `DD_LLMOBS_ENABLED` is unset (local dev, tests), the span
+#      becomes a no-op rather than failing loudly.
+try:  # pragma: no cover — import-time guard
+    from ddtrace.llmobs import LLMObs as _LLMObs
+
+    def _llmobs_llm(**kwargs: Any) -> Any:
+        return _LLMObs.llm(**kwargs)
+
+    def _llmobs_annotate(**kwargs: Any) -> None:
+        _LLMObs.annotate(**kwargs)
+except ImportError:  # pragma: no cover — local dev without ddtrace
+
+    class _NoopSpan:
+        def __enter__(self) -> "_NoopSpan":
+            return self
+        def __exit__(self, *a: Any) -> bool:
+            return False
+
+    def _llmobs_llm(**kwargs: Any) -> Any:
+        return _NoopSpan()
+
+    def _llmobs_annotate(**kwargs: Any) -> None:
+        return None
+
+_LLMOBS_NAME = "elder_code_review"
+_LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
+
+
+def _elapsed_ms(start_ns: int) -> int:
+    """Wall-clock elapsed in ms since `start_ns` (monotonic). Used for
+    LLM Obs latency metrics — `time.monotonic_ns` avoids clock-skew."""
+    return (time.monotonic_ns() - start_ns) // 1_000_000
+
 # Per-backend endpoints + default models.
 _POOLSIDE_URL = "https://inference.poolside.ai/v1/chat/completions"
 _POOLSIDE_MODEL = "poolside/laguna-m.1"
@@ -346,8 +385,48 @@ def _parse_response(
     return tuple(coerced), model_name, ""
 
 
+def _llmobs_tags(pr_context: Optional[dict]) -> dict[str, str]:
+    """Build the tag dict for an LLM Obs span from `pr_context`.
+
+    Tags are stringified because DD facet types are inferred from the
+    first value seen — keeping all coords as strings prevents schema
+    drift if a future call passes an int where another passed a string.
+    `head_sha` is truncated to 8 chars so the tag-cardinality budget
+    isn't blown by full 40-char hashes.
+    """
+    if not pr_context:
+        return {}
+    tags: dict[str, str] = {}
+    if "installation_id" in pr_context:
+        tags["installation_id"] = str(pr_context["installation_id"])
+    if "repo" in pr_context:
+        tags["repo"] = str(pr_context["repo"])
+    if "pr_number" in pr_context:
+        tags["pr_number"] = str(pr_context["pr_number"])
+    if "head_sha" in pr_context:
+        tags["head_sha"] = str(pr_context["head_sha"])[:_LLMOBS_HEAD_SHA_TAG_LEN]
+    return tags
+
+
+def _extract_usage_metrics(body: Any) -> dict[str, Optional[int]]:
+    """Pull token counts from an OpenAI-compat response body. Missing
+    `usage` is normal (OpenRouter free-tier omits it sometimes) and
+    must not crash the span emission."""
+    if not isinstance(body, dict):
+        return {"input_tokens": None, "output_tokens": None}
+    usage = body.get("usage") or {}
+    if not isinstance(usage, dict):
+        return {"input_tokens": None, "output_tokens": None}
+    return {
+        "input_tokens": usage.get("prompt_tokens"),
+        "output_tokens": usage.get("completion_tokens"),
+    }
+
+
 def review_diff(
-    hunks: list[Hunk], installation_id: int
+    hunks: list[Hunk],
+    installation_id: int,
+    pr_context: Optional[dict] = None,
 ) -> LlmReviewResponse:
     """Send `hunks` to the round-robin-selected LLM and return findings.
 
@@ -356,6 +435,10 @@ def review_diff(
       - `reviewed`: at least one backend returned a parseable payload.
       - `parse_failed`: LLM responded but the content wasn't usable JSON.
       - `all_failed`: every backend errored or timed out.
+
+    `pr_context` (Optional dict) carries the PR coords for DD LLM Obs
+    tags. Keys consumed: installation_id, repo, pr_number, head_sha.
+    Omitted ⇒ traces still emit but without filterable PR tags.
     """
     if not hunks:
         return LlmReviewResponse(kind="no_diff")
@@ -365,27 +448,80 @@ def review_diff(
         Backend.OPENROUTER if primary == Backend.POOLSIDE else Backend.POOLSIDE
     )
     messages = _build_messages(hunks)
+    pr_tags = _llmobs_tags(pr_context)
 
     last_error = ""
     for backend in (primary, secondary):
         config = _BACKEND_CONFIGS[backend]
-        try:
-            resp = _call_backend(config, messages)
-        except _BackendConfigError as e:
-            log.error(
-                "llm_backend_misconfigured",
-                extra={"backend": backend.value, "detail": str(e)},
+        # Open one LLM Obs span per backend attempt. Annotate on every
+        # exit path (success + failures) so DD captures latency tails
+        # and error rates per-backend.
+        start_ns = time.monotonic_ns()
+        with _llmobs_llm(
+            model_name=config.model,
+            model_provider=backend.value,
+            name=_LLMOBS_NAME,
+        ) as span:
+            try:
+                resp = _call_backend(config, messages)
+            except _BackendConfigError as e:
+                log.error(
+                    "llm_backend_misconfigured",
+                    extra={"backend": backend.value, "detail": str(e)},
+                )
+                _llmobs_annotate(
+                    span=span, input_data=messages,
+                    metadata={"backend": backend.value, "error": "config"},
+                    metrics={"latency_ms": _elapsed_ms(start_ns)},
+                    tags=pr_tags,
+                )
+                last_error = f"{backend.value} misconfigured: {e}"
+                continue
+            except (httpx.RequestError, httpx.TimeoutException) as e:
+                log.warning(
+                    "llm_backend_transport_failed",
+                    extra={"backend": backend.value, "kind": type(e).__name__},
+                )
+                _llmobs_annotate(
+                    span=span, input_data=messages,
+                    metadata={"backend": backend.value, "error": type(e).__name__},
+                    metrics={"latency_ms": _elapsed_ms(start_ns)},
+                    tags=pr_tags,
+                )
+                last_error = f"{backend.value}: {type(e).__name__}"
+                continue
+            findings, model, err = _parse_response(resp)
+            # Annotate AFTER the response is parsed so we capture the
+            # raw content + token counts. resp.json() was already
+            # consumed inside _parse_response; re-call it here for the
+            # span input — httpx caches the parsed body so this is cheap.
+            try:
+                body = resp.json() if resp.status_code == 200 else {}
+            except (ValueError, json.JSONDecodeError):
+                body = {}
+            content = ""
+            if isinstance(body, dict):
+                choices = body.get("choices") or []
+                if choices and isinstance(choices[0], dict):
+                    content = (choices[0].get("message") or {}).get("content", "")
+            usage_metrics = _extract_usage_metrics(body)
+            _llmobs_annotate(
+                span=span,
+                input_data=messages,
+                output_data=content or None,
+                metadata={
+                    "backend": backend.value,
+                    "status_code": resp.status_code,
+                    "kind": "reviewed" if not err else (
+                        "parse_failed" if resp.status_code == 200 else "http_error"
+                    ),
+                },
+                metrics={
+                    "latency_ms": _elapsed_ms(start_ns),
+                    **usage_metrics,
+                },
+                tags=pr_tags,
             )
-            last_error = f"{backend.value} misconfigured: {e}"
-            continue
-        except (httpx.RequestError, httpx.TimeoutException) as e:
-            log.warning(
-                "llm_backend_transport_failed",
-                extra={"backend": backend.value, "kind": type(e).__name__},
-            )
-            last_error = f"{backend.value}: {type(e).__name__}"
-            continue
-        findings, model, err = _parse_response(resp)
         if not err:
             return LlmReviewResponse(
                 kind="reviewed",

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -68,6 +68,15 @@ except ImportError:  # pragma: no cover — local dev without ddtrace
     def _llmobs_annotate(**kwargs: Any) -> None:
         return None
 
+    # Loud signal so a layer-drift / partial-install in Lambda doesn't
+    # silently turn off DD LLM Obs. AWS_LAMBDA_FUNCTION_NAME is the
+    # canonical Lambda-environment marker; in local dev it's unset.
+    if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+        log.warning(
+            "llmobs_import_failed_falling_back_to_noop",
+            extra={"lambda_fn": os.environ["AWS_LAMBDA_FUNCTION_NAME"]},
+        )
+
 _LLMOBS_NAME = "elder_code_review"
 _LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
 
@@ -514,6 +523,19 @@ def review_diff(
             try:
                 body = resp.json() if resp.status_code == 200 else {}
             except (ValueError, json.JSONDecodeError):
+                # The first parse succeeded (otherwise err would be
+                # truthy and we'd skip the body fields); a re-parse
+                # failure here means httpx cache mutation or a real
+                # divergence. Log so DD can alert on the rate —
+                # silently emitting `kind=reviewed` with empty
+                # content would undercount token cost in dashboards.
+                log.warning(
+                    "llm_body_reparse_failed",
+                    extra={
+                        "backend": backend.value,
+                        "status_code": resp.status_code,
+                    },
+                )
                 body = {}
             content = ""
             if isinstance(body, dict):

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -518,8 +518,10 @@ def review_diff(
             findings, model, err = _parse_response(resp)
             # Annotate AFTER the response is parsed so we capture the
             # raw content + token counts. resp.json() was already
-            # consumed inside _parse_response; re-call it here for the
-            # span input — httpx caches the parsed body so this is cheap.
+            # consumed inside _parse_response; re-call here for the
+            # span input. httpx.Response.json() re-parses every call,
+            # but review response bodies are small — re-parse cost is
+            # negligible vs the LLM round-trip we just paid.
             try:
                 body = resp.json() if resp.status_code == 200 else {}
             except (ValueError, json.JSONDecodeError):

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -79,6 +80,63 @@ except ImportError:  # pragma: no cover — local dev without ddtrace
 
 _LLMOBS_NAME = "elder_code_review"
 _LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
+
+# Per-payload cap on input/output captured in LLM Obs spans. Bounded
+# because PR diffs can contain massive blobs (PEM files, lockfiles,
+# generated code) — without this, a single .env-touching PR could
+# persist KB of secrets in DD storage. 16 KB is large enough to keep
+# typical review context but small enough to bound exposure.
+_LLMOBS_PAYLOAD_TRUNC_BYTES = 16 * 1024
+
+# Best-effort redaction patterns applied BEFORE payloads leave the
+# process. Defense-in-depth atop DD's org-level sensitive data scanner
+# — the scanner runs on ingest, but we should not be shipping raw
+# secrets across the wire in the first place. Pattern order: anchored
+# format-specific first (AWS, GitHub, Slack), then the generic
+# "key=value" sweeps. False positives are acceptable; missing a real
+# secret is not.
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[REDACTED:aws-access-key]"),
+    (re.compile(r"ghp_[A-Za-z0-9]{36,}"), "[REDACTED:github-pat]"),
+    (re.compile(r"ghs_[A-Za-z0-9]{36,}"), "[REDACTED:github-app-token]"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{82,}"), "[REDACTED:github-fine-grained-pat]"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "[REDACTED:slack-token]"),
+    (re.compile(r"sk-[A-Za-z0-9]{32,}"), "[REDACTED:openai-style-key]"),
+    (re.compile(r"sk-or-v1-[A-Za-z0-9]{32,}"), "[REDACTED:openrouter-key]"),
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----"), "[REDACTED:pem-private-key]"),
+    # Generic `KEY=VALUE` env-var leak inside an added diff line.
+    # Min-length 8 catches `secret=hunter22` but not `key=42`; longer
+    # is too strict (real secrets like `secret12345` would slip).
+    (re.compile(
+        r'((?:password|passwd|secret|api[-_]?key|token|access[-_]?key)\s*[:=]\s*)["\']?[A-Za-z0-9_\-+/=]{8,}["\']?',
+        re.IGNORECASE,
+    ), r"\1[REDACTED:env-secret]"),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Apply best-effort secret-pattern redaction. False positives are
+    acceptable (an `AKIA...`-shaped string in code that isn't an AWS
+    key still gets masked); missing a real secret is not. Patterns
+    target shapes most likely to appear in a PR diff: AWS/GH tokens,
+    Slack bot tokens, PEM private keys, `KEY=VALUE` env lines."""
+    for pattern, repl in _SECRET_PATTERNS:
+        text = pattern.sub(repl, text)
+    return text
+
+
+def _redact_payload(payload: Any) -> Any:
+    """Walk a payload (str | list-of-message-dicts | dict) and apply
+    `_redact_secrets` to every string value. Truncates each string to
+    `_LLMOBS_PAYLOAD_TRUNC_BYTES` AFTER redaction so a trailing PEM
+    fragment can't survive a mid-string cut."""
+    if isinstance(payload, str):
+        return _redact_secrets(payload)[:_LLMOBS_PAYLOAD_TRUNC_BYTES]
+    if isinstance(payload, list):
+        return [_redact_payload(item) for item in payload]
+    if isinstance(payload, dict):
+        return {k: _redact_payload(v) for k, v in payload.items()}
+    return payload
 
 
 class PrContext(TypedDict, total=False):
@@ -497,7 +555,7 @@ def review_diff(
                     extra={"backend": backend.value, "detail": str(e)},
                 )
                 _llmobs_annotate(
-                    span=span, input_data=messages,
+                    span=span, input_data=_redact_payload(messages),
                     metadata={"backend": backend.value, "error": "config"},
                     metrics={"latency_ms": _elapsed_ms(start_ns)},
                     tags=pr_tags,
@@ -510,7 +568,7 @@ def review_diff(
                     extra={"backend": backend.value, "kind": type(e).__name__},
                 )
                 _llmobs_annotate(
-                    span=span, input_data=messages,
+                    span=span, input_data=_redact_payload(messages),
                     metadata={"backend": backend.value, "error": type(e).__name__},
                     metrics={"latency_ms": _elapsed_ms(start_ns)},
                     tags=pr_tags,
@@ -547,8 +605,8 @@ def review_diff(
             usage_metrics = _extract_usage_metrics(body)
             _llmobs_annotate(
                 span=span,
-                input_data=messages,
-                output_data=content or None,
+                input_data=_redact_payload(messages),
+                output_data=_redact_payload(content) if content else None,
                 metadata={
                     "backend": backend.value,
                     "status_code": resp.status_code,

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -30,7 +30,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Literal, Optional, get_args
+from typing import Any, Callable, Literal, Optional, TypedDict, get_args
 
 import httpx
 
@@ -70,6 +70,22 @@ except ImportError:  # pragma: no cover — local dev without ddtrace
 
 _LLMOBS_NAME = "elder_code_review"
 _LLMOBS_HEAD_SHA_TAG_LEN = 8  # truncated to keep tag cardinality bounded
+
+
+class PrContext(TypedDict, total=False):
+    """PR coords threaded into DD LLM Obs span tags.
+
+    `total=False` (every key optional) because callers without GH
+    coords (e.g. ad-hoc tests, future REPL probes) still need to be
+    able to call `review_diff` — they just get traces without
+    PR-filterable tags. Promoting from a bare `dict` makes typos like
+    `pr_num` fail at type-check time rather than silently dropping the
+    tag in DD.
+    """
+    installation_id: int
+    repo: str
+    pr_number: int
+    head_sha: str
 
 
 def _elapsed_ms(start_ns: int) -> int:
@@ -385,7 +401,7 @@ def _parse_response(
     return tuple(coerced), model_name, ""
 
 
-def _llmobs_tags(pr_context: Optional[dict]) -> dict[str, str]:
+def _llmobs_tags(pr_context: Optional[PrContext]) -> dict[str, str]:
     """Build the tag dict for an LLM Obs span from `pr_context`.
 
     Tags are stringified because DD facet types are inferred from the
@@ -426,7 +442,7 @@ def _extract_usage_metrics(body: Any) -> dict[str, Optional[int]]:
 def review_diff(
     hunks: list[Hunk],
     installation_id: int,
-    pr_context: Optional[dict] = None,
+    pr_context: Optional[PrContext] = None,
 ) -> LlmReviewResponse:
     """Send `hunks` to the round-robin-selected LLM and return findings.
 

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -98,8 +98,7 @@ class PrContext(TypedDict, total=False):
 
 
 def _elapsed_ms(start_ns: int) -> int:
-    """Wall-clock elapsed in ms since `start_ns` (monotonic). Used for
-    LLM Obs latency metrics — `time.monotonic_ns` avoids clock-skew."""
+    """`time.monotonic_ns` avoids clock-skew during the span."""
     return (time.monotonic_ns() - start_ns) // 1_000_000
 
 # Per-backend endpoints + default models.
@@ -479,8 +478,11 @@ def review_diff(
     for backend in (primary, secondary):
         config = _BACKEND_CONFIGS[backend]
         # Open one LLM Obs span per backend attempt. Annotate on every
-        # exit path (success + failures) so DD captures latency tails
-        # and error rates per-backend.
+        # CAUGHT exit path (success + the three explicit `except` arms)
+        # so DD captures latency tails and per-backend error rates. A
+        # surprise exception escaping `_call_backend` would propagate
+        # without annotation — that's intentional (it's a bug worth
+        # seeing in Sentry, not a routine signal).
         start_ns = time.monotonic_ns()
         with _llmobs_llm(
             model_name=config.model,
@@ -516,21 +518,19 @@ def review_diff(
                 last_error = f"{backend.value}: {type(e).__name__}"
                 continue
             findings, model, err = _parse_response(resp)
-            # Annotate AFTER the response is parsed so we capture the
-            # raw content + token counts. resp.json() was already
-            # consumed inside _parse_response; re-call here for the
-            # span input. httpx.Response.json() re-parses every call,
-            # but review response bodies are small — re-parse cost is
-            # negligible vs the LLM round-trip we just paid.
+            # Annotate AFTER the response so we capture the raw content
+            # + token counts. httpx.Response.json() re-parses from the
+            # cached .content bytes; review response bodies are small,
+            # so the cost is negligible vs the LLM round-trip.
             try:
                 body = resp.json() if resp.status_code == 200 else {}
             except (ValueError, json.JSONDecodeError):
-                # The first parse succeeded (otherwise err would be
-                # truthy and we'd skip the body fields); a re-parse
-                # failure here means httpx cache mutation or a real
-                # divergence. Log so DD can alert on the rate —
-                # silently emitting `kind=reviewed` with empty
-                # content would undercount token cost in dashboards.
+                # Triggered when the first parse also failed (CF HTML
+                # interstitial, truncated body) OR — rarely — when
+                # the cache diverges. Either way the LLM Obs span
+                # would otherwise silently emit kind=reviewed with
+                # empty content and undercount DD token-cost
+                # dashboards.
                 log.warning(
                     "llm_body_reparse_failed",
                     extra={

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -236,9 +236,7 @@ def dispatch_code_review(
             reason="fetch_or_parse_failed",
         )
 
-    # review_diff already swallows backend failures into discriminated
-    # `LlmReviewResponse.kind` values; no extra try needed. The
-    # `pr_context` dict flows into DD LLM Obs span tags so traces are
+    # `pr_context` flows into DD LLM Obs span tags so traces are
     # filterable by repo / PR / installation in the LLM Obs UI.
     llm_response: LlmReviewResponse = review_diff(
         _to_llm_hunks(hunks),

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -237,9 +237,18 @@ def dispatch_code_review(
         )
 
     # review_diff already swallows backend failures into discriminated
-    # `LlmReviewResponse.kind` values; no extra try needed.
+    # `LlmReviewResponse.kind` values; no extra try needed. The
+    # `pr_context` dict flows into DD LLM Obs span tags so traces are
+    # filterable by repo / PR / installation in the LLM Obs UI.
     llm_response: LlmReviewResponse = review_diff(
-        _to_llm_hunks(hunks), installation_id=installation_id,
+        _to_llm_hunks(hunks),
+        installation_id=installation_id,
+        pr_context={
+            "installation_id": installation_id,
+            "repo": f"{owner}/{repo_name}",
+            "pr_number": pull_number,
+            "head_sha": head_sha,
+        },
     )
     if llm_response.kind != "reviewed":
         # Without this log, a 100% LLM-outage rate looks identical to

--- a/services/webhook/tests/test_code_reviewer_dispatch.py
+++ b/services/webhook/tests/test_code_reviewer_dispatch.py
@@ -75,7 +75,7 @@ def test_dispatch_advisory_mode_posts_neutral_check_and_comment_review(monkeypat
     posted_check = []
     posted_review = []
 
-    def _fake_review_diff(hunks, installation_id):
+    def _fake_review_diff(hunks, installation_id, pr_context=None):
         return llm
 
     def _fake_post_check_run(install_token, owner, repo, result, external_id=None):
@@ -483,6 +483,33 @@ def test_dispatch_structured_log_carries_degraded_reason(monkeypatch, caplog):
     )
     assert rec.__dict__.get("degraded_reason") == "all_failed"
     assert rec.__dict__.get("result") == "skipped"
+
+
+def test_dispatch_passes_pr_context_to_review_diff(monkeypatch):
+    """The PR coords flow into review_diff(pr_context=...) so DD LLM
+    Obs spans carry tags that filter by repo / PR / install. Without
+    this, all traces would look identical in the LLM Obs UI."""
+    captured = []
+
+    def _fake_review_diff(hunks, installation_id, pr_context=None):
+        captured.append(pr_context)
+        return LlmReviewResponse(kind="no_diff")
+
+    monkeypatch.setattr(cr_dispatch, "review_diff", _fake_review_diff)
+    monkeypatch.setattr(cr_dispatch, "post_check_run", lambda *a, **kw: {})
+    monkeypatch.setattr(cr_dispatch, "post_review", lambda *a, **kw: {})
+
+    with patch("httpx.get", return_value=_diff_response()):
+        cr_dispatch.dispatch_code_review(_payload(), blocking=False)
+
+    assert len(captured) == 1
+    ctx = captured[0]
+    assert ctx == {
+        "installation_id": 11,
+        "repo": "myorg/myrepo",
+        "pr_number": 7,
+        "head_sha": "abcd1234efgh",
+    }
 
 
 def test_dispatch_fetches_diff_with_diff_accept_header(monkeypatch):

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -576,6 +576,55 @@ def test_review_diff_llmobs_span_handles_missing_usage(monkeypatch) -> None:
     assert metrics.get("output_tokens") is None
 
 
+def test_llmobs_span_annotate_called_exactly_once_per_backend_attempt(monkeypatch) -> None:
+    """Per backend attempt, the `with _llmobs_llm(...)` block must call
+    `_llmobs_annotate` exactly ONCE — no double-annotation across the
+    success/config-error/transport-error branches. Future refactors
+    adding an early `continue` could double-annotate; lock the count."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    annotate_calls = _capture_llmobs(monkeypatch)
+    # Primary backend exhausts its 3 retries on timeout (3 httpx.post
+    # calls), then secondary backend succeeds.
+    seq: list = [
+        httpx.ReadTimeout("p1"), httpx.ReadTimeout("p2"), httpx.ReadTimeout("p3"),
+        httpx.Response(200, json=_openai_json_response('{"findings":[]}')),
+    ]
+    idx = {"n": 0}
+
+    def staged(*a, **kw):
+        i = idx["n"]; idx["n"] += 1
+        x = seq[i]
+        if isinstance(x, Exception): raise x
+        return x
+
+    with patch.object(httpx, "post", side_effect=staged):
+        review_diff([_hunk()], installation_id=1)
+
+    # Exactly 2 spans (one per backend attempt — primary timeout +
+    # secondary success). Not 4 (one per httpx.post retry) — the span
+    # wraps the whole `_call_backend`, not each retry.
+    assert len(annotate_calls) == 2
+
+
+def test_llmobs_tags_match_pr_context_keys(monkeypatch) -> None:
+    """Lock the tag-key set so a future `PrContext` field addition is
+    a deliberate edit to _llmobs_tags, not a silent drop. If PrContext
+    grows a `branch` key but _llmobs_tags doesn't, this test fails."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    response = httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+    with patch.object(httpx, "post", return_value=response):
+        review_diff(
+            [_hunk()], installation_id=42,
+            pr_context={
+                "installation_id": 42, "repo": "o/r", "pr_number": 1,
+                "head_sha": "abc123def456",
+            },
+        )
+    assert set(annotate_calls[0]["tags"].keys()) == {
+        "installation_id", "repo", "pr_number", "head_sha",
+    }
+
+
 def test_no_diff_short_circuit_does_not_emit_llmobs_span(monkeypatch) -> None:
     """Empty hunks short-circuit before any LLM call — no span should
     be emitted (no LLM call happened)."""

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -625,6 +625,106 @@ def test_llmobs_tags_match_pr_context_keys(monkeypatch) -> None:
     }
 
 
+def test_llmobs_config_error_annotates_with_error_config(monkeypatch) -> None:
+    """_BackendConfigError path must annotate with metadata.error=`config`.
+    Without this signal DD dashboards see only transport errors and
+    can't tell `secret missing` from `backend down`."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    monkeypatch.setattr(lc, "_load_poolside_key", lambda: "")
+    monkeypatch.setattr(lc, "_load_openrouter_key", lambda: "")
+    annotate_calls = _capture_llmobs(monkeypatch)
+
+    with patch.object(httpx, "post") as mock_post:
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "all_failed"
+    mock_post.assert_not_called()
+    # Two backends each fail config check → 2 spans, both error=config.
+    assert len(annotate_calls) == 2
+    for call in annotate_calls:
+        assert call["metadata"].get("error") == "config"
+        # output_data absent on config error.
+        assert call.get("output_data") is None
+
+
+def test_llmobs_metadata_kind_parse_failed_on_200_with_bad_content(monkeypatch) -> None:
+    """When the LLM returns 200 + non-JSON content, the span metadata
+    must tag kind="parse_failed" (not "reviewed", not "http_error").
+    Locks the ternary order on the success-annotate path."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    # 200 envelope is valid JSON, but the message.content is not JSON.
+    response = httpx.Response(200, json=_openai_json_response("sorry I cannot"))
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+    assert out.kind == "parse_failed"
+    assert annotate_calls[0]["metadata"]["kind"] == "parse_failed"
+
+
+def test_llmobs_metadata_kind_http_error_on_non_200(monkeypatch) -> None:
+    """Non-200 status → metadata.kind="http_error" (not "parse_failed"
+    or "reviewed"). DD dashboards aggregate by this facet — a
+    mislabel would undercount backend health rate."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    annotate_calls = _capture_llmobs(monkeypatch)
+    # 500 with no retryable status; both backends will return 500.
+    response = httpx.Response(500, json={"error": "down"})
+    with patch.object(httpx, "post", return_value=response):
+        review_diff([_hunk()], installation_id=1)
+    # Both backends tagged http_error.
+    for call in annotate_calls:
+        assert call["metadata"]["kind"] == "http_error"
+        assert call["metadata"]["status_code"] == 500
+
+
+def test_extract_usage_metrics_handles_non_dict_usage() -> None:
+    """A future backend that returns `usage` as a string or list must
+    not crash. The `isinstance(usage, dict)` guard is the load-bearing
+    one — removing it would AttributeError on `.get()`."""
+    # body with usage=list (degenerate).
+    out = lc._extract_usage_metrics({"usage": [1, 2, 3]})
+    assert out == {"input_tokens": None, "output_tokens": None}
+    # body that itself isn't a dict.
+    out = lc._extract_usage_metrics("not a dict")
+    assert out == {"input_tokens": None, "output_tokens": None}
+    # body=None (defensive — the upstream re-parse fallback sets body={}
+    # but a future caller might pass None).
+    out = lc._extract_usage_metrics(None)
+    assert out == {"input_tokens": None, "output_tokens": None}
+
+
+def test_llmobs_body_reparse_failure_logs_warning(monkeypatch, caplog) -> None:
+    """The re-parse except branch logs `llm_body_reparse_failed`. A
+    regression that drops the log line (or that swaps `except` to
+    `Exception` and masks an unrelated bug) silently misses the DD
+    alert. Pin the log emission to a discriminator the test can read."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+
+    # Build a Response where the first .json() succeeds (during
+    # _parse_response — invalid `choices` shape returns err=missing
+    # choices) AND the second .json() (the re-parse) also returns 200.
+    # We force a divergence by stubbing _parse_response to return
+    # success (err="") but stubbing .json() the second time to raise.
+    call_count = {"n": 0}
+
+    def fake_json(self):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First call from _parse_response — return a valid envelope.
+            return _openai_json_response('{"findings":[]}')
+        raise ValueError("divergent")
+
+    response = httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+    monkeypatch.setattr(httpx.Response, "json", fake_json)
+    with caplog.at_level("WARNING"):
+        with patch.object(httpx, "post", return_value=response):
+            review_diff([_hunk()], installation_id=1)
+    assert any(
+        "llm_body_reparse_failed" in r.message for r in caplog.records
+    )
+    # Span still emitted, just with empty output.
+    assert annotate_calls[0]["metadata"]["backend"] == "openrouter"
+
+
 def test_no_diff_short_circuit_does_not_emit_llmobs_span(monkeypatch) -> None:
     """Empty hunks short-circuit before any LLM call — no span should
     be emitted (no LLM call happened)."""

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -1,6 +1,7 @@
 """Tests for the LLM client abstraction."""
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import httpx
@@ -723,6 +724,85 @@ def test_llmobs_body_reparse_failure_logs_warning(monkeypatch, caplog) -> None:
     )
     # Span still emitted, just with empty output.
     assert annotate_calls[0]["metadata"]["backend"] == "openrouter"
+
+
+def test_redact_secrets_strips_aws_github_pem_env_patterns() -> None:
+    """Defense-in-depth atop the DD org-level sensitive data scanner.
+    We must not ship raw secrets across the wire in the first place —
+    a PR diff that touches a .env or accidentally commits a key file
+    should not persist in DD storage as plaintext."""
+    raw = (
+        "AKIAIOSFODNN7EXAMPLE in some code "
+        "and ghp_1234567890abcdefghijklmnopqrstuvwxyzAB github token "
+        "and PASSWORD=supersecretvalue12345 env line "
+        "and -----BEGIN RSA PRIVATE KEY-----\nMIIEpAIB\n-----END RSA PRIVATE KEY----- pem"
+    )
+    out = lc._redact_secrets(raw)
+    assert "AKIAIOSFODNN7EXAMPLE" not in out
+    assert "[REDACTED:aws-access-key]" in out
+    assert "ghp_1234567890" not in out
+    assert "[REDACTED:github-pat]" in out
+    assert "supersecretvalue" not in out
+    assert "[REDACTED:env-secret]" in out
+    assert "MIIEpAIB" not in out
+    assert "[REDACTED:pem-private-key]" in out
+
+
+def test_redact_payload_walks_message_list_structure() -> None:
+    """The OpenAI-compat `messages` payload is `list[dict[str, str]]`.
+    Redaction must walk the structure — not just stringify it — so
+    nested string values get scrubbed without losing the shape."""
+    messages = [
+        {"role": "system", "content": "You are a reviewer"},
+        {"role": "user", "content": "diff: PASSWORD=secret12345 line"},
+    ]
+    out = lc._redact_payload(messages)
+    assert isinstance(out, list)
+    assert out[0]["role"] == "system"
+    assert "secret12345" not in out[1]["content"]
+    assert "[REDACTED:env-secret]" in out[1]["content"]
+
+
+def test_redact_payload_truncates_after_redaction() -> None:
+    """Truncation runs AFTER redaction so a trailing PEM fragment can't
+    survive a mid-string cut. Bound exposure even when no patterns
+    match (massive lockfile diff)."""
+    huge = "x" * 100_000
+    out = lc._redact_payload(huge)
+    assert len(out) == lc._LLMOBS_PAYLOAD_TRUNC_BYTES
+
+
+def test_llmobs_input_data_is_redacted_on_success(monkeypatch) -> None:
+    """End-to-end: a diff containing a fake AWS key reaches the span
+    redacted. Catches a regression where _redact_payload is dropped
+    from the input_data argument."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    leaky_hunk = lc.Hunk(
+        path="bad.py",
+        body="+AWS_KEY = 'AKIAIOSFODNN7EXAMPLE'  # oops",
+    )
+    response = httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+    with patch.object(httpx, "post", return_value=response):
+        review_diff([leaky_hunk], installation_id=1)
+    span_input_str = json.dumps(annotate_calls[0]["input_data"])
+    assert "AKIAIOSFODNN7EXAMPLE" not in span_input_str
+    assert "[REDACTED:aws-access-key]" in span_input_str
+
+
+def test_llmobs_output_data_is_redacted_on_success(monkeypatch) -> None:
+    """A hallucinating LLM might echo a secret back in its response.
+    output_data must also pass through _redact_payload."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    leaky_content = (
+        '{"findings": [{"path": "x", "line": 1, "rule": "leak", '
+        '"severity": "critical", "message": "found AKIAIOSFODNN7EXAMPLE"}]}'
+    )
+    response = httpx.Response(200, json=_openai_json_response(leaky_content))
+    with patch.object(httpx, "post", return_value=response):
+        review_diff([_hunk()], installation_id=1)
+    out_str = str(annotate_calls[0]["output_data"])
+    assert "AKIAIOSFODNN7EXAMPLE" not in out_str
+    assert "[REDACTED:aws-access-key]" in out_str
 
 
 def test_no_diff_short_circuit_does_not_emit_llmobs_span(monkeypatch) -> None:

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -458,3 +458,128 @@ def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
     # other backend would likely return the same edge HTML).
     assert out.kind == "parse_failed"
     assert "envelope" in out.error.lower() or "json" in out.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# DD LLM Obs tracing — every successful LLM call emits a trace span with
+# prompt/response/latency/tokens; failures emit a span with error metadata.
+# ---------------------------------------------------------------------------
+
+def _capture_llmobs(monkeypatch):
+    """Patch LLMObs.llm + LLMObs.annotate; return a list of all
+    annotate calls so tests can introspect the trace shape."""
+    from unittest.mock import MagicMock as _MM
+
+    annotate_calls: list[dict] = []
+
+    class _FakeSpan:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr(lc, "_llmobs_llm", lambda **kw: _FakeSpan())
+    monkeypatch.setattr(
+        lc, "_llmobs_annotate",
+        lambda **kw: annotate_calls.append(kw),
+    )
+    return annotate_calls
+
+
+def test_review_diff_emits_llmobs_span_on_success(monkeypatch) -> None:
+    """Every successful LLM call must emit a DD LLM Obs span carrying
+    prompt + response + latency_ms + tokens + model + backend."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    body = _openai_json_response('{"findings":[]}')
+    body["usage"] = {"prompt_tokens": 100, "completion_tokens": 25}
+    response = httpx.Response(200, json=body)
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert len(annotate_calls) == 1
+    call = annotate_calls[0]
+    # Prompt = the messages array (system + user).
+    assert isinstance(call["input_data"], list)
+    assert call["input_data"][0]["role"] == "system"
+    # Response = the model's content string.
+    assert call["output_data"] == '{"findings":[]}'
+    # Metrics include tokens + latency.
+    metrics = call["metrics"]
+    assert metrics["input_tokens"] == 100
+    assert metrics["output_tokens"] == 25
+    assert "latency_ms" in metrics
+    assert metrics["latency_ms"] >= 0
+    # Metadata names the backend.
+    assert call["metadata"]["backend"] == "openrouter"  # installation_id=1 → odd
+
+
+def test_review_diff_llmobs_span_carries_pr_context_tags(monkeypatch) -> None:
+    """The PR coords (install_id, repo, pr_number, head_sha) must flow
+    into span tags so DD LLM Obs can filter traces by repo or PR."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    response = httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+    pr_context = {
+        "installation_id": 42,
+        "repo": "myorg/myrepo",
+        "pr_number": 7,
+        "head_sha": "abc123def456",
+    }
+    with patch.object(httpx, "post", return_value=response):
+        review_diff(
+            [_hunk()], installation_id=42, pr_context=pr_context,
+        )
+
+    tags = annotate_calls[0]["tags"]
+    assert tags["installation_id"] == "42"
+    assert tags["repo"] == "myorg/myrepo"
+    assert tags["pr_number"] == "7"
+    # head_sha truncated to 8 chars to keep tag cardinality bounded.
+    assert tags["head_sha"] == "abc123de"
+
+
+def test_review_diff_emits_llmobs_span_on_transport_failure(monkeypatch) -> None:
+    """A backend timeout must STILL emit an LLM Obs span so the failure
+    is visible in DD (latency tail, error rate). Span metadata names
+    the error class; output_data is absent."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    annotate_calls = _capture_llmobs(monkeypatch)
+
+    def _timeout(*a, **kw):
+        raise httpx.ReadTimeout("hung")
+
+    with patch.object(httpx, "post", side_effect=_timeout):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "all_failed"
+    # Two backends tried → two spans.
+    assert len(annotate_calls) == 2
+    for call in annotate_calls:
+        # Error class captured in metadata.
+        assert call["metadata"].get("error") == "ReadTimeout"
+        # No output content on a transport failure.
+        assert call.get("output_data") is None
+
+
+def test_review_diff_llmobs_span_handles_missing_usage(monkeypatch) -> None:
+    """OpenRouter free-tier sometimes omits the `usage` field. Span
+    must not crash — token metrics surface as None."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    # OpenAI shape but NO usage key.
+    body = {"choices": [{"message": {"content": '{"findings":[]}'}}], "model": "x"}
+    response = httpx.Response(200, json=body)
+    with patch.object(httpx, "post", return_value=response):
+        out = review_diff([_hunk()], installation_id=1)
+    assert out.kind == "reviewed"
+    metrics = annotate_calls[0]["metrics"]
+    # latency must still be present even when tokens are missing.
+    assert "latency_ms" in metrics
+    assert metrics.get("input_tokens") is None
+    assert metrics.get("output_tokens") is None
+
+
+def test_no_diff_short_circuit_does_not_emit_llmobs_span(monkeypatch) -> None:
+    """Empty hunks short-circuit before any LLM call — no span should
+    be emitted (no LLM call happened)."""
+    annotate_calls = _capture_llmobs(monkeypatch)
+    out = review_diff([], installation_id=1)
+    assert out.kind == "no_diff"
+    assert annotate_calls == []


### PR DESCRIPTION
## Summary

Instrument `review_diff` so every LLM call (success + failure) emits a Datadog LLM Observability trace span. Each span captures the prompt messages, response content, latency_ms, input/output tokens, model + backend metadata, and PR-context tags (installation_id, repo, pr_number, head_sha[:8]). The dispatcher threads `pr_context` through from the webhook payload, so traces are filterable by repo and PR in the LLM Obs UI. Webhook Lambda gets `DD_LLMOBS_ENABLED=true` and `DD_LLMOBS_ML_APP=grug-elder` via Pulumi (api Lambda excluded — never calls LLMs). Module-level `_llmobs_llm` / `_llmobs_annotate` indirection is patchable from tests AND gracefully no-ops on ImportError for local dev without ddtrace installed.

## Test plan

- [x] 5 new LLM Obs tests: happy-path span shape (prompt + response + metrics), PR-context tags propagate, transport-failure span emission, missing-usage doesn't crash, `no_diff` short-circuit emits no span
- [x] 1 dispatch test: `pr_context` flows from dispatch → review_diff with correct shape
- [x] Existing dispatch test mocks updated to accept the new `pr_context` kwarg
- [x] Drift-lint green (21 mirrored pairs)
- [x] Full webhook suite: 345 passing
- [x] Phase-Xb operator post-merge: verify spans appear in DD LLM Obs UI under `ml_app:grug-elder` after `pulumi up` + test PR

## Out of scope

- DD LLM Obs sensitive-data-scanner configuration (set at the org level per existing runbook)
- DD LLM Obs custom evaluations + annotation queues (PRD #181 post-MVP slices)
- Prompt library improvements (#188)
- Per-finding feedback loop via GH reactions (PRD #181)

Size: M

closes #187