### PR TITLE
fix(infra): grant deploy role dynamodb:* on grug-main (deploy-trap hotfix)

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -139,7 +139,9 @@ gha_deploy_role = _deploy_role_bundle.role
 _iam_propagation_wait = _deploy_role_bundle.iam_propagation_wait
 
 # Slice 2 (#23) — DDB single-table + KMS CMK + api Lambda
-grug_main_table = ddb_table.create("grug-main")
+grug_main_table = ddb_table.create(
+    "grug-main", iam_propagation_wait=_iam_propagation_wait,
+)
 grug_tokens_cmk = kms_cmk.create("grug-tokens")
 
 # CF→AWS auth boundary (parent #173). Provisioned before the Lambdas so

--- a/infra/pulumi/components/ddb_table.py
+++ b/infra/pulumi/components/ddb_table.py
@@ -23,9 +23,24 @@ import pulumi
 import pulumi_aws as aws
 
 
-def create(name: str = "grug-main") -> aws.dynamodb.Table:
+def create(
+    name: str = "grug-main",
+    *,
+    iam_propagation_wait: pulumi.Resource | None = None,
+) -> aws.dynamodb.Table:
+    # Gate table create/update behind the deploy-role IAM-propagation wait
+    # (#272): the dynamodb:* grant is added to grug-gha-deploy in the SAME
+    # plan as the first table mutation (TTL enable), so without the 45s wait
+    # the UpdateTable/UpdateTimeToLive call can fire before the grant
+    # propagates → AccessDenied (same race the Lambda/dd_rum gating solves).
+    opts = (
+        pulumi.ResourceOptions(depends_on=[iam_propagation_wait])
+        if iam_propagation_wait is not None
+        else None
+    )
     return aws.dynamodb.Table(
         name,
+        opts=opts,
         name=name,
         billing_mode="PAY_PER_REQUEST",
         hash_key="PK",

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -187,6 +187,23 @@ def create(
                         ],
                         "Resource": "arn:aws:ssm:*:*:parameter/grug/*",
                     },
+                    {
+                        # Pulumi-managed DynamoDB table lifecycle. The deploy
+                        # role had NO dynamodb perms — the grug-main table's
+                        # create/PITR/GSI predate this role (broader bootstrap
+                        # principal), so the gap stayed latent until #272's
+                        # TTL-enable became the FIRST table MUTATION this role
+                        # attempted → AccessDeniedException: UpdateTimeToLive
+                        # (deploy run 26735432997; preview can't catch an
+                        # apply-time auth check). Scoped to the grug-main table
+                        # + its sub-resources (indexes/streams), not "*".
+                        "Effect": "Allow",
+                        "Action": "dynamodb:*",
+                        "Resource": [
+                            "arn:aws:dynamodb:*:*:table/grug-main",
+                            "arn:aws:dynamodb:*:*:table/grug-main/*",
+                        ],
+                    },
                 ],
             },
         )


### PR DESCRIPTION
## Summary

Hotfix for #272's failed deploy (run 26735432997). Enabling DynamoDB TTL was the first table *mutation* the `grug-gha-deploy` OIDC role ever attempted — and the role had **zero** dynamodb permissions (the `grug-main` create/PITR/GSI predate this role, via a broader bootstrap principal). The `dynamodb:UpdateTimeToLive` call hit `AccessDeniedException`, aborting `pulumi up` before the webhook Function update — so prod stayed on the old synchronous image (safe, no half-deployed state). `pulumi preview` can't catch this; it's an apply-time IAM auth check.

Grants the deploy role `dynamodb:*` scoped to the `grug-main` table ARN (+ sub-resources), and gates the table update on the existing `iam_propagation_wait` (45s) so the new grant propagates before the `UpdateTable`/`UpdateTimeToLive` fires — the same race the Lambda + dd_rum gating already solves. Re-deploy then ships #272's runtime (async offload) plus the TTL/timeout/EventInvokeConfig that the failed run never applied.

## Test plan
- [x] `py_compile` clean on oidc_role.py, ddb_table.py, __main__.py
- [x] Root cause confirmed from the deploy log (`AccessDeniedException: dynamodb:UpdateTimeToLive on grug-main`) + live state (timeout still 60, TTL still DISABLED, Function not updated)
- [ ] Re-deploy succeeds; verify live: timeout=420, TTL ENABLED on `ttl`, EventInvokeConfig MaximumRetryAttempts=0, webhook image updated

## Out of scope
- ARN-scoping the other broad deploy-role grants (lambda:*/events:*/etc.) — pre-existing deferred follow-up
- #276 operator arm-up

Size: XS

closes #272