### PR TITLE
fix(elder): judge crash on every review (is_real_bug evals dead) + persona face in comment

### DIFF
--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -49,6 +49,13 @@ from adapters.install_store import put_comment_record  # type: ignore
 
 log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.persona.code_reviewer")
 
+# Grug's face on the review comment. This dispatch IS the Elder (code-reviewer)
+# persona, so it leads with the Elder portrait — hosted at grug.lol/assets and
+# rendered via an <img> (GitHub markdown allows width/align) so it's a little
+# face, not a giant banner.
+_PERSONA = "Elder"
+_PERSONA_PORTRAIT = "https://grug.lol/assets/grug_elder.png"
+
 _CHECK_NAME = "Grug — Code Review"
 # 10s (was 30s) — a GitHub diff fetch is fast; the over-generous 30s let a
 # hung fetch alone eat most of the webhook Lambda budget (#252). Well under
@@ -290,7 +297,10 @@ def _build_review_result(
     return ReviewResult(
         commit_id=head_sha,
         event=event,
-        body=f"Grug code review · {len(comments)} finding(s)",
+        body=(
+            f'<img src="{_PERSONA_PORTRAIT}" width="46" align="left" alt="Grug {_PERSONA}" />'
+            f"\n\n**Grug {_PERSONA}** reviewed your PR · {len(comments)} finding(s)"
+        ),
         comments=comments,
     )
 

--- a/services/api/personas/code_reviewer/judge.py
+++ b/services/api/personas/code_reviewer/judge.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from llm_client import (
     FindingJudgement,
+    Hunk,
     JudgeFindingRepr,
     PrContext,
     judge_findings,
@@ -91,9 +92,14 @@ def run_judge(
 
     try:
         findings = evaluation.findings
+        # Convert parser DiffHunks → wire `Hunk`s (path/body) the SAME way the
+        # review path does (dispatch._to_llm_hunks). judge_findings is typed
+        # `list[Hunk]` and reads `.path`; passing raw DiffHunks (field is
+        # `file_path`) crashed the judge with AttributeError on EVERY review
+        # with findings, silently killing all `is_real_bug` LLM-Obs evals.
         verdicts = judge_findings(
             [_finding_to_repr(f) for f in findings],
-            list(hunks),
+            [Hunk(path=h.file_path, body=h.body) for h in hunks],
             installation_id=installation_id,
             pr_context=pr_context,
         )

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -49,6 +49,13 @@ from adapters.install_store import put_comment_record  # type: ignore
 
 log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.persona.code_reviewer")
 
+# Grug's face on the review comment. This dispatch IS the Elder (code-reviewer)
+# persona, so it leads with the Elder portrait — hosted at grug.lol/assets and
+# rendered via an <img> (GitHub markdown allows width/align) so it's a little
+# face, not a giant banner.
+_PERSONA = "Elder"
+_PERSONA_PORTRAIT = "https://grug.lol/assets/grug_elder.png"
+
 _CHECK_NAME = "Grug — Code Review"
 # 10s (was 30s) — a GitHub diff fetch is fast; the over-generous 30s let a
 # hung fetch alone eat most of the webhook Lambda budget (#252). Well under
@@ -290,7 +297,10 @@ def _build_review_result(
     return ReviewResult(
         commit_id=head_sha,
         event=event,
-        body=f"Grug code review · {len(comments)} finding(s)",
+        body=(
+            f'<img src="{_PERSONA_PORTRAIT}" width="46" align="left" alt="Grug {_PERSONA}" />'
+            f"\n\n**Grug {_PERSONA}** reviewed your PR · {len(comments)} finding(s)"
+        ),
         comments=comments,
     )
 

--- a/services/webhook/personas/code_reviewer/judge.py
+++ b/services/webhook/personas/code_reviewer/judge.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 from llm_client import (
     FindingJudgement,
+    Hunk,
     JudgeFindingRepr,
     PrContext,
     judge_findings,
@@ -91,9 +92,14 @@ def run_judge(
 
     try:
         findings = evaluation.findings
+        # Convert parser DiffHunks → wire `Hunk`s (path/body) the SAME way the
+        # review path does (dispatch._to_llm_hunks). judge_findings is typed
+        # `list[Hunk]` and reads `.path`; passing raw DiffHunks (field is
+        # `file_path`) crashed the judge with AttributeError on EVERY review
+        # with findings, silently killing all `is_real_bug` LLM-Obs evals.
         verdicts = judge_findings(
             [_finding_to_repr(f) for f in findings],
-            list(hunks),
+            [Hunk(path=h.file_path, body=h.body) for h in hunks],
             installation_id=installation_id,
             pr_context=pr_context,
         )

--- a/services/webhook/tests/test_code_reviewer_judge.py
+++ b/services/webhook/tests/test_code_reviewer_judge.py
@@ -76,6 +76,36 @@ def test_run_judge_submits_one_eval_per_finding(monkeypatch):
     assert submitted[1]["tags"]["rule_name"] == "style"
 
 
+def test_run_judge_converts_diffhunks_to_wire_hunks(monkeypatch):
+    """Regression: run_judge must convert parser DiffHunks → wire `Hunk`s
+    (field `path`) before judge_findings, which reads `.path`. Passing raw
+    DiffHunks (field `file_path`) crashed the judge with AttributeError on
+    EVERY review with findings — silently killing all is_real_bug LLM-Obs
+    evals — while the fully-mocked judge_findings tests stayed green."""
+    evaluation = CodeReviewEvaluation(findings=(_finding(),), conclusion="success")
+    review = _reviewed(evaluation.findings)
+    captured: dict = {}
+    monkeypatch.setattr(
+        cr_judge, "judge_findings",
+        lambda fr, h, installation_id, pr_context=None: (
+            captured.update(hunks=list(h)) or (FindingJudgement(0, True, "real"),)
+        ),
+    )
+    monkeypatch.setattr(cr_judge, "submit_finding_evaluation", lambda **kw: None)
+
+    cr_judge.run_judge(
+        evaluation, parse_diff(_DIFF), installation_id=1,
+        review_span_context=review.review_span_context, pr_context={"repo": "o/r"},
+    )
+
+    hunks = captured.get("hunks")
+    assert hunks, "judge_findings received no hunks"
+    # Each must expose `.path` (the wire-Hunk contract _build_judge_messages
+    # reads) — a raw DiffHunk (`.file_path`) would fail this and crash judge.
+    assert all(hasattr(h, "path") for h in hunks)
+    assert hunks[0].path == "src/x.py"
+
+
 def test_run_judge_skips_when_no_findings(monkeypatch):
     """Clean review (no findings) → no judge call, no evals."""
     evaluation = CodeReviewEvaluation(findings=(), conclusion="success")


### PR DESCRIPTION
## Summary

Surfaced by your grug-tribe review on somatic-scripts #1118 (the CRITICAL `secret-in-log-or-trace` finding on a harmless test regex — a hallucinated false positive):

1. **The LLM-as-judge has been crashing on every review with findings.** `run_judge` passed raw parser `DiffHunk`s (field `file_path`) into `judge_findings`, which is typed `list[Hunk]` and reads `.path` → `AttributeError` in `_build_judge_messages` (logged `judge_unhandled` / `kind=AttributeError`, no `judge_completed`). So the judge never graded anything and **zero `is_real_bug` evaluations reached DD LLM-Obs** — the false-positive-detection + calibration layer was silently dead. The review path avoids this via `_to_llm_hunks`; the judge path forgot to convert. **This is the answer to "why wasn't it caught":** the judge that exists to flag exactly that false positive had crashed. Fixed by converting `DiffHunk → Hunk(path=file_path, body=body)` in `run_judge`.
2. **Persona face in the comment.** The review-level comment now leads with the Elder Grug portrait + "Grug Elder reviewed your PR · N finding(s)".

## Test plan
- [x] Root cause from prod logs: `AttributeError: 'DiffHunk' object has no attribute 'path'` at `_build_judge_messages` (llm_client.py:775)
- [x] Added `test_run_judge_converts_diffhunks_to_wire_hunks` — passes real `DiffHunk`s through `run_judge`, asserts the hunks reaching `judge_findings` expose `.path` (the old tests mocked `judge_findings` away, so they stayed green while prod crashed — the mock-vs-real trap)
- [x] webhook 534 pass; code_reviewer judge+dispatch 50 pass; drift-lint 26; api flake (`test_installations_update_config`) pre-existing
- [ ] Post-deploy: next review with a finding → `judge_completed` (not `judge_unhandled`) + `is_real_bug` evals in LLM-Obs + Elder face on the comment

## Out of scope
- The hallucinated-FP itself is a precision problem addressed by the #191 prompt A/B + (future) having the judge downgrade findings pre-publish; this PR restores the judge so those FPs get *labeled* again. Elder stays advisory (doesn't block merge) by design.

Size: S