### PR TITLE
fix(infra): point Elder LLM key lookups at shared /infra/llm SSM path

### DIFF
--- a/docs/HITL_PREREQUISITES.md
+++ b/docs/HITL_PREREQUISITES.md
@@ -60,17 +60,22 @@ aws ssm put-parameter --region us-east-1 \
   --type SecureString \
   --value "<the openssl rand -hex 32 output>"
 
+# LLM backend keys live at the SHARED cross-project path
+# `/infra/llm/<provider>_api_key` (NOT a grug-specific copy) so each key is
+# minted/rotated once across all projects. If they already exist (other
+# projects use them too), skip these — grug's Pulumi just reads them.
+#
 # OpenRouter API key — for Elder persona LLM calls (PRD #181). Mint at
 # https://openrouter.ai/settings/keys. Webhook Lambda only.
 aws ssm put-parameter --region us-east-1 \
-  --name /grug/openrouter-api-key \
+  --name /infra/llm/openrouter_api_key \
   --type SecureString \
   --value "sk-or-v1-..."
 
 # Poolside API key — second backend for Elder persona round-robin
 # (installation_id % 2). Mint at https://poolside.ai/. Webhook Lambda only.
 aws ssm put-parameter --region us-east-1 \
-  --name /grug/poolside-api-key \
+  --name /infra/llm/poolside_api_key \
   --type SecureString \
   --value "<poolside-api-key>"
 ```
@@ -79,7 +84,9 @@ Verify:
 
 ```bash
 aws ssm get-parameters-by-path --region us-east-1 --path /grug --recursive --query 'Parameters[].Name'
-# Expected: ["/grug/github-app-id", "/grug/github-app-private-key", "/grug/github-app-webhook-secret", "/grug/openrouter-api-key", "/grug/poolside-api-key"]
+# Expected: ["/grug/github-app-id", "/grug/github-app-private-key", "/grug/github-app-webhook-secret"]
+aws ssm get-parameters-by-path --region us-east-1 --path /infra/llm --recursive --query 'Parameters[].Name'
+# Expected (shared): ["/infra/llm/openrouter_api_key", "/infra/llm/poolside_api_key"]
 ```
 
 ## 4. Reserve the OIDC role for GitHub Actions deploy

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -273,8 +273,8 @@ this verification to confirm the full pipeline works on a real PR.
 ### Prerequisites
 
 1. SSM parameters loaded per `docs/HITL_PREREQUISITES.md` step 3:
-   - `/grug/poolside-api-key` (SecureString)
-   - `/grug/openrouter-api-key` (SecureString)
+   - `/infra/llm/poolside_api_key` (SecureString, shared cross-project)
+   - `/infra/llm/openrouter_api_key` (SecureString, shared cross-project)
 2. `pulumi up` against the target stack — confirm the webhook Lambda
    environment has both keys mounted.
 3. `code_reviewer_enabled=True` and `code_reviewer_blocking=False` on

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -86,21 +86,23 @@ _dd_api_key = aws.ssm.get_parameter(
     with_decryption=True,
 )
 
-# OpenRouter API key — pre-loaded by the operator (see docs/HITL_PREREQUISITES.md).
-# Consumed by the webhook Lambda only — Elder persona dispatches the LLM
-# call from the same path that handles `pull_request:opened`. api Lambda
-# never needs it; scoping to webhook keeps the IAM blast radius small.
+# OpenRouter API key — shared cross-project SecureString at the canonical
+# `/infra/llm/<provider>_api_key` path (not a grug-specific copy), so the
+# key is minted/rotated once. Consumed by the webhook Lambda only — Elder
+# persona dispatches the LLM call from the same path that handles
+# `pull_request:opened`. api Lambda never needs it; scoping to webhook
+# keeps the IAM blast radius small.
 _openrouter_api_key = aws.ssm.get_parameter(
-    name="/grug/openrouter-api-key",
+    name="/infra/llm/openrouter_api_key",
     with_decryption=True,
 )
 
-# Poolside API key — same scoping rationale as OpenRouter (webhook-only).
+# Poolside API key — same shared-path + webhook-only rationale as OpenRouter.
 # The Elder persona round-robins via `installation_id % 2`; both keys
 # must be present for the round-robin to work without permanent fallback
 # to the other backend.
 _poolside_api_key = aws.ssm.get_parameter(
-    name="/grug/poolside-api-key",
+    name="/infra/llm/poolside_api_key",
     with_decryption=True,
 )
 

--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -18,8 +18,8 @@ default model name differ. Response is constrained to JSON via
 `response_format={"type": "json_object"}` and parsed defensively —
 malformed JSON or refusals degrade to empty findings rather than crash.
 
-Secrets are loaded via secrets_loader.py (`/grug/poolside-api-key` +
-`/grug/openrouter-api-key`); api Lambda has no IAM grant on these
+Secrets are loaded via secrets_loader.py (`/infra/llm/poolside_api_key` +
+`/infra/llm/openrouter_api_key`); api Lambda has no IAM grant on these
 paths so this module only ever runs from the webhook process.
 """
 from __future__ import annotations

--- a/services/api/tests/test_secrets_loader.py
+++ b/services/api/tests/test_secrets_loader.py
@@ -91,10 +91,10 @@ def test_get_openrouter_api_key_reads_env_var(monkeypatch):
     """Elder persona LLM client (#184) calls this; needs the same
     env-var-to-SSM shape as the GitHub App secrets."""
     _clear_cache()
-    monkeypatch.setenv("GRUG_OPENROUTER_API_KEY_SSM", "/grug/openrouter-api-key")
+    monkeypatch.setenv("GRUG_OPENROUTER_API_KEY_SSM", "/infra/llm/openrouter_api_key")
     monkeypatch.setattr(
         sl._ssm, "get_parameter",
-        _stub_ssm({"/grug/openrouter-api-key": "sk-or-test-value"}),
+        _stub_ssm({"/infra/llm/openrouter_api_key": "sk-or-test-value"}),
     )
     assert sl.get_openrouter_api_key() == "sk-or-test-value"
 

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -18,8 +18,8 @@ default model name differ. Response is constrained to JSON via
 `response_format={"type": "json_object"}` and parsed defensively —
 malformed JSON or refusals degrade to empty findings rather than crash.
 
-Secrets are loaded via secrets_loader.py (`/grug/poolside-api-key` +
-`/grug/openrouter-api-key`); api Lambda has no IAM grant on these
+Secrets are loaded via secrets_loader.py (`/infra/llm/poolside_api_key` +
+`/infra/llm/openrouter_api_key`); api Lambda has no IAM grant on these
 paths so this module only ever runs from the webhook process.
 """
 from __future__ import annotations

--- a/services/webhook/tests/test_secrets_loader.py
+++ b/services/webhook/tests/test_secrets_loader.py
@@ -91,10 +91,10 @@ def test_get_openrouter_api_key_reads_env_var(monkeypatch):
     """Elder persona LLM client (#184) calls this; needs the same
     env-var-to-SSM shape as the GitHub App secrets."""
     _clear_cache()
-    monkeypatch.setenv("GRUG_OPENROUTER_API_KEY_SSM", "/grug/openrouter-api-key")
+    monkeypatch.setenv("GRUG_OPENROUTER_API_KEY_SSM", "/infra/llm/openrouter_api_key")
     monkeypatch.setattr(
         sl._ssm, "get_parameter",
-        _stub_ssm({"/grug/openrouter-api-key": "sk-or-test-value"}),
+        _stub_ssm({"/infra/llm/openrouter_api_key": "sk-or-test-value"}),
     )
     assert sl.get_openrouter_api_key() == "sk-or-test-value"
 


### PR DESCRIPTION
## Summary

`main`'s prod deploy ([run 26702628445](https://github.com/githumps/grug/actions/runs/26702628445/job/78698173910)) failed with `reading SSM Parameter (/grug/openrouter-api-key): couldn't find resource`. The merged Elder epic added `aws.ssm.get_parameter` lookups for grug-specific OpenRouter + Poolside keys that were never pre-loaded by an operator, so `pulumi up` threw at program-eval time and aborted the entire stack update. The canonical cross-project keys already exist at `/infra/llm/openrouter_api_key` and `/infra/llm/poolside_api_key` (SecureString, `alias/aws/ssm`). This repoints the two lookups there so no grug-specific copy needs minting or rotating — IAM grant, deploy-time decrypt, and runtime fetch all key off the same param object and follow automatically.

## Test plan

- [x] `pulumi preview --stack prod` evaluates clean (was throwing) — diff repoints `grug-webhook-ssm-policy` ARNs + webhook env vars only
- [x] Verified both `/infra/llm/*` params exist as SecureString under `alias/aws/ssm` (same key as the grug params, so decrypt grant unchanged)
- [x] `test_secrets_loader.py` + `test_llm_client.py` pass on both webhook (69) and api (7) mirrors
- [x] Drift-lint green (25 mirrored pairs); docs (HITL_PREREQUISITES, RUNBOOK) updated to shared path

Size: XS

## Out of scope

- Minting new vendor keys (the shared keys already exist)
- The `extra_ssm_secrets` Protocol type-hygiene refactor (tracked by #235)
- Pre-existing `grug-api` image/datadog-provider version drift surfaced by the same preview

closes #254

