### PR TITLE
feat(infra): introduce SsmSecretRef Protocol for lambda_service.extra_ssm_secrets

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -171,12 +171,12 @@ webhook = lambda_service.create(
     ecr_repo=webhook_ecr,
     image_tag=webhook_image_tag,
     secrets=secrets,
-    # cf_secret.ssm_parameter is `aws.ssm.Parameter` (Pulumi resource)
-    # while the others are `GetParameterResult` (sync data lookup). Both
-    # expose `.arn` and `.name`, and the consuming IAM policy in
-    # lambda_service already wraps the arn list in `Output.all(...).apply()`,
-    # so Output[str] arns resolve correctly. Issue #235 tracks tightening
-    # the type contract via a structural Protocol.
+    # Mixed refs: cf_secret.ssm_parameter is `aws.ssm.Parameter` (created
+    # resource, Output[str] arns) while the others are `GetParameterResult`
+    # (sync data lookup, plain-str arns). Both satisfy the `SsmSecretRef`
+    # Protocol (components/_types.py) — they expose `.arn`/`.name`, and the
+    # consuming IAM policy wraps the arn list in `Output.all(...).apply()`,
+    # so either arm resolves correctly (#235 tightened this contract).
     extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter, _openrouter_api_key, _poolside_api_key],
     # NOTE: DD extension is BAKED into the Lambda container image
     # (services/webhook/Dockerfile.lambda copies from

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -176,7 +176,7 @@ webhook = lambda_service.create(
     # (sync data lookup, plain-str arns). Both satisfy the `SsmSecretRef`
     # Protocol (components/_types.py) — they expose `.arn`/`.name`, and the
     # consuming IAM policy wraps the arn list in `Output.all(...).apply()`,
-    # so either arm resolves correctly (#235 tightened this contract).
+    # so either arm resolves correctly (#235 named this contract).
     extra_ssm_secrets=[_dd_api_key, cf_secret.ssm_parameter, _openrouter_api_key, _poolside_api_key],
     # NOTE: DD extension is BAKED into the Lambda container image
     # (services/webhook/Dockerfile.lambda copies from

--- a/infra/pulumi/components/_types.py
+++ b/infra/pulumi/components/_types.py
@@ -27,7 +27,19 @@ class SsmSecretRef(Protocol):
     arns in `Output.all(...).apply(...)`, so a plain `str` and an
     `Output[str]` both resolve correctly. The `| str` arms of each field
     are what let the eager `GetParameterResult` satisfy the protocol.
+
+    `.name` is part of the secret-ref contract (env-var wiring elsewhere
+    reads it) even though this particular consumer only needs `.arn`.
+
+    Members are declared as read-only `@property`, NOT bare attributes: a
+    bare `arn: T` is a *settable, invariantly-matched* protocol member, so a
+    checker would reject `Parameter`/`GetParameterResult` (whose `arn`/`name`
+    are read-only properties). The property form matches covariantly, which
+    is what lets a `str` arn satisfy the `Output[str] | str` union.
     """
 
-    arn: pulumi.Output[str] | str
-    name: pulumi.Output[str] | str
+    @property
+    def arn(self) -> pulumi.Output[str] | str: ...
+
+    @property
+    def name(self) -> pulumi.Output[str] | str: ...

--- a/infra/pulumi/components/_types.py
+++ b/infra/pulumi/components/_types.py
@@ -1,0 +1,33 @@
+"""Shared structural types for the Pulumi component factories.
+
+These are typing-only helpers (no runtime resources). They give a NAME to
+the duck-typed contracts the factories already rely on, so a future reader
+can see what a parameter actually accepts instead of trusting a concrete
+annotation that lies.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import pulumi
+
+
+class SsmSecretRef(Protocol):
+    """An SSM parameter reference that exposes an ARN + name.
+
+    Satisfied structurally by BOTH:
+      - `aws.ssm.Parameter` — a created resource; `.arn`/`.name` are
+        `pulumi.Output[str]` (unknown until apply).
+      - `aws.ssm.GetParameterResult` — a data-source lookup; `.arn`/`.name`
+        are plain `str` (resolved during program eval).
+
+    `lambda_service.create(extra_ssm_secrets=...)` accepts either: it only
+    reads `.arn` (to grant `ssm:GetParameter`) and the policy doc wraps the
+    arns in `Output.all(...).apply(...)`, so a plain `str` and an
+    `Output[str]` both resolve correctly. The `| str` arms of each field
+    are what let the eager `GetParameterResult` satisfy the protocol.
+    """
+
+    arn: pulumi.Output[str] | str
+    name: pulumi.Output[str] | str

--- a/infra/pulumi/components/lambda_service.py
+++ b/infra/pulumi/components/lambda_service.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass
 import pulumi
 import pulumi_aws as aws
 
+from components._types import SsmSecretRef
+
 
 @dataclass
 class LambdaService:
@@ -35,7 +37,7 @@ def create(
     timeout_seconds: int = 15,
     memory_mb: int = 512,
     layers: list[str] | None = None,
-    extra_ssm_secrets: list[aws.ssm.GetParameterResult] | None = None,
+    extra_ssm_secrets: list[SsmSecretRef] | None = None,
     cors_allow_origins: list[str] | None = None,
     cors_allow_methods: list[str] | None = None,
     cors_allow_headers: list[str] | None = None,


### PR DESCRIPTION
## Summary

`lambda_service.create(extra_ssm_secrets=...)` was typed `list[aws.ssm.GetParameterResult]` but duck-typed to also accept `aws.ssm.Parameter` — the cf_shared_secret bundle passes a *created* Parameter into the list (PR #234 / commit d068de5). The annotation lied, and a future reader had no way to know what was actually accepted. This adds a structural `SsmSecretRef` Protocol (`arn`/`name` as `pulumi.Output[str] | str`) in a new `infra/pulumi/components/_types.py`, retypes the `create()` signature, and refreshes the call-site comment. Both `aws.ssm.Parameter` (Output-typed arns) and `aws.ssm.GetParameterResult` (plain-str arns) satisfy the protocol structurally — the `| str` arm is what lets the eager lookup qualify.

## Test plan

- [x] `pulumi preview --stack prod` evaluates clean — program imports the new Protocol with no circular-import/error
- [x] Zero new resource diff attributable to the change (a type annotation is invisible to Pulumi's resource graph; only pre-existing imageUri/datadog-version drift shows)
- [x] Drift-lint green (25 mirrored pairs) — infra files are outside the services/ mirror, no discipline impact
- [x] All `__main__.py` call sites (mixed `Parameter` + `GetParameterResult`) pass under the new union type with no edit

## Out of scope

- Refactoring `lambda_service` internals (per issue)
- Replacing other duck-typed contracts elsewhere in the codebase (per issue)
- TDD red/green + temper spec: type-only change, no runtime/behavior change, no domain concept — nothing testable to assert beyond the clean preview

Size: XS

closes #235