### PR TITLE
fix(web): cap concurrent enforcement fetches (prevent Lambda-throttle 429 storm)

### DIFF
--- a/web/src/lib/installations.ts
+++ b/web/src/lib/installations.ts
@@ -1,6 +1,38 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "./api";
 
+// Client-side concurrency gate. The dashboard mounts one useEnforcement per
+// repo and React Query fires them ALL at once; 14 parallel calls each
+// cold-start the grug-api Lambda (~2.8s/slot) and blow past its concurrency →
+// AWS throttles the overflow with 429 (verified: aws.lambda Throttles metric),
+// which the UI then had to paper over. Capping the in-flight enforcement
+// fetches PREVENTS the burst instead of retrying after it — the "slowdown"
+// that fixes the storm at the source. A tiny promise-pool, no dependency.
+function createLimiter(max: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const next = () => {
+    if (active >= max || queue.length === 0) return;
+    active++;
+    queue.shift()!();
+  };
+  return function run<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        task().then(resolve, reject).finally(() => {
+          active--;
+          next();
+        });
+      });
+      next();
+    });
+  };
+}
+
+// 5 keeps the dashboard responsive while staying under the api's effective
+// concurrency (≈9 succeeded before throttling in the observed burst).
+const enforcementGate = createLimiter(5);
+
 export interface Installation {
   install_id: number;
   account_login: string;
@@ -53,7 +85,10 @@ function jitteredBackoff(attempt: number): number {
 export function useEnforcement(installId: number | undefined, repoId: number | undefined) {
   return useQuery<{ repo_id: number; enforcement_state: EnforcementState; degraded?: boolean }>({
     queryKey: ["enforcement", installId, repoId],
-    queryFn: () => api(`/api/v1/installations/${installId}/repos/${repoId}/enforcement`),
+    queryFn: () =>
+      enforcementGate(() =>
+        api(`/api/v1/installations/${installId}/repos/${repoId}/enforcement`),
+      ),
     enabled: installId != null && repoId != null,
     staleTime: 60_000,
     // Resilience (dashboard 429 storm): the server now absorbs GitHub rate


### PR DESCRIPTION
## Summary

Follow-up to #280. Verifying #280 on the live dashboard revealed the per-repo `/enforcement` **429s are AWS Lambda concurrency throttling, not GitHub** — the `aws.lambda` `Throttles` metric showed `Sum=5` for the 14-wide burst, and grug-api logs show the handler ran `200` only for the ~9 that got a slot. React Query fires one `useEnforcement` per repo at once; 14 parallel calls each cold-start grug-api (~2.8s/slot) and exceed its concurrency, so AWS 429s the overflow **at the invoke layer, before the handler** (which is why #280's server-side GitHub retry/fallback can't catch it). This caps the in-flight enforcement fetches with a tiny promise-pool limiter (5) so the burst never trips the throttle — the "slowdown" that fixes it at the source. #280's retry+jitter is now the residual safety net; the degraded-fallback badge handles anything that still slips through.

## Test plan
- [x] Root cause confirmed via ground truth: `aws cloudwatch get-metric-statistics` Throttles Sum=5 on grug-api; logs show 200 for the slots that ran
- [x] Limiter is a standard promise-pool (cap 5, < the ≈9 that succeeded pre-throttle); no new dependency
- [x] `tsc -b && vite build` clean
- [ ] Post-deploy: reload dashboard, confirm 0×429 on the enforcement burst (cap serialises into ≤5 concurrent)

## Out of scope
- Provisioned concurrency on grug-api (would also fix it by killing cold-start slot-holds, but costs always-on $$); the client cap is free
- A batch `/enforcement` endpoint (one request for all repos) — larger refactor

Size: S

closes #272