### PR TITLE
feat(infra): gate non-Lambda resources on iam_propagation_wait (#172)

### DIFF
--- a/docs/NETWORK-TOPOLOGY.md
+++ b/docs/NETWORK-TOPOLOGY.md
@@ -237,7 +237,7 @@ flowchart LR
 | `/grug/cloudflare-api-token` SSM | Web deploys read this at workflow time (NOT a GitHub Actions secret — intentional). Rotate via SSM put; no code changes |
 | `/shared/datadog-app-key/github-grug` SSM | Per-project DD APP key. Needs `monitors_write` + `logs_read_data` + `rum_apps_read` + `rum_apps_write` + `product_analytics_apps_write` scopes — every scope earned a 403 during the RUM cascade until added |
 | `grug-gha-deploy` IAM role | OIDC-trust-scoped to `githumps/grug`. Policy must allow `ssm:PutParameter` on `/grug/*` (added PR #171 after RUM `dd_rum` component became the first Pulumi-managed SSM writer) |
-| `iam_propagation_wait` (`pulumiverse_time.Sleep`) | Gates KMS-using Lambda updates on IAM policy propagation. **Does NOT yet gate non-Lambda resources** — RUM SSM Put raced ahead of policy update on first attempt; one-shot re-trigger cleared it (follow-up: extend wait to SSM Params + KMS Grants) |
+| `iam_propagation_wait` (`pulumiverse_time.Sleep`) | Gates resources whose create/update runs an upfront AWS auth check against a freshly-updated deploy-role policy, so the policy has ~45s to propagate. Threaded via an `iam_propagation_wait=` kwarg into the factories that create them (#172): **Lambda** Functions (`lambda_service` / `scheduled_lambda`, KMS encrypt check), **SSM Params** (`dd_rum`, `ssm:PutParameter` — the RUM cascade race), and **EventBridge rules** (`scheduled_lambda`, `events:TagResource` — the #261 poller race). Any new resource class that depends on a same-run role-policy grant should take the kwarg + add it to `opts.depends_on` (grep `iam_propagation_wait=`). |
 | `DD Lambda Extension 96-next` (baked into ECR image) | Cold-start path loads this binary. Version bump = full image rebuild |
 
 ---

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -536,7 +536,10 @@ monitors = dd_monitors.create_all(
 # Application ID + client token exported to SSM so web.deploy.yml can
 # substitute them into the build at deploy time without committing
 # either value to the repo.
-rum = dd_rum.create(name="grug-web", provider=_dd_provider)
+rum = dd_rum.create(
+    name="grug-web", provider=_dd_provider,
+    iam_propagation_wait=_iam_propagation_wait,
+)
 
 # Elder code-review health dashboard (#192). LLM Obs span metrics +
 # dispatch-log outcomes; eval-based surfaces deep-link to the LLM Obs

--- a/infra/pulumi/components/dd_rum.py
+++ b/infra/pulumi/components/dd_rum.py
@@ -42,6 +42,7 @@ def create(
     *,
     name: str,
     provider: datadog.Provider,
+    iam_propagation_wait: pulumi.Resource | None = None,
 ) -> RumBundle:
     """Provision the DD RUM Application + export its credentials to SSM.
 
@@ -51,7 +52,18 @@ def create(
         `rum_service_tag_is_grug_web_canonical_per_dd_naming_canon`).
       provider: The pre-configured `datadog.Provider` from `__main__.py`
         — same one used by `dd_monitors`.
+      iam_propagation_wait: gates the `ssm:PutParameter` creates on the
+        deploy-role policy having propagated (#172). Without it, a deploy
+        that adds `ssm:PutParameter` to the role in the SAME `pulumi up`
+        races the param creates → transient AccessDenied (the RUM cascade,
+        PRs #164→#171). `None` keeps the resources ungated (dev/tests).
     """
+    # SSM param creates depend on the freshly-granted deploy-role policy;
+    # gate them on its propagation when the wait is supplied.
+    param_opts = (
+        pulumi.ResourceOptions(depends_on=[iam_propagation_wait])
+        if iam_propagation_wait is not None else None
+    )
     app = datadog.RumApplication(
         f"{name}-rum-app",
         name=name,
@@ -77,6 +89,7 @@ def create(
         value=pulumi.Output.secret(app.id),
         description="DD RUM Application ID for grug-web. Public by design (lives in browser bundle); sourced from SSM so rotation is `pulumi up` not a git commit.",
         tags={"managed_by": "pulumi", "scope": "grug", "service": "grug-web"},
+        opts=param_opts,
     )
     ssm_client_token = aws.ssm.Parameter(
         f"{name}-rum-client-token",
@@ -85,6 +98,7 @@ def create(
         value=pulumi.Output.secret(app.client_token),
         description="DD RUM client token for grug-web. Public by design; sourced from SSM so rotation is `pulumi up` not a git commit.",
         tags={"managed_by": "pulumi", "scope": "grug", "service": "grug-web"},
+        opts=param_opts,
     )
 
     return RumBundle(

--- a/infra/pulumi/components/scheduled_lambda.py
+++ b/infra/pulumi/components/scheduled_lambda.py
@@ -188,13 +188,22 @@ def create(
         opts=function_opts,
     )
 
-    # EventBridge schedule → invoke the Lambda on a fixed cadence.
+    # EventBridge schedule → invoke the Lambda on a fixed cadence. Gated on
+    # iam_propagation_wait (#172): a TAGGED rule create needs the deploy
+    # role's `events:TagResource` grant, and a deploy that adds `events:*` in
+    # the SAME `pulumi up` races propagation → AccessDenied (hit on #261's
+    # first deploy, needed a re-run). The wait makes it one-shot. The target +
+    # permission depend on the rule, so gating the rule covers the chain.
     rule = aws.cloudwatch.EventRule(
         f"{name}-schedule",
         name=f"{name}-schedule",
         schedule_expression=schedule_expression,
         description=f"grug {name} cron ({schedule_expression})",
         tags={"app": "grug", "service": name},
+        opts=(
+            pulumi.ResourceOptions(depends_on=[iam_propagation_wait])
+            if iam_propagation_wait is not None else None
+        ),
     )
     aws.cloudwatch.EventTarget(
         f"{name}-target",


### PR DESCRIPTION
## Summary

`iam_propagation_wait` (the 45s `pulumiverse_time.Sleep` that lets a freshly-updated deploy-role policy propagate) only gated **Lambda** Functions. Any other resource whose create runs an upfront AWS auth check against that same just-granted policy raced it in the same `pulumi up`. This threads the wait into the factories that create them — retiring two observed races: the RUM `ssm:PutParameter` cascade (#164→#171) and today's `#261` poller EventBridge `events:TagResource` race (which needed a manual deploy re-run). The target + permission depend on the rule, so gating the rule covers the EventBridge chain.

## Test plan

- [x] `dd_rum.create` accepts `iam_propagation_wait` and adds it to both `aws.ssm.Parameter` `depends_on`; `__main__` passes it
- [x] `scheduled_lambda` EventRule gated on the wait (target/permission inherit via rule dependency)
- [x] `pulumi preview` clean — `depends_on` edges are graph metadata, no new resource diff; eval succeeds
- [x] `NETWORK-TOPOLOGY.md` footnote updated — the "does NOT yet gate non-Lambda" caveat removed; the `iam_propagation_wait=` kwarg pattern is documented + grep-able
- [x] Future deploys that grant a new role permission in the same `up` are now one-shot (no re-trigger)

## Out of scope

- Replacing the static `Sleep` with an active IAM-visibility waiter (per the issue — the 45s static wait suffices)
- Tightening any individual policy's resource scope (separate Slice-1 follow-up)

Size: S

closes #172