### PR TITLE
fix: admin Scan IAM + surface dashboard fix-button errors

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -445,6 +445,11 @@ _aws.iam.RolePolicy(
                             "dynamodb:UpdateItem",
                             "dynamodb:DeleteItem",
                             "dynamodb:Query",
+                            # Scan backs the admin endpoints (_scan_all over
+                            # USER#/INST# rows). Its absence 500'd
+                            # GET /admin/users + /admin/installations with
+                            # AccessDeniedException — admin never worked.
+                            "dynamodb:Scan",
                             "dynamodb:BatchGetItem",
                             "dynamodb:BatchWriteItem",
                         ],

--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -189,6 +189,19 @@ def create_ruleset(
         headers=_auth_headers(install_token),
         timeout=10,
     )
+    if resp.status_code >= 400:
+        # Log GitHub's validation detail before raising — a 422 here is
+        # otherwise opaque (raise_for_status drops the body), and it's exactly
+        # what the dashboard "fix" button hit. The body names the real cause
+        # (duplicate ruleset name / invalid rule param / missing perm).
+        log.warning(
+            "create_ruleset_rejected",
+            extra={
+                "owner": owner, "repo": repo, "ruleset_name": name,
+                "status": resp.status_code,
+                "body": resp.text[:600],
+            },
+        )
     resp.raise_for_status()
     return resp.json()
 

--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -364,7 +364,25 @@ def fix_enforcement(
         state = ensure_enforcement(token, owner, repo_name, default_branch, install_id, repo_id)
         return {"repo_id": repo_id, "enforcement_state": state}
 
-    return with_install_token_retry(install_id, _fix)
+    try:
+        return with_install_token_retry(install_id, _fix)
+    except httpx.HTTPStatusError as e:
+        # GitHub rejected the ruleset create/update (e.g. 422 validation:
+        # duplicate name, invalid rule, or the App lacks administration:write).
+        # Surface an ACTIONABLE error instead of a raw 500 — the old behavior
+        # made the dashboard "fix" button silently do nothing. The GitHub body
+        # carries the reason; pass a trimmed version through to the client.
+        gh_status = e.response.status_code
+        detail = (e.response.text or "")[:300]
+        log.warning(
+            "fix_enforcement_github_rejected",
+            extra={"install_id": install_id, "repo_id": repo_id,
+                   "gh_status": gh_status, "detail": detail},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"GitHub rejected the ruleset ({gh_status}): {detail}",
+        ) from e
 
 
 def _resolve_repo(

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -189,6 +189,19 @@ def create_ruleset(
         headers=_auth_headers(install_token),
         timeout=10,
     )
+    if resp.status_code >= 400:
+        # Log GitHub's validation detail before raising — a 422 here is
+        # otherwise opaque (raise_for_status drops the body), and it's exactly
+        # what the dashboard "fix" button hit. The body names the real cause
+        # (duplicate ruleset name / invalid rule param / missing perm).
+        log.warning(
+            "create_ruleset_rejected",
+            extra={
+                "owner": owner, "repo": repo, "ruleset_name": name,
+                "status": resp.status_code,
+                "body": resp.text[:600],
+            },
+        )
     resp.raise_for_status()
     return resp.json()
 

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -136,6 +136,11 @@ function RepoPanel({ installId }: { installId: number | null }) {
             onFix={() => fixEnforcement.mutate(r.repo_id)}
             pending={setConfig.isPending && setConfig.variables?.repo_id === r.repo_id}
             fixPending={fixEnforcement.isPending && fixEnforcement.variables === r.repo_id}
+            fixError={
+              fixEnforcement.isError && fixEnforcement.variables === r.repo_id
+                ? ((fixEnforcement.error as Error)?.message ?? "fix failed")
+                : undefined
+            }
           />
         ))}
       </div>
@@ -144,7 +149,7 @@ function RepoPanel({ installId }: { installId: number | null }) {
 }
 
 function RepoRow({
-  repo, installId, onToggle, onFix, pending, fixPending,
+  repo, installId, onToggle, onFix, pending, fixPending, fixError,
 }: {
   repo: Repo;
   installId: number;
@@ -152,6 +157,7 @@ function RepoRow({
   onFix: () => void;
   pending: boolean;
   fixPending: boolean;
+  fixError?: string;
 }) {
   const enforcement = useEnforcement(
     repo.config.tpm_enabled ? installId : undefined,
@@ -187,6 +193,14 @@ function RepoRow({
         )}
         {fixPending && (
           <span className="text-xs font-mono text-stone-500">fixing…</span>
+        )}
+        {fixError && !fixPending && (
+          <span
+            className="text-xs font-mono text-red-400 max-w-[14rem] truncate"
+            title={fixError}
+          >
+            ⚠ fix failed
+          </span>
         )}
         <label className="flex items-center gap-2 text-xs font-mono text-stone-400 select-none cursor-pointer">
           <input


### PR DESCRIPTION
## Summary

Two live dashboard bugs, both diagnosed from grug-api logs (ground truth):

1. **`/admin` "failed to load"** — `GET /admin/users` + `/admin/installations` 500'd with `AccessDeniedException` on `dynamodb:Scan`. The `grug-api` execution role had GetItem/Query/Put/Update/Delete/Batch but **not `Scan`**, which `_scan_all` (admin USER#/INST# listing) requires — so admin has never worked. Added `dynamodb:Scan` to the api role's DDB policy.
2. **"fix" button did nothing** — `POST .../enforcement` let GitHub's `422` propagate as a raw `500`, and the SPA swallowed it. Now `create_ruleset` logs the GitHub response **body** on ≥400 (so the opaque 422 cause is visible in DD), `fix_enforcement` returns `502` + the trimmed reason instead of `500`, and the dashboard renders **"⚠ fix failed"** (hover = reason) instead of silently nothing.

## Test plan
- [x] Root causes from logs: `AccessDeniedException ... Scan` (admin); `POST /rulesets 422` → 500 (fix button)
- [x] api installations routes 12 pass; webhook rulesets 31 pass; drift-lint 26; web `tsc -b && vite build` clean
- [x] Log-key `ruleset_name` (not `name` — collides with LogRecord reserved attr; caught by the 401-propagate test)
- [ ] Post-deploy: `/admin` loads users+installs; clicking "fix" either succeeds or shows "⚠ fix failed" + the `create_ruleset_rejected` log reveals the 422 cause

## Out of scope
- The root 422 fix (needs the body the new logging captures — likely duplicate-name idempotency or `administration:write`); follow-up once the reason is logged
- The Grug caveman-editorial design implementation (separate, larger effort)

Size: S

closes #272