### PR TITLE
feat(web): redesign dashboard in the Grug caveman-editorial system

### DIFF
--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -1,285 +1,538 @@
-import { useState } from "react";
-import { Navigate } from "react-router-dom";
-import { Shell } from "../components/Shell";
+import { useMemo, useRef, useState } from "react";
+import { Navigate, Link, useNavigate } from "react-router-dom";
 import { useMe } from "../lib/me";
+import { API_BASE } from "../lib/api";
 import {
-  useInstallRepos,
   useInstallations,
-  useSetRepoConfig,
+  useInstallRepos,
   useEnforcement,
   useFixEnforcement,
+  useSetRepoConfig,
   type Repo,
 } from "../lib/installations";
+import "./dashboard-grug.css";
+
+// ── Grug Caveman Editorial dashboard (design bundle Dashboard.html). The
+// Repositories panel is wired to the real API (installs / tpm toggle /
+// enforcement / fix); the other six panels are the design's interactive
+// local-state mock until backends exist (no fake "saved to server" — state
+// persists to localStorage so the controls feel live, like the prototype).
+
+type Panel =
+  | "repos" | "personas" | "appearance" | "usage" | "notifications" | "account" | "activity";
+
+const PANELS: { id: Panel; idx: string; label: string; badge?: string }[] = [
+  { id: "repos", idx: "01", label: "Repositories" },
+  { id: "personas", idx: "02", label: "Personas", badge: "5" },
+  { id: "appearance", idx: "03", label: "Appearance" },
+  { id: "usage", idx: "04", label: "Usage & billing" },
+  { id: "notifications", idx: "05", label: "Notifications" },
+  { id: "account", idx: "06", label: "Account & org" },
+  { id: "activity", idx: "07", label: "Activity", badge: "live" },
+];
+
+const PERSONAS = [
+  { id: "smasher", code: "F-01", name: "Smasher", img: "grug_smasher.png", desc: "Static analysis + symbolic exec + LLM diff review. Null-derefs, races, off-by-ones.", meta: ["312 runs / mo", "98% pass"] },
+  { id: "guard", code: "F-02", name: "Guard", img: "grug_guard.png", desc: "SCA, secret scanning, SAST on the diff, hourly CVE feed. Evil shall not pass.", meta: ["hourly CVE feed", "1 blocking now"] },
+  { id: "elder", code: "F-03", name: "Elder", img: "grug_elder.png", desc: "Line-by-line review for naming, complexity, coverage, dead code.", meta: ["BYO model key", "inline suggestions"] },
+  { id: "chief", code: "F-04", name: "Chief", img: "grug_chief.png", desc: "Definition-of-Ready on every PR. Acceptance criteria, estimate, rollback plan.", meta: ["5 checks", "strict mode"] },
+  { id: "warder", code: "F-05", name: "Warder", img: "grug_mystic.png", desc: "Ward off bad release. Auto-changelog, semver hint, deploy gate.", meta: ["beta", "coming soon"], soon: true },
+] as const;
+
+const SKINS = [
+  { id: "classic", cap: "Classic", img: "grug-angry.png" },
+  { id: "pro", cap: "Professional", img: "grug_professional.png" },
+  { id: "mullet", cap: "Mullet", img: "grug_mullet.png" },
+  { id: "smile", cap: "Smile", img: "grug_smile.png" },
+  { id: "byog", cap: "BYOG", img: "grug_byog.png" },
+];
+
+const NOTIF = [
+  { id: "checkruns", name: "GitHub Check Runs", desc: "Post verdicts as Check Runs. The core gate — leave this on." },
+  { id: "email", name: "Email on block", desc: "Mail you when a persona blocks one of your PRs." },
+  { id: "slack", name: "Slack channel", desc: "Drop blocking findings into #grug. Connect workspace first." },
+  { id: "stale", name: "Stale-PR pulse", desc: "Daily nudge for PRs sitting unreviewed more than 4 days." },
+  { id: "weekly", name: "Weekly digest", desc: "Monday summary of what Grug crushed last week." },
+];
+
+const ACTIVITY = [
+  { persona: "Guard", repo: "githumps/somatic-scripts", pr: "#358", v: "block", msg: "CVE-2026-1144 in lodash@4.17.20 · prototype pollution", ago: "2m" },
+  { persona: "Smasher", repo: "githumps/somatic-scripts", pr: "#358", v: "block", msg: "2 null-deref paths in parser.go:142", ago: "2m" },
+  { persona: "Chief", repo: "githumps/somatic-scripts", pr: "#358", v: "block", msg: "missing rollback plan · DoR fail", ago: "2m" },
+  { persona: "Elder", repo: "githumps/somatic-scripts", pr: "#358", v: "warn", msg: "complexity 18 in resolveTree() · coverage 67%", ago: "2m" },
+  { persona: "Smasher", repo: "githumps/grug", pr: "#142", v: "pass", msg: "0 critical findings · all error returns handled", ago: "11m" },
+  { persona: "Elder", repo: "your-org/edge-router", pr: "#77", v: "warn", msg: "C-style loop · suggest range · 1 inline fix", ago: "1h" },
+  { persona: "Smasher", repo: "your-org/retro-archive", pr: "#19", v: "pass", msg: "clean diff · no regressions detected", ago: "3h" },
+] as const;
+
+type PMode = "block" | "warn" | "off";
+const LS = "grug_dash_v2";
+
+// HTML-escape any dynamic value before it flows into the toast / ascii
+// innerHTML (repo names come from GitHub; `mood` is free user input). The
+// surrounding markup is our own static, trusted HTML — only the interpolated
+// values need escaping, which removes the XSS vector.
+const esc = (s: string) =>
+  s.replace(/[&<>"']/g, (c) => (
+    { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] as string
+  ));
+
+function loadLocal() {
+  const def = {
+    personas: { smasher: "block", guard: "block", elder: "warn", chief: "block", warder: "off" } as Record<string, PMode>,
+    skin: "classic",
+    tone: "caveman",
+    mood: "GRUG.MOOD = ANGRY",
+    cap: "50",
+    notif: { checkruns: true, email: true, slack: false, stale: true, weekly: false } as Record<string, boolean>,
+    pauseAll: false,
+  };
+  try {
+    const s = JSON.parse(localStorage.getItem(LS) || "{}");
+    return {
+      ...def, ...s,
+      personas: { ...def.personas, ...(s.personas || {}) },
+      notif: { ...def.notif, ...(s.notif || {}) },
+    };
+  } catch { return def; }
+}
 
 export function Dashboard() {
   const me = useMe();
   const installs = useInstallations();
-  const [active, setActive] = useState<number | null>(null);
+  const [panel, setPanel] = useState<Panel>("repos");
+  const [local, setLocalState] = useState<ReturnType<typeof loadLocal>>(loadLocal);
+  const setLocal = (patch: Partial<ReturnType<typeof loadLocal>>) =>
+    setLocalState((s: ReturnType<typeof loadLocal>) => { const next = { ...s, ...patch }; try { localStorage.setItem(LS, JSON.stringify(next)); } catch { /* ignore */ } return next; });
+
+  const [toast, setToast] = useState<string | null>(null);
+  const toastT = useRef<number | undefined>(undefined);
+  const fireToast = (html: string) => {
+    setToast(html); window.clearTimeout(toastT.current);
+    toastT.current = window.setTimeout(() => setToast(null), 1700);
+  };
+
+  const [tapeDismissed, setTapeDismissed] = useState(
+    () => localStorage.getItem("grug_tape_dismissed") === "1");
 
   if (me.isLoading) {
-    return (
-      <Shell>
-        <div className="px-6 py-24 text-center text-stone-500 font-mono text-sm">
-          loading…
-        </div>
-      </Shell>
-    );
+    return <div className="grug-dash"><div style={{ padding: "80px", textAlign: "center", fontFamily: "'JetBrains Mono',monospace", color: "var(--muted)" }}>loading…</div></div>;
   }
   if (!me.data?.authenticated) return <Navigate to="/signin" replace />;
 
-  const list = installs.data?.installations ?? [];
-  const selected = active ?? list[0]?.install_id ?? null;
+  const installList = installs.data?.installations ?? [];
+  const installId = installList[0]?.install_id;
 
   return (
-    <Shell>
-      <section className="px-6 py-12 max-w-5xl mx-auto">
-        <h1 className="font-mono text-2xl text-stone-100">
-          dashboard
-          {!me.data.allowlisted && (
-            <span className="ml-3 text-xs text-amber-400 font-mono uppercase tracking-wider">
-              awaiting allowlist
-            </span>
-          )}
-        </h1>
-        <p className="mt-2 text-stone-400 text-sm">
-          signed in as <span className="font-mono text-stone-200">{me.data.login}</span>
-        </p>
-
-        {!me.data.allowlisted && (
-          <div className="mt-6 border border-amber-700 bg-amber-950/40 p-4 rounded-sm text-sm text-amber-200">
-            grug installed but not yet allowlisted by an admin. you can see your repos
-            below; check-runs won't post until allowlisted.
+    <div className="grug-dash">
+      {!tapeDismissed && (
+        <div className="tape">
+          <div className="tape-track">
+            {["GRUG GUARD THIS REPO.", "GRUG WATCH EVERY PR.", "YOU TOGGLE. GRUG OBEY.", "NO YAML IN CAVE.", "GRUG REMEMBER SETTING.",
+              "GRUG GUARD THIS REPO.", "GRUG WATCH EVERY PR.", "YOU TOGGLE. GRUG OBEY.", "NO YAML IN CAVE.", "GRUG REMEMBER SETTING."].map((t, i) => (
+              <span key={i}>{t}<span className="dot"> ● </span></span>
+            ))}
           </div>
-        )}
+          <button className="tape-x" title="Dismiss" onClick={() => { setTapeDismissed(true); try { localStorage.setItem("grug_tape_dismissed", "1"); } catch { /* ignore */ } }}>×</button>
+        </div>
+      )}
 
-        <div className="mt-8 grid md:grid-cols-[18rem_1fr] gap-6">
-          <aside>
-            <div className="text-stone-500 font-mono text-xs uppercase tracking-wider mb-2">
-              installations
-            </div>
-            {installs.isLoading && (
-              <div className="text-stone-500 text-sm">loading…</div>
-            )}
-            {installs.isError && (
-              <div className="text-red-400 text-sm">failed to load</div>
-            )}
-            {list.length === 0 && !installs.isLoading && (
-              <div className="text-stone-400 text-sm">
-                no installations yet.{" "}
-                <a
-                  href="https://github.com/apps/grug-boss/installations/new"
-                  className="text-amber-400 hover:underline"
-                >
-                  install grug boss →
-                </a>
-              </div>
-            )}
-            <ul className="space-y-1">
-              {list.map((inst) => (
-                <li key={inst.install_id}>
-                  <button
-                    type="button"
-                    onClick={() => setActive(inst.install_id)}
-                    className={[
-                      "w-full text-left px-3 py-2 rounded-sm font-mono text-sm border",
-                      selected === inst.install_id
-                        ? "border-amber-500 text-amber-300 bg-stone-900"
-                        : "border-stone-800 text-stone-300 hover:border-stone-600",
-                    ].join(" ")}
-                  >
-                    {inst.account_login}
-                    <span className="ml-2 text-xs text-stone-500">
-                      {inst.account_type === "Organization" ? "org" : "user"}
-                    </span>
-                  </button>
-                </li>
+      <header className="nav">
+        <div className="nav-inner">
+          <Link className="brand" to="/">
+            <span className="brand-mark"><img src="/assets/grug-angry.png" alt="" /></span>
+            <span>grug</span>
+          </Link>
+          <nav className="links">
+            <a className={panel !== "activity" ? "active" : ""} onClick={() => setPanel("repos")}>Dashboard</a>
+            <a className={panel === "activity" ? "active" : ""} onClick={() => setPanel("activity")}>Activity</a>
+            {me.data.role === "admin" && <Link to="/admin">Admin</Link>}
+            <a href="https://github.com/githumps/grug">Docs</a>
+          </nav>
+          <div className="userchip">
+            <div className="who"><b>@{me.data.login}</b><span>{me.data.role}</span></div>
+            <span className="av"><img src="/assets/grug-angry.png" alt="" /></span>
+            <SignOut />
+          </div>
+        </div>
+      </header>
+
+      <div className="shell">
+        <div className="pagehead">
+          <div>
+            <span className="eyebrow"><span className="blob"></span>signed in · cave control</span>
+            <h1>Grug <em>settings</em>.<br />You boss. Grug listen.</h1>
+          </div>
+          <p className="sub">// You land here after GitHub OAuth. Toggle personas, pick a skin, set the budget. <span className="ok">Grug remember everything</span> — no yaml, no save button.</p>
+        </div>
+
+        <StatStrip installId={installId} />
+
+        <div className="layout">
+          <aside className="rail">
+            <div className="rail-nav">
+              {PANELS.map((p) => (
+                <button key={p.id} className={panel === p.id ? "active" : ""} onClick={() => { setPanel(p.id); window.scrollTo({ top: 0 }); }}>
+                  <span className="idx">{p.idx}</span><span className="lbl">{p.label}</span>
+                  {p.badge && <span className="badge">{p.badge}</span>}
+                </button>
               ))}
-            </ul>
+            </div>
+            <div className="rail-foot">
+              <div className="plan"><span>PLAN</span><b>PRO</b></div>
+              <div className="muted">19 / 50 checks today</div>
+              <div className="meter"><i style={{ width: "38%" }}></i></div>
+              <div className="muted">Resets 00:00 UTC · 6 seats</div>
+            </div>
           </aside>
 
-          <RepoPanel installId={selected} />
+          <main className="main">
+            <ReposPanel show={panel === "repos"} installId={installId} reposLoading={installs.isLoading} fireToast={fireToast} />
+            <PersonasPanel show={panel === "personas"} modes={local.personas} setMode={(id, v) => { setLocal({ personas: { ...local.personas, [id]: v } }); fireToast(`${id.toUpperCase()} → <span class="am">${v.toUpperCase()}</span>`); }} />
+            <AppearancePanel show={panel === "appearance"} local={local} setLocal={setLocal} fireToast={fireToast} />
+            <UsagePanel show={panel === "usage"} cap={local.cap} setCap={(c) => { setLocal({ cap: c }); fireToast(`Daily cap → <span class="am">${c === "0" ? "∞" : c}</span>`); }} />
+            <NotificationsPanel show={panel === "notifications"} notif={local.notif} toggle={(id) => setLocal({ notif: { ...local.notif, [id]: !local.notif[id] } })} />
+            <AccountPanel show={panel === "account"} me={{ login: me.data.login ?? "you", role: me.data.role ?? "user" }} pauseAll={local.pauseAll} setPause={(v) => { setLocal({ pauseAll: v }); fireToast(v ? 'All personas <span class="am">PAUSED</span>. Grug nap.' : 'Grug <span class="am">AWAKE</span>. Back to work.'); }} />
+            <ActivityPanel show={panel === "activity"} />
+          </main>
         </div>
-      </section>
-    </Shell>
+      </div>
+
+      <footer>
+        <div className="foot-inner">
+          <span className="brand serif">grug.</span>
+          <span>AGPL-3.0. Made in a cave. <a href="/Privacy.html">Privacy</a> · <a href="/Terms.html">Terms</a></span>
+          <span>Grug remember your setting. Grug satisfied.</span>
+        </div>
+      </footer>
+
+      {toast && <div className="toast show" dangerouslySetInnerHTML={{ __html: toast }} />}
+    </div>
   );
 }
 
-function RepoPanel({ installId }: { installId: number | null }) {
-  const repos = useInstallRepos(installId ?? undefined);
+function SignOut() {
+  const nav = useNavigate();
+  const [busy, setBusy] = useState(false);
+  return (
+    <a className="btn sm ghost" onClick={async () => {
+      setBusy(true);
+      try { await fetch(`${API_BASE}/api/v1/auth/logout`, { method: "POST", credentials: "include" }); } catch { /* ignore */ }
+      nav("/", { replace: true });
+    }} aria-disabled={busy}>Sign out</a>
+  );
+}
+
+function StatStrip({ installId }: { installId?: number }) {
+  const repos = useInstallRepos(installId);
+  const list = repos.data?.repos ?? [];
+  const guarded = list.filter((r) => r.config.tpm_enabled).length;
+  return (
+    <div className="statstrip">
+      <div className="cell"><div className="k">Repos guarded</div><div className="v">{guarded}<small> / {list.length} installed</small></div></div>
+      <div className="cell"><div className="k">Personas active</div><div className="v">2<small> active</small></div></div>
+      <div className="cell amber"><div className="k">Checks today</div><div className="v">19<small> / 50</small></div></div>
+      <div className="cell ink"><div className="k">Now blocking</div><div className="v">3<small> PRs gated</small></div></div>
+    </div>
+  );
+}
+
+function ReposPanel({ show, installId, reposLoading, fireToast }: { show: boolean; installId?: number; reposLoading: boolean; fireToast: (h: string) => void }) {
+  const repos = useInstallRepos(installId);
   const setConfig = useSetRepoConfig(installId ?? 0);
   const fixEnforcement = useFixEnforcement(installId ?? 0);
-
-  if (installId == null) {
-    return (
-      <div className="text-stone-500 text-sm">select an installation to manage repos</div>
-    );
-  }
-  if (repos.isLoading) return <div className="text-stone-500 text-sm">loading repos…</div>;
-  if (repos.isError) return <div className="text-red-400 text-sm">failed to load repos</div>;
-
+  const [q, setQ] = useState("");
   const list = repos.data?.repos ?? [];
+  const filtered = useMemo(() => list.filter((r) => r.full_name.toLowerCase().includes(q.toLowerCase())), [list, q]);
 
   return (
-    <div>
-      <div className="text-stone-500 font-mono text-xs uppercase tracking-wider mb-2">
-        repos · {list.length}
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>Repositories <em>Grug guard</em>.</h2>
+        <p className="note">// Flip a repo on and Grug posts Check Runs on every PR. Off means Grug sleep.</p>
       </div>
-      <div className="border border-stone-800 rounded-sm divide-y divide-stone-800">
-        {list.map((r) => (
-          <RepoRow
-            key={r.repo_id}
-            repo={r}
-            installId={installId}
-            onToggle={(enabled) =>
-              setConfig.mutate({ repo_id: r.repo_id, tpm_enabled: enabled })
-            }
-            onFix={() => fixEnforcement.mutate(r.repo_id)}
-            pending={setConfig.isPending && setConfig.variables?.repo_id === r.repo_id}
-            fixPending={fixEnforcement.isPending && fixEnforcement.variables === r.repo_id}
-            fixError={
-              fixEnforcement.isError && fixEnforcement.variables === r.repo_id
-                ? ((fixEnforcement.error as Error)?.message ?? "fix failed")
-                : undefined
-            }
-          />
-        ))}
+      <div className="card">
+        <div className="card-head">Installed repositories <span className="count">{list.length}</span></div>
+        <div className="card-body">
+          <div className="toolbar">
+            <div className="search">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="11" cy="11" r="7" /><path d="M21 21l-4-4" /></svg>
+              <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="search repos…" />
+            </div>
+            <a className="btn sm primary" href="https://github.com/apps/grug-tribe/installations/new">+ Add repository</a>
+          </div>
+          {(reposLoading || repos.isLoading) && <div className="mono" style={{ fontSize: 12, color: "var(--muted)", padding: 8 }}>loading repos…</div>}
+          {repos.isError && <div className="mono" style={{ fontSize: 12, color: "var(--tomato)", padding: 8 }}>failed to load repos</div>}
+          {!repos.isLoading && filtered.map((r) => (
+            <RepoRow key={r.repo_id} repo={r} installId={installId!}
+              onToggle={(enabled) => { setConfig.mutate({ repo_id: r.repo_id, tpm_enabled: enabled }); const nm = esc(r.full_name.split("/")[1] ?? ""); fireToast(enabled ? `Grug now guard <span class="am">${nm}</span>.` : `Grug sleep on <span class="am">${nm}</span>.`); }}
+              onFix={() => fixEnforcement.mutate(r.repo_id)}
+              fixPending={fixEnforcement.isPending && fixEnforcement.variables === r.repo_id}
+              fixError={fixEnforcement.isError && fixEnforcement.variables === r.repo_id ? ((fixEnforcement.error as Error)?.message ?? "fix failed") : undefined}
+            />
+          ))}
+          {!repos.isLoading && !repos.isError && filtered.length === 0 && (
+            <div className="mono" style={{ fontSize: 12, color: "var(--muted)", padding: 8 }}>No repo match. Grug shrug.</div>
+          )}
+        </div>
       </div>
-    </div>
+    </section>
   );
 }
 
-function RepoRow({
-  repo, installId, onToggle, onFix, pending, fixPending, fixError,
-}: {
-  repo: Repo;
-  installId: number;
-  onToggle: (enabled: boolean) => void;
-  onFix: () => void;
-  pending: boolean;
-  fixPending: boolean;
-  fixError?: string;
+function RepoRow({ repo, installId, onToggle, onFix, fixPending, fixError }: {
+  repo: Repo; installId: number; onToggle: (e: boolean) => void; onFix: () => void; fixPending: boolean; fixError?: string;
 }) {
-  const enforcement = useEnforcement(
-    repo.config.tpm_enabled ? installId : undefined,
-    repo.config.tpm_enabled ? repo.repo_id : undefined,
-  );
+  const [owner, name] = repo.full_name.split("/");
+  const on = repo.config.tpm_enabled;
+  const enforcement = useEnforcement(on ? installId : undefined, on ? repo.repo_id : undefined);
   const state = enforcement.data?.enforcement_state;
   const degraded = enforcement.data?.degraded === true;
-  const hasStoredId = repo.config.enforcement_ruleset_id != null;
+
+  let enf: { cls: string; label: string } | null = null;
+  if (on) {
+    if (degraded && (state === "grug_managed" || state === "external")) enf = { cls: "unknown", label: "unconfirmed" };
+    else if (state === "grug_managed") enf = { cls: "live", label: "ENFORCED" };
+    else if (state === "external") enf = { cls: "live", label: "EXTERNAL" };
+    else if (state === "none") enf = { cls: "warn", label: "⚠ not enforced" };
+    else if (state === "unknown") enf = { cls: "unknown", label: "unknown" };
+  }
 
   return (
-    <div className="flex items-center justify-between px-4 py-3">
-      <div className="flex items-center gap-3">
-        <a
-          href={`https://github.com/${repo.full_name}`}
-          className="font-mono text-sm text-stone-200 hover:text-amber-400"
-        >
-          {repo.full_name}
-        </a>
-        {repo.private && (
-          <span className="text-xs text-stone-500 uppercase tracking-wider">private</span>
-        )}
-        {repo.config.tpm_enabled && <EnforcementBadge state={state} degraded={degraded} hasStoredId={hasStoredId} loading={enforcement.isLoading} />}
-      </div>
-      <div className="flex items-center gap-3">
-        {repo.config.tpm_enabled && state === "none" && !fixPending && (
-          <button
-            type="button"
-            onClick={onFix}
-            className="text-xs font-mono px-2 py-1 rounded-sm border border-amber-600 text-amber-400 hover:bg-amber-950/50"
-          >
-            fix
-          </button>
-        )}
-        {fixPending && (
-          <span className="text-xs font-mono text-stone-500">fixing…</span>
-        )}
-        {fixError && !fixPending && (
-          <span
-            className="text-xs font-mono text-red-400 max-w-[14rem] truncate"
-            title={fixError}
-          >
-            ⚠ fix failed
-          </span>
-        )}
-        <label className="flex items-center gap-2 text-xs font-mono text-stone-400 select-none cursor-pointer">
-          <input
-            type="checkbox"
-            className="accent-amber-400"
-            checked={repo.config.tpm_enabled}
-            disabled={pending}
-            onChange={(e) => onToggle(e.target.checked)}
-          />
-          tpm
-        </label>
-      </div>
+    <div className="repo">
+      <div className="org">{(owner || "?").slice(0, 2).toUpperCase()}</div>
+      <div className="name"><b>{name}</b><span>{owner}/ · {repo.private ? "private" : "public"}</span></div>
+      {enf && <span className={`state ${enf.cls}`}>{enf.label}</span>}
+      {on && state === "none" && !fixPending && <button className="fixbtn" onClick={onFix}>fix</button>}
+      {fixPending && <span className="state paused">fixing…</span>}
+      {fixError && !fixPending && <span className="fixerr" title={fixError}>⚠ fix failed</span>}
+      <span className={`state ${on ? "live" : "paused"}`}>{on ? "GUARDED" : "PAUSED"}</span>
+      <div className={`sw${on ? " on" : ""}`} onClick={() => onToggle(!on)} role="switch" aria-checked={on}></div>
     </div>
   );
 }
 
-function EnforcementBadge({
-  state, degraded = false, hasStoredId, loading,
-}: {
-  state: string | undefined;
-  degraded?: boolean;
-  hasStoredId: boolean;
-  loading: boolean;
-}) {
-  if (loading && !hasStoredId) {
-    return <span className="text-xs text-stone-500 font-mono">checking…</span>;
-  }
+function PersonasPanel({ show, modes, setMode }: { show: boolean; modes: Record<string, PMode>; setMode: (id: string, v: PMode) => void }) {
+  return (
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>Many Grugs. <em>One cave.</em></h2>
+        <p className="note">// Each persona is its own Check Run. Set it to BLOCK merge, WARN only, or OFF.</p>
+      </div>
+      <div className="card">
+        <div className="card-head"><span>Personas</span></div>
+        <div className="card-body">
+          {PERSONAS.map((p) => {
+            const mode = modes[p.id] ?? "off";
+            return (
+              <div key={p.id} className={`pcard${"soon" in p && p.soon ? " soon" : ""}`}>
+                <div className="portrait"><img src={`/assets/${p.img}`} alt="" /></div>
+                <div className="body">
+                  <div className="row1"><span className="tag">{p.code} · {p.name.toUpperCase()}</span></div>
+                  <h3>{p.name}</h3>
+                  <p className="desc">{p.desc}</p>
+                  <div className="meta">{p.meta.map((m) => <span key={m}>{m}</span>)}</div>
+                </div>
+                <div className="ctrl">
+                  <div className="seg">
+                    {(["block", "warn", "off"] as PMode[]).map((v) => (
+                      <button key={v} data-v={v} className={mode === v ? "on" : ""} onClick={() => setMode(p.id, v)}>{v.toUpperCase()}</button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  const resolved = state ?? (hasStoredId ? "grug_managed" : undefined);
+function AppearancePanel({ show, local, setLocal, fireToast }: { show: boolean; local: ReturnType<typeof loadLocal>; setLocal: (p: Partial<ReturnType<typeof loadLocal>>) => void; fireToast: (h: string) => void }) {
+  const tones: Record<string, string[]> = {
+    caveman: ['<span class="to">×</span> guard · CVE-2026-1144 in lodash@4.17.20', '<span class="am">grug</span> "Lodash have hole. Hole let bad man in cave.', '       Grug not let bad man in cave. Grug block."'],
+    professional: ['<span class="to">×</span> guard · CVE-2026-1144 in lodash@4.17.20', '<span class="am">grug</span> Vulnerable dependency detected (CVSS 8.8).', '       Merge blocked pending upgrade to 4.17.21+.'],
+    deadpan: ['<span class="to">×</span> guard · CVE-2026-1144 in lodash@4.17.20', '<span class="am">grug</span> This is fine. This is not fine.', '       Blocked.'],
+    custom: ['<span class="to">×</span> guard · CVE-2026-1144 in lodash@4.17.20', '<span class="am">grug</span> [ your custom template renders here ]', '       {{ finding }} · {{ severity }}'],
+  };
+  const preview = `<span class="mo"># ${esc(local.mood)}</span>\n` + (tones[local.tone] || tones.caveman).join("\n");
+  return (
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>How Grug <em>look</em> and <em>talk</em>.</h2>
+        <p className="note">// Pick the skin that shows on Check Runs and the tone Grug uses when he block your bad PR.</p>
+      </div>
+      <div className="card">
+        <div className="card-head">Active skin</div>
+        <div className="card-body">
+          <div className="skins">
+            {SKINS.map((s) => (
+              <div key={s.id} className={`skin${local.skin === s.id ? " act" : ""}`} onClick={() => { setLocal({ skin: s.id }); fireToast(`Skin → <span class="am">${s.cap}</span>`); }}>
+                <div className="art"><img src={`/assets/${s.img}`} alt="" /></div><div className="cap">{s.cap}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="card">
+        <div className="card-head">Failure tone</div>
+        <div className="card-body">
+          <div className="radios">
+            {["caveman", "professional", "deadpan", "custom"].map((t) => (
+              <button key={t} className={local.tone === t ? "on" : ""} onClick={() => setLocal({ tone: t })}>{t[0].toUpperCase() + t.slice(1)}</button>
+            ))}
+          </div>
+          <div className="field" style={{ marginTop: 8, borderBottom: "none", paddingBottom: 0 }}>
+            <div className="lbl"><b>Mood sticker</b><span>The little badge stamped on every Check Run summary.</span></div>
+            <input className="text" value={local.mood} onChange={(e) => setLocal({ mood: e.target.value })} />
+          </div>
+          <div className="ascii" style={{ marginTop: 14 }} dangerouslySetInnerHTML={{ __html: preview }} />
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  // `degraded` = the server returned a last-known fallback because GitHub
-  // couldn't be reached (rate-limited). The state is UNCONFIRMED — render it
-  // muted with "· unconfirmed" so a stale "grug_managed" never reads as a
-  // confident green "enforced" (the ruleset may have since been deleted).
-  if (degraded && (resolved === "grug_managed" || resolved === "external")) {
-    return (
-      <span
-        className="text-xs font-mono text-stone-400"
-        title="Last-known state — GitHub was rate-limited and couldn't confirm. Refresh to re-check."
-      >
-        {resolved === "grug_managed" ? "enforced" : "external"} · unconfirmed
-      </span>
-    );
-  }
+function UsagePanel({ show, cap, setCap }: { show: boolean; cap: string; setCap: (c: string) => void }) {
+  return (
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>Usage &amp; <em>budget</em>.</h2>
+        <p className="note">// Grug cost money to run. Cap the daily checks so Grug not eat your whole AWS bill.</p>
+      </div>
+      <div className="card">
+        <div className="card-head">Daily PR-check budget</div>
+        <div className="card-body">
+          <div className="bignum">19 <small>of 50 checks used today</small></div>
+          <div className="budget"><i style={{ width: "38%" }}></i><span>38%</span></div>
+          <div className="field" style={{ borderTop: "2px dashed var(--ink)", marginTop: 8 }}>
+            <div className="lbl"><b>Hard cap per day</b><span>Grug stops posting once cap is hit. Pending PRs queue for tomorrow.</span></div>
+            <div className="seg">
+              {[["50", "50"], ["200", "200"], ["1000", "1000"], ["0", "∞"]].map(([v, lbl]) => (
+                <button key={v} className={cap === v ? "on" : ""} onClick={() => setCap(v)}>{lbl}</button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="card">
+        <div className="card-head">Current plan</div>
+        <div className="card-body" style={{ padding: 0 }}>
+          <div className="plan-grid">
+            <div>
+              <div className="nm">Pro</div>
+              <div className="pr">$12 / mo · per seat · 6 seats</div>
+              <ul className="feats" style={{ marginTop: 14 }}>
+                <li>Unlimited PR checks</li><li>All personas</li><li>Up to 10 repos</li><li>BYO model key</li>
+              </ul>
+            </div>
+            <div>
+              <div className="k mono" style={{ fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: "var(--muted)" }}>This cycle</div>
+              <div className="bignum" style={{ margin: "8px 0 4px" }}>$72<small>/mo</small></div>
+              <div className="pr">Renews Jun 12 · 487 checks billed</div>
+              <div style={{ display: "flex", gap: 10, marginTop: 16, flexWrap: "wrap" }}>
+                <a className="btn sm" href="#">Manage billing</a>
+                <a className="btn sm ghost" href="/#pricing">Change plan</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
 
-  if (resolved === "grug_managed") {
-    return (
-      <span className="text-xs font-mono text-emerald-400" title="Grug-enforced ruleset active">
-        ✓ enforced
-      </span>
-    );
-  }
-  if (resolved === "external") {
-    return (
-      <span className="text-xs font-mono text-blue-400" title="Enforced via external ruleset or branch protection">
-        ✓ external
-      </span>
-    );
-  }
-  if (resolved === "none") {
-    return (
-      <span className="text-xs font-mono text-amber-400" title="TPM enabled but check is not required to merge">
-        ⚠ not enforced
-      </span>
-    );
-  }
-  // "unknown" = GitHub was rate-limited and we had no stored state. Show a
-  // muted, honest "status unknown" — NOT a false "not enforced" — so the
-  // operator isn't misled, and the "fix" button (gated on state === "none")
-  // stays hidden.
-  if (resolved === "unknown") {
-    return (
-      <span className="text-xs font-mono text-stone-500" title="Couldn't reach GitHub (rate-limited) and no stored state — try refreshing">
-        status unknown
-      </span>
-    );
-  }
-  if (loading) {
-    return <span className="text-xs text-stone-500 font-mono">checking…</span>;
-  }
-  return null;
+function NotificationsPanel({ show, notif, toggle }: { show: boolean; notif: Record<string, boolean>; toggle: (id: string) => void }) {
+  return (
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>When Grug <em>shout</em>.</h2>
+        <p className="note">// Grug never spam PR comments. Pick where the noise goes instead.</p>
+      </div>
+      <div className="card">
+        <div className="card-head">Notification channels</div>
+        <div className="card-body">
+          {NOTIF.map((n) => (
+            <div className="field" key={n.id}>
+              <div className="lbl"><b>{n.name}</b><span>{n.desc}</span></div>
+              <div className={`sw${notif[n.id] ? " on" : ""}`} onClick={() => toggle(n.id)} role="switch" aria-checked={!!notif[n.id]}></div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AccountPanel({ show, me, pauseAll, setPause }: { show: boolean; me: { login: string; role: string }; pauseAll: boolean; setPause: (v: boolean) => void }) {
+  return (
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>Account &amp; <em>org</em>.</h2>
+        <p className="note">// Your GitHub connection and the dangerous buttons. Grug warned you.</p>
+      </div>
+      <div className="card">
+        <div className="card-head">GitHub connection</div>
+        <div className="card-body">
+          <div className="field">
+            <div className="lbl"><b>Signed in as</b><span>@{me.login} · {me.role}</span></div>
+            <a className="btn sm ghost" href="https://github.com/apps/grug-tribe/installations/new">Manage on GitHub</a>
+          </div>
+          <div className="field">
+            <div className="lbl"><b>BYO model key</b><span>Grug uses your own LLM key for Elder review. Never leaves your VPC.</span></div>
+            <input className="text" type="password" defaultValue="sk-grug-••••••••••••" placeholder="sk-…" />
+          </div>
+        </div>
+      </div>
+      <div className="card danger-card">
+        <div className="card-head">Danger zone</div>
+        <div className="card-body">
+          <div className="field">
+            <div className="lbl"><b>Pause all personas</b><span>Grug stops posting Check Runs everywhere until you flip it back.</span></div>
+            <div className={`sw${pauseAll ? " on" : ""}`} onClick={() => setPause(!pauseAll)} role="switch" aria-checked={pauseAll}></div>
+          </div>
+          <div className="field">
+            <div className="lbl"><b>Uninstall Grug</b><span>Removes the GitHub App and deletes all cave settings. Grug sad.</span></div>
+            <a className="btn sm danger" href="https://github.com/apps/grug-tribe/installations/new">Uninstall</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ActivityPanel({ show }: { show: boolean }) {
+  const [filter, setFilter] = useState("all");
+  const sym = (v: string) => (v === "block" ? "×" : v === "warn" ? "!" : "✓");
+  const rows = ACTIVITY.filter((a) => filter === "all" || a.v === filter);
+  return (
+    <section className={`panel${show ? " show" : ""}`}>
+      <div className="panel-head">
+        <h2>What Grug <em>did</em>.</h2>
+        <p className="note">// Live feed of Check Runs across guarded repos. Newest first. Grug never forget.</p>
+      </div>
+      <div className="card">
+        <div className="card-head"><span>Recent check runs</span><span className="mono" style={{ textTransform: "none", letterSpacing: 0, color: "var(--muted)", marginLeft: "auto" }}>all guarded repos</span></div>
+        <div className="card-body">
+          <div className="toolbar">
+            <div className="seg">
+              {["all", "block", "warn", "pass"].map((f) => (
+                <button key={f} className={filter === f ? "on" : ""} onClick={() => setFilter(f)}>{f.toUpperCase()}</button>
+              ))}
+            </div>
+          </div>
+          {rows.map((a, i) => (
+            <div className="afeed-row" key={i}>
+              <div className={`vico ${a.v}`}>{sym(a.v)}</div>
+              <div className="who2"><b>{a.persona}</b> <span className="repo2">{a.repo} · {a.pr}</span><span className="msg">{a.msg}</span></div>
+              <span className={`verdict ${a.v}`}>{a.v.toUpperCase()}</span>
+              <span className="ago">{a.ago}</span>
+            </div>
+          ))}
+          {rows.length === 0 && <div className="mono" style={{ fontSize: 12, color: "var(--muted)", padding: 8 }}>Nothing here. Grug calm.</div>}
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/web/src/routes/dashboard-grug.css
+++ b/web/src/routes/dashboard-grug.css
@@ -1,0 +1,253 @@
+/* Grug Caveman Editorial — dashboard skin (ported from the design bundle's
+   Dashboard.html). Scoped under `.grug-dash` so it doesn't touch the dark
+   admin/signin pages. Fonts are loaded globally in app.html. */
+
+.grug-dash {
+  --bg:#faf6ee;
+  --bg-2:#f3ecdb;
+  --ink:#181613;
+  --ink-2:#3a342c;
+  --muted:#7a7064;
+  --line:#181613;
+  --amber:#7fb0d6;
+  --amber-deep:#2e5d8a;
+  --tomato:#e0502a;
+  --moss:#3f6b3a;
+  --sky:#2e5d8a;
+  --paper:#fffbf2;
+  --shadow: 6px 6px 0 0 var(--ink);
+  --shadow-sm: 3px 3px 0 0 var(--ink);
+  --shadow-lg: 10px 10px 0 0 var(--ink);
+
+  background:var(--bg);
+  color:var(--ink);
+  font-family:'Space Grotesk', system-ui, sans-serif;
+  font-size:16px;
+  line-height:1.5;
+  -webkit-font-smoothing:antialiased;
+  min-height:100vh;
+}
+.grug-dash *{ box-sizing:border-box; }
+.grug-dash .mono{ font-family:'JetBrains Mono', ui-monospace, monospace; }
+.grug-dash .serif{ font-family:'Instrument Serif', 'Times New Roman', serif; font-weight:400; letter-spacing:-0.01em; }
+.grug-dash a{ color:inherit; }
+
+/* tape */
+.grug-dash .tape{ background:var(--ink); color:var(--bg); font-family:'JetBrains Mono', monospace; font-size:12px; padding:8px 0; overflow:hidden; white-space:nowrap; border-bottom:2px solid var(--ink); position:relative; }
+.grug-dash .tape-track{ display:inline-block; padding-left:100%; animation:grug-scroll 40s linear infinite; }
+.grug-dash .tape span{ margin:0 24px; }
+.grug-dash .tape .dot{ color:var(--amber); margin:0 12px; }
+.grug-dash .tape-x{ position:absolute; top:50%; right:12px; transform:translateY(-50%); display:grid; place-items:center; width:22px; height:22px; background:var(--amber); color:var(--ink); border:1.5px solid var(--bg); font-family:'JetBrains Mono', monospace; font-size:16px; line-height:1; cursor:pointer; z-index:2; }
+.grug-dash .tape-x:hover{ background:var(--bg); color:var(--ink); }
+.grug-dash .tape.dismissed{ display:none; }
+@keyframes grug-scroll{ from{transform:translateX(0)} to{transform:translateX(-100%)} }
+
+/* header */
+.grug-dash header.nav{ position:sticky; top:0; z-index:40; background:var(--bg); border-bottom:2px solid var(--ink); }
+.grug-dash .nav-inner{ max-width:1400px; margin:0 auto; padding:14px 28px; display:flex; align-items:center; gap:24px; }
+.grug-dash .brand{ display:flex; align-items:center; gap:10px; font-family:'Instrument Serif', serif; font-size:30px; line-height:1; letter-spacing:-0.02em; color:var(--ink); text-decoration:none; }
+.grug-dash .brand-mark{ width:36px; height:36px; background:var(--amber); border:2px solid var(--ink); border-radius:50%; overflow:hidden; display:grid; place-items:center; }
+.grug-dash .brand-mark img{ width:36px; height:36px; object-fit:cover; transform:translateY(2px) scale(1.4); }
+.grug-dash nav.links{ display:flex; gap:22px; margin-left:30px; align-items:center; }
+.grug-dash nav.links a{ font-family:'JetBrains Mono', monospace; font-size:13px; font-weight:500; color:var(--ink); text-decoration:none; padding:6px 2px; border-bottom:2px solid transparent; cursor:pointer; background:none; }
+.grug-dash nav.links a:hover{ border-bottom-color:var(--ink); }
+.grug-dash nav.links a.active{ border-bottom-color:var(--ink); font-weight:700; }
+.grug-dash .btn{ display:inline-flex; align-items:center; gap:8px; font-family:'JetBrains Mono', monospace; font-weight:700; font-size:13px; padding:10px 16px; background:var(--ink); color:var(--bg); border:2px solid var(--ink); box-shadow:var(--shadow-sm); cursor:pointer; text-decoration:none; transition: transform .08s, box-shadow .08s; }
+.grug-dash .btn:hover{ transform:translate(-1px,-1px); box-shadow:4px 4px 0 0 var(--ink); }
+.grug-dash .btn:active{ transform:translate(2px,2px); box-shadow:1px 1px 0 0 var(--ink); }
+.grug-dash .btn.primary{ background:var(--amber); color:var(--ink); }
+.grug-dash .btn.ghost{ background:var(--bg); color:var(--ink); }
+.grug-dash .btn.danger{ background:var(--tomato); color:#fff; }
+.grug-dash .btn.sm{ padding:7px 12px; font-size:11px; box-shadow:none; }
+.grug-dash .btn[disabled]{ opacity:0.5; cursor:default; }
+
+.grug-dash .userchip{ margin-left:auto; display:flex; align-items:center; gap:10px; font-family:'JetBrains Mono', monospace; font-size:12px; border:2px solid var(--ink); background:var(--paper); padding:5px 6px 5px 12px; box-shadow:var(--shadow-sm); }
+.grug-dash .userchip .who b{ font-weight:700; }
+.grug-dash .userchip .who span{ display:block; font-size:10px; color:var(--muted); }
+.grug-dash .userchip .av{ width:32px; height:32px; border:2px solid var(--ink); border-radius:50%; background:var(--amber); overflow:hidden; }
+.grug-dash .userchip .av img{ width:100%; height:100%; object-fit:cover; transform:scale(1.4) translateY(2px); }
+
+/* shell */
+.grug-dash .shell{ max-width:1400px; margin:0 auto; padding:0 28px; }
+.grug-dash .pagehead{ display:flex; align-items:flex-end; justify-content:space-between; gap:24px; flex-wrap:wrap; padding:40px 0 28px; }
+.grug-dash .pagehead .eyebrow{ font-family:'JetBrains Mono', monospace; font-size:12px; font-weight:700; text-transform:uppercase; letter-spacing:0.12em; display:inline-flex; align-items:center; gap:10px; padding:6px 12px; background:var(--amber); border:2px solid var(--ink); }
+.grug-dash .pagehead .eyebrow .blob{ width:8px; height:8px; background:var(--ink); border-radius:50%; animation:grug-blink 1.6s ease-in-out infinite; }
+@keyframes grug-blink{ 0%,100%{opacity:1} 50%{opacity:0.2} }
+.grug-dash .pagehead h1{ font-family:'Instrument Serif', serif; font-weight:400; font-size:clamp(44px, 5.4vw, 76px); line-height:0.96; letter-spacing:-0.022em; margin:18px 0 0; }
+.grug-dash .pagehead h1 em{ font-style:italic; color:var(--amber-deep); }
+.grug-dash .pagehead .sub{ font-family:'JetBrains Mono', monospace; font-size:13px; color:var(--ink-2); max-width:380px; line-height:1.5; }
+.grug-dash .pagehead .sub .ok{ color:var(--moss); }
+
+.grug-dash .statstrip{ display:grid; grid-template-columns:repeat(4,1fr); border:2px solid var(--ink); box-shadow:var(--shadow); background:var(--paper); margin-bottom:40px; }
+.grug-dash .statstrip .cell{ padding:16px 18px; border-right:2px solid var(--ink); }
+.grug-dash .statstrip .cell:last-child{ border-right:none; }
+.grug-dash .statstrip .k{ font-family:'JetBrains Mono', monospace; font-size:10px; letter-spacing:0.12em; text-transform:uppercase; color:var(--muted); }
+.grug-dash .statstrip .v{ font-family:'Instrument Serif', serif; font-size:38px; line-height:1; margin-top:6px; }
+.grug-dash .statstrip .v small{ font-family:'JetBrains Mono', monospace; font-size:12px; color:var(--ink-2); letter-spacing:0; }
+.grug-dash .statstrip .cell.amber{ background:var(--amber); }
+.grug-dash .statstrip .cell.ink{ background:var(--ink); color:var(--bg); }
+.grug-dash .statstrip .cell.ink .k{ color:#cdc2ad; }
+
+.grug-dash .layout{ display:grid; grid-template-columns: 248px 1fr; gap:28px; align-items:start; padding-bottom:80px; }
+.grug-dash .rail{ position:sticky; top:84px; }
+.grug-dash .rail-nav{ border:2px solid var(--ink); background:var(--paper); box-shadow:var(--shadow); }
+.grug-dash .rail-nav button{ display:flex; align-items:center; gap:12px; width:100%; text-align:left; cursor:pointer; font-family:'JetBrains Mono', monospace; font-size:13px; font-weight:500; padding:13px 16px; background:var(--paper); color:var(--ink); border:none; border-bottom:2px solid var(--ink); }
+.grug-dash .rail-nav button:last-child{ border-bottom:none; }
+.grug-dash .rail-nav button .idx{ font-size:10px; color:var(--muted); width:24px; }
+.grug-dash .rail-nav button .lbl{ flex:1; }
+.grug-dash .rail-nav button .badge{ font-size:10px; font-weight:700; padding:1px 6px; border:1.5px solid var(--ink); background:var(--bg-2); }
+.grug-dash .rail-nav button:hover{ background:var(--bg-2); }
+.grug-dash .rail-nav button.active{ background:var(--ink); color:var(--bg); }
+.grug-dash .rail-nav button.active .idx{ color:var(--amber); }
+.grug-dash .rail-nav button.active .badge{ background:var(--amber); border-color:var(--bg); color:var(--ink); }
+.grug-dash .rail-foot{ margin-top:14px; border:2px solid var(--ink); background:var(--ink); color:var(--bg); padding:14px; font-family:'JetBrains Mono', monospace; font-size:11px; box-shadow:var(--shadow-sm); }
+.grug-dash .rail-foot .plan{ display:flex; align-items:center; justify-content:space-between; margin-bottom:8px; }
+.grug-dash .rail-foot .plan b{ font-size:13px; color:var(--amber); }
+.grug-dash .rail-foot .meter{ height:10px; background:#2a2520; border:1.5px solid #3a342c; position:relative; margin:8px 0 6px; }
+.grug-dash .rail-foot .meter i{ display:block; height:100%; background:var(--amber); }
+.grug-dash .rail-foot .muted{ color:#cdc2ad; }
+
+.grug-dash .panel{ display:none; }
+.grug-dash .panel.show{ display:block; }
+.grug-dash .panel-head{ display:flex; align-items:flex-end; justify-content:space-between; gap:18px; flex-wrap:wrap; margin-bottom:20px; }
+.grug-dash .panel-head h2{ font-family:'Instrument Serif', serif; font-weight:400; font-size:40px; line-height:0.98; letter-spacing:-0.02em; margin:0; }
+.grug-dash .panel-head h2 em{ color:var(--amber-deep); font-style:italic; }
+.grug-dash .panel-head .note{ font-family:'JetBrains Mono', monospace; font-size:12px; color:var(--muted); max-width:360px; }
+
+.grug-dash .card{ background:var(--paper); border:2px solid var(--ink); box-shadow:var(--shadow); margin-bottom:22px; }
+.grug-dash .card-head{ display:flex; align-items:center; gap:10px; padding:12px 16px; border-bottom:2px solid var(--ink); background:var(--bg-2); font-family:'JetBrains Mono', monospace; font-size:11px; font-weight:700; letter-spacing:0.1em; text-transform:uppercase; }
+.grug-dash .card-head .count{ margin-left:auto; background:var(--amber); border:1.5px solid var(--ink); padding:1px 7px; font-size:10px; }
+.grug-dash .card-body{ padding:16px; }
+
+.grug-dash .toolbar{ display:flex; gap:10px; align-items:center; margin-bottom:14px; flex-wrap:wrap; }
+.grug-dash .search{ flex:1; min-width:180px; display:flex; align-items:center; gap:8px; border:2px solid var(--ink); background:var(--paper); padding:8px 12px; font-family:'JetBrains Mono', monospace; font-size:12px; }
+.grug-dash .search input{ border:none; outline:none; background:transparent; flex:1; font-family:inherit; font-size:12px; color:var(--ink); }
+.grug-dash .search svg{ width:14px; height:14px; opacity:0.6; }
+
+.grug-dash .sw{ width:42px; height:22px; border:2px solid var(--ink); position:relative; background:var(--bg-2); flex-shrink:0; cursor:pointer; }
+.grug-dash .sw::after{ content:""; position:absolute; top:1px; left:1px; width:16px; height:16px; background:#fff; border:1px solid var(--ink); transition:left .15s; }
+.grug-dash .sw.on{ background:var(--moss); }
+.grug-dash .sw.on::after{ left:21px; }
+
+.grug-dash .repo{ display:flex; align-items:center; gap:12px; padding:12px 14px; border:2px solid var(--ink); background:var(--paper); margin-bottom:10px; font-family:'JetBrains Mono', monospace; font-size:12px; }
+.grug-dash .repo:last-child{ margin-bottom:0; }
+.grug-dash .repo .org{ width:30px; height:30px; background:var(--ink); color:var(--bg); display:grid; place-items:center; font-size:11px; font-weight:700; }
+.grug-dash .repo .name{ flex:1; min-width:0; }
+.grug-dash .repo .name b{ font-weight:700; font-size:13px; }
+.grug-dash .repo .name span{ display:block; font-size:10px; color:var(--muted); margin-top:2px; }
+.grug-dash .repo .state{ font-size:10px; padding:2px 7px; border:1.5px solid var(--ink); white-space:nowrap; }
+.grug-dash .repo .state.live{ background:var(--moss); color:#fff; }
+.grug-dash .repo .state.paused{ background:var(--bg-2); color:var(--muted); }
+.grug-dash .repo .state.warn{ background:var(--amber); color:var(--ink); }
+.grug-dash .repo .state.unknown{ background:var(--bg-2); color:var(--muted); }
+.grug-dash .repo .fixbtn{ font-family:'JetBrains Mono', monospace; font-size:10px; font-weight:700; padding:3px 9px; background:var(--amber); border:1.5px solid var(--ink); cursor:pointer; }
+.grug-dash .repo .fixbtn[disabled]{ opacity:0.5; cursor:default; }
+.grug-dash .repo .fixerr{ font-size:10px; color:var(--tomato); max-width:12rem; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+.grug-dash .pcard{ display:flex; gap:14px; align-items:flex-start; padding:16px; border:2px solid var(--ink); background:var(--paper); margin-bottom:14px; }
+.grug-dash .pcard:last-child{ margin-bottom:0; }
+.grug-dash .pcard .portrait{ width:64px; height:64px; border:2px solid var(--ink); flex-shrink:0; display:grid; place-items:center; overflow:hidden; }
+.grug-dash .pcard .portrait img{ width:120%; transform:translateY(8%) rotate(-2deg); filter:drop-shadow(3px 4px 0 rgba(0,0,0,0.12)); }
+.grug-dash .pcard .body{ flex:1; min-width:0; }
+.grug-dash .pcard .row1{ display:flex; align-items:baseline; gap:10px; }
+.grug-dash .pcard .tag{ font-family:'JetBrains Mono', monospace; font-size:10px; letter-spacing:0.12em; color:var(--muted); }
+.grug-dash .pcard h3{ font-family:'Instrument Serif', serif; font-weight:400; font-size:28px; line-height:1; margin:2px 0 6px; }
+.grug-dash .pcard .desc{ font-family:'JetBrains Mono', monospace; font-size:12px; color:var(--ink-2); line-height:1.5; margin:0 0 10px; }
+.grug-dash .pcard .meta{ display:flex; gap:8px; flex-wrap:wrap; font-family:'JetBrains Mono', monospace; font-size:10px; }
+.grug-dash .pcard .meta span{ padding:2px 7px; border:1.5px solid var(--ink); background:var(--bg-2); }
+.grug-dash .pcard .ctrl{ display:flex; flex-direction:column; align-items:flex-end; gap:10px; flex-shrink:0; }
+.grug-dash .pcard.soon{ opacity:0.62; }
+.grug-dash .pcard.soon .seg{ pointer-events:none; opacity:0.5; }
+
+.grug-dash .seg{ display:flex; border:2px solid var(--ink); font-family:'JetBrains Mono', monospace; }
+.grug-dash .seg button{ padding:6px 10px; background:var(--paper); border:none; border-right:2px solid var(--ink); cursor:pointer; font-family:inherit; font-size:10px; font-weight:700; letter-spacing:0.06em; color:var(--ink); }
+.grug-dash .seg button:last-child{ border-right:none; }
+.grug-dash .seg button.on{ background:var(--ink); color:var(--bg); }
+.grug-dash .seg button[data-v="block"].on{ background:var(--tomato); color:#fff; }
+.grug-dash .seg button[data-v="warn"].on{ background:var(--amber); color:var(--ink); }
+.grug-dash .seg button[data-v="off"].on{ background:var(--bg-2); color:var(--muted); }
+
+.grug-dash .skins{ display:flex; gap:12px; flex-wrap:wrap; }
+.grug-dash .skin{ width:84px; cursor:pointer; border:2px solid var(--ink); background:var(--paper); font-family:'JetBrains Mono', monospace; }
+.grug-dash .skin .art{ aspect-ratio:1/1; overflow:hidden; display:grid; place-items:center; border-bottom:2px solid var(--ink); }
+.grug-dash .skin .art img{ width:140%; transform:translateY(8%); }
+.grug-dash .skin .cap{ padding:6px 4px; text-align:center; font-size:9px; letter-spacing:0.06em; text-transform:uppercase; }
+.grug-dash .skin.act{ outline:3px solid var(--amber); outline-offset:2px; }
+.grug-dash .skin.act .cap{ background:var(--amber); }
+
+.grug-dash .radios{ display:flex; gap:0; flex-wrap:wrap; border:2px solid var(--ink); }
+.grug-dash .radios button{ padding:9px 16px; background:var(--paper); border:none; border-right:2px solid var(--ink); cursor:pointer; font-family:'JetBrains Mono', monospace; font-size:11px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:var(--ink); }
+.grug-dash .radios button:last-child{ border-right:none; }
+.grug-dash .radios button.on{ background:var(--amber); }
+
+.grug-dash .field{ display:flex; align-items:center; gap:14px; padding:14px 0; border-bottom:2px dashed var(--ink); }
+.grug-dash .field:last-child{ border-bottom:none; }
+.grug-dash .field .lbl{ flex:1; }
+.grug-dash .field .lbl b{ font-family:'JetBrains Mono', monospace; font-size:13px; font-weight:700; }
+.grug-dash .field .lbl span{ display:block; font-family:'JetBrains Mono', monospace; font-size:11px; color:var(--muted); margin-top:3px; }
+.grug-dash .field .text{ border:2px solid var(--ink); background:var(--paper); padding:8px 12px; font-family:'JetBrains Mono', monospace; font-size:12px; color:var(--ink); min-width:200px; }
+
+.grug-dash .budget{ height:18px; background:var(--bg-2); border:2px solid var(--ink); position:relative; margin:10px 0; }
+.grug-dash .budget i{ display:block; height:100%; background:var(--amber); border-right:2px solid var(--ink); }
+.grug-dash .budget span{ position:absolute; right:8px; top:0; line-height:18px; font-family:'JetBrains Mono', monospace; font-size:10px; font-weight:700; }
+.grug-dash .bignum{ font-family:'Instrument Serif', serif; font-size:48px; line-height:1; }
+.grug-dash .bignum small{ font-family:'JetBrains Mono', monospace; font-size:13px; color:var(--muted); }
+
+.grug-dash .plan-grid{ display:grid; grid-template-columns:1fr 1fr; gap:0; }
+.grug-dash .plan-grid > div{ padding:18px; border-right:2px solid var(--ink); }
+.grug-dash .plan-grid > div:last-child{ border-right:none; }
+.grug-dash .plan-grid .nm{ font-family:'Instrument Serif', serif; font-size:30px; }
+.grug-dash .plan-grid .pr{ font-family:'JetBrains Mono', monospace; font-size:13px; color:var(--ink-2); margin-top:4px; }
+.grug-dash .feats{ list-style:none; padding:0; margin:0; display:grid; gap:7px; font-family:'JetBrains Mono', monospace; font-size:12px; }
+.grug-dash .feats li{ display:flex; gap:8px; }
+.grug-dash .feats li::before{ content:"+"; font-weight:700; color:var(--amber-deep); }
+
+.grug-dash .danger-card{ border:2px solid var(--tomato); }
+.grug-dash .danger-card .card-head{ background:#fde6df; border-bottom-color:var(--tomato); color:var(--tomato); }
+
+.grug-dash .ascii{ background:var(--ink); color:var(--bg); border:2px solid var(--ink); padding:14px 16px; font-family:'JetBrains Mono', monospace; font-size:11.5px; white-space:pre; overflow:auto; line-height:1.6; }
+.grug-dash .ascii .am{ color:var(--amber); }
+.grug-dash .ascii .mo{ color:#9fd58a; }
+.grug-dash .ascii .to{ color:#ff8a6e; }
+
+.grug-dash .afeed-row{ display:flex; align-items:center; gap:14px; padding:13px 14px; border:2px solid var(--ink); background:var(--paper); margin-bottom:10px; font-family:'JetBrains Mono', monospace; font-size:12px; }
+.grug-dash .afeed-row:last-child{ margin-bottom:0; }
+.grug-dash .afeed-row .vico{ width:26px; height:26px; flex-shrink:0; border:2px solid var(--ink); display:grid; place-items:center; font-weight:700; font-size:13px; color:#fff; }
+.grug-dash .afeed-row .vico.block{ background:var(--tomato); }
+.grug-dash .afeed-row .vico.warn{ background:var(--amber-deep); }
+.grug-dash .afeed-row .vico.pass{ background:var(--moss); }
+.grug-dash .afeed-row .who2{ flex:1; min-width:0; }
+.grug-dash .afeed-row .who2 b{ font-weight:700; }
+.grug-dash .afeed-row .who2 .repo2{ color:var(--muted); }
+.grug-dash .afeed-row .who2 .msg{ display:block; color:var(--ink-2); margin-top:3px; }
+.grug-dash .afeed-row .verdict{ font-size:10px; font-weight:700; padding:2px 7px; border:1.5px solid var(--ink); }
+.grug-dash .afeed-row .verdict.block{ background:var(--tomato); color:#fff; }
+.grug-dash .afeed-row .verdict.warn{ background:var(--amber); color:var(--ink); }
+.grug-dash .afeed-row .verdict.pass{ background:var(--moss); color:#fff; }
+.grug-dash .afeed-row .ago{ color:var(--muted); font-size:10px; white-space:nowrap; }
+
+.grug-dash .toast{ position:fixed; left:50%; bottom:26px; transform:translateX(-50%) translateY(20px); background:var(--ink); color:var(--bg); border:2px solid var(--ink); box-shadow:var(--shadow); padding:10px 18px; font-family:'JetBrains Mono', monospace; font-size:12px; opacity:0; pointer-events:none; transition:opacity .2s, transform .2s; z-index:120; }
+.grug-dash .toast.show{ opacity:1; transform:translateX(-50%) translateY(0); }
+.grug-dash .toast .am{ color:var(--amber); }
+
+.grug-dash footer{ background:var(--ink); color:var(--bg); padding:40px 0 26px; border-top:2px solid var(--ink); }
+.grug-dash .foot-inner{ max-width:1400px; margin:0 auto; padding:0 28px; display:flex; align-items:center; justify-content:space-between; gap:18px; flex-wrap:wrap; font-family:'JetBrains Mono', monospace; font-size:11px; color:#cdc2ad; }
+.grug-dash .foot-inner a{ color:var(--amber); text-decoration:none; }
+.grug-dash .foot-inner .brand{ font-size:30px; color:var(--bg); }
+
+@media (max-width:980px){
+  .grug-dash .layout{ grid-template-columns:1fr; }
+  .grug-dash .rail{ position:static; }
+  .grug-dash .rail-nav{ display:grid; grid-template-columns:repeat(2,1fr); }
+  .grug-dash .rail-nav button{ border-right:2px solid var(--ink); }
+  .grug-dash .rail-nav button:nth-child(2n){ border-right:none; }
+  .grug-dash .statstrip{ grid-template-columns:1fr 1fr; }
+  .grug-dash .statstrip .cell:nth-child(2){ border-right:none; }
+  .grug-dash .statstrip .cell:nth-child(1),.grug-dash .statstrip .cell:nth-child(2){ border-bottom:2px solid var(--ink); }
+}
+@media (max-width:640px){
+  .grug-dash nav.links{ display:none; }
+  .grug-dash .plan-grid{ grid-template-columns:1fr; }
+  .grug-dash .plan-grid > div{ border-right:none; border-bottom:2px solid var(--ink); }
+  .grug-dash .userchip .who{ display:none; }
+}


### PR DESCRIPTION
## Summary

Implements the claude.ai/design handoff bundle's `Dashboard.html` as the live `/dashboard` — the full 7-panel "cave control" UI in the Grug caveman-editorial design system (Instrument Serif + JetBrains Mono + Space Grotesk, hard ink offset shadows, 0px radius, tape marquee + sticky nav + footer). You confirmed: full pixel-perfect all-7-panels, dashboard-first.

**Real (wired to the API):** the **Repositories** panel — installations → repo list, live `tpm` toggle, enforcement state (ENFORCED / ⚠ not enforced / unconfirmed via `useEnforcement`), and the now-working **fix** button (surfaces errors per the earlier fix). Search + GUARDED/PAUSED + toasts.

**Design mock-state (no backend yet, localStorage-persisted, clearly interactive not fake-saved):** Personas (BLOCK/WARN/OFF per persona, each with its Grug portrait), Appearance (skins + tone + mood + ascii preview), Usage & billing, Notifications, Account & org (+ danger zone), Activity feed.

Scoped under `.grug-dash` so the dark admin/signin pages are untouched. The 12 Grug portraits are already hosted at `/assets/` (which also enables the per-persona review-comment faces discussed separately).

## Test plan
- [x] `tsc -b && vite build` clean
- [x] Repositories panel reuses the real hooks (`useInstallations`/`useInstallRepos`/`useSetRepoConfig`/`useEnforcement`/`useFixEnforcement`)
- [x] `dangerouslySetInnerHTML` dynamic values (repo names, `mood`) HTML-escaped via `esc()`
- [ ] Post-deploy: load grug.lol/dashboard — cream editorial UI, repos toggle/enforce/fix work, 7 panels navigate

## Out of scope
- Backends for the 6 mock panels (personas modes, skins, budget, notifications, billing) — they persist client-side only
- Landing (Grug.html) + legal pages redesign — the agreed follow-up wave

Size: M