### PR TITLE
fix(infra): Elder dashboard tags use only org-allowed keys (team) — unblock deploy

### DIFF
--- a/infra/pulumi/components/dd_dashboard.py
+++ b/infra/pulumi/components/dd_dashboard.py
@@ -271,7 +271,10 @@ def create_elder_health(
         ),
         "layout_type": "ordered",
         "reflow_type": "auto",
-        "tags": [f"env:{env}", "team:grug", "service:grug-webhook"],
+        # This DD org restricts DASHBOARD tag keys to `team` + `ai` (enforced
+        # only at POST /api/v1/dashboard — not by pulumi preview). env/service
+        # scoping lives in the widget queries, not dashboard tags.
+        "tags": ["team:grug"],
         "widgets": widgets,
     }
 


### PR DESCRIPTION
## Summary

`main` prod deploy ([run 26716579454](https://github.com/githumps/grug/actions/runs/26716579454)) failed creating the `grug-elder-health` dashboard: `POST /api/v1/dashboard → 400 "Invalid tag format. Valid tag keys are: team, ai."` This DD org restricts dashboard-level tag keys to `team` and `ai`; the `env:`/`service:` tags I set were rejected. The rule is enforced only at the DD API on create, so `pulumi preview` and widget-schema validation both passed and it surfaced only at deploy. Fix drops dashboard tags to `["team:grug"]` — env/service scoping already lives in the widget queries.

## Test plan

- [x] `pulumi preview --stack prod` plans the DashboardJson create cleanly (was already clean; the failure was API-create-only)
- [x] Confirmed via the failed run log that the sole error was the tag-key rejection — no other widget/query error
- [x] Deploy on merge will create the dashboard; will watch run + confirm `elder_dashboard_url` populates
- [x] Single-key `team:grug` matches the org-allowed `team`/`ai` set

## Out of scope

- Any widget/query change (those validated clean; only dashboard-level tags were wrong)
- Adding an `ai:` tag (allowed but unknown valid values; `team:grug` suffices)

Size: XS

closes #258