### PR TITLE
fix(infra): grant deploy role events:* for EventBridge (unblock deploy)

### DIFF
--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -121,6 +121,15 @@ def create(
                             "ssm:GetParameter*",
                             "ssm:DescribeParameters",
                             "cloudwatch:*",
+                            # EventBridge (events:*) is a DISTINCT namespace
+                            # from cloudwatch:* (metrics/alarms). The reaction-
+                            # poll scheduled Lambda (#261) is the first
+                            # EventBridge resource; creating a TAGGED rule needs
+                            # events:TagResource + PutRule/PutTargets/etc. Broad
+                            # like the lambda:*/cloudwatch:* grants above
+                            # (Slice-1 "deploy works"; ARN-scoping is the
+                            # deferred follow-up).
+                            "events:*",
                             "sts:GetCallerIdentity",
                             "kms:Decrypt",
                             # Lambda eagerly encrypts env vars on the


### PR DESCRIPTION
## Summary

`main`'s deploy is red: creating the poller's EventBridge rule fails with `AccessDeniedException: grug-gha-deploy is not authorized to perform events:TagResource`. The deploy role grants `cloudwatch:*` but **not `events:*`** — EventBridge is a distinct IAM namespace from CloudWatch, and #261 is the repo's first EventBridge resource, so the role was never granted it. Creating a tagged rule needs `events:TagResource` + `PutRule`/`PutTargets`. This adds `events:*` to the deploy-role policy, matching the existing broad `lambda:*`/`cloudwatch:*` Slice-1 grants.

## Test plan

- [x] Root cause confirmed from the failed run log (`events:TagResource` AccessDenied on `rule/grug-poller-schedule`)
- [x] `events:*` is the correct namespace (EventBridge ≠ `cloudwatch:*`); covers PutRule/PutTargets/TagResource/DeleteRule/RemoveTargets
- [x] The deploy role self-updates via `iam:*` (already granted), so this propagates on the next `pulumi up`
- [x] Deploy watched post-merge — confirm grug-poller-schedule + target + Lambda + monitors create + smoke test green (re-run once if IAM propagation races)

## Out of scope

- ARN-scoping the deploy role's broad grants (a pre-existing Slice-1 follow-up across lambda:*/cloudwatch:*/events:*)
- The poller resources themselves (already merged #268 — this only unblocks their creation)

Size: XS

closes #269