### PR TITLE
chore(web): strip leaked design-tool anchors from prod landing

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -867,9 +867,9 @@
   <!-- HEADER -->
   <header class="nav">
     <div class="nav-inner">
-      <a class="brand" href="#hero" aria-label="Grug home" data-comment-anchor="3189c62282-a">
+      <a class="brand" href="#hero" aria-label="Grug home">
         <span class="brand-mark"><img src="assets/grug-angry.png" alt=""></span>
-        <span data-comment-anchor="f26918c072-span">grug</span>
+        <span>grug</span>
       </a>
       <nav class="links">
         <a href="#features">What Grug do</a>
@@ -891,7 +891,7 @@
   <main>
     <section class="hero" id="hero">
       <div>
-        <div class="eyebrow" data-comment-anchor="c8268d3633-div">v0.7.0</div>
+        <div class="eyebrow">v0.7.0</div>
         <h1 class="headline">
           Grug <span class="strike">code monkey</span>.<br>
           Grug <span class="em">whole <em class="serif" style="font-style:italic">cave</em></span>.
@@ -911,7 +911,7 @@
         <div class="hero-meta">
           <span class="pill">AGPL-3.0</span>
           <span>Posts as GitHub <b>Check Runs</b></span>
-          <span data-comment-anchor="a4a6e32355-span">Many personas, one app</span>
+          <span>Many personas, one app</span>
           <span><b>$0</b> to self-host</span>
         </div>
       </div>
@@ -1016,7 +1016,7 @@
           <span class="eyebrow">02 · what grug do</span>
           <h2>Grug do <em>whole cave</em>.<br>From <em>idea</em> to <em>ship</em>.</h2>
         </div>
-        <p class="aside" data-comment-anchor="0cddcf814f-p">// One GitHub App. Many personas. Posts as Check Runs so branch-protection rules can require any of them. Toggle the ones your team needs.</p>
+        <p class="aside">// One GitHub App. Many personas. Posts as Check Runs so branch-protection rules can require any of them. Toggle the ones your team needs.</p>
       </div>
 
       <div class="feat-grid">
@@ -1093,14 +1093,14 @@
       <div class="sec-head">
         <div>
           <span class="eyebrow">03 · the personas</span>
-          <h2 data-comment-anchor="9554ceb741-h2">Five Grugs. One <em>cave</em>.</h2>
+          <h2>Five Grugs. One <em>cave</em>.</h2>
         </div>
         <p class="aside">// Each persona is its own Check Run. Require any of them in branch protection. Toggle per-repo. BYO model key on Pro.</p>
       </div>
 
       <div class="persona-roster">
         <article class="proster">
-          <div class="proster-art" style="background:#fde6df;" data-comment-anchor="8cdd74632c-div">
+          <div class="proster-art" style="background:#fde6df;">
             <span class="persona-stamp">F-01</span>
             <img class="persona-portrait" src="assets/grug_smasher.png" alt="Smasher Grug, holding a stone club">
           </div>
@@ -1117,7 +1117,7 @@
         </article>
 
         <article class="proster">
-          <div class="proster-art" style="background:#dde7f0;" data-comment-anchor="c8b7f883af-div">
+          <div class="proster-art" style="background:#dde7f0;">
             <span class="persona-stamp">F-02</span>
             <img class="persona-portrait" src="assets/grug_guard.png" alt="Guard Grug, wearing a stone helmet, arms crossed">
           </div>
@@ -1134,7 +1134,7 @@
         </article>
 
         <article class="proster">
-          <div class="proster-art" style="background:#dff0d6;" data-comment-anchor="57c5d83c0e-div">
+          <div class="proster-art" style="background:#dff0d6;">
             <span class="persona-stamp">F-03</span>
             <img class="persona-portrait" src="assets/grug_elder.png" alt="Elder Grug, grizzled with white hair">
           </div>
@@ -1151,7 +1151,7 @@
         </article>
 
         <article class="proster">
-          <div class="proster-art" style="background:#fff2cc;" data-comment-anchor="58c1a40347-div">
+          <div class="proster-art" style="background:#fff2cc;">
             <span class="persona-stamp">F-04</span>
             <img class="persona-portrait" src="assets/grug_chief.png" alt="Chief Grug, wearing a skull-and-feather crown">
           </div>
@@ -1168,7 +1168,7 @@
         </article>
 
         <article class="proster">
-          <div class="proster-art" style="background:#e8e0ff;" data-comment-anchor="30bb1560c7-div">
+          <div class="proster-art" style="background:#e8e0ff;">
             <span class="persona-stamp">F-05</span>
             <img class="persona-portrait" src="assets/grug_mystic.png" alt="Warder Grug, shaman with a glowing staff">
           </div>
@@ -1221,7 +1221,7 @@
             <div class="row1">
               <span class="tag-mini" style="background:var(--moss); color:#fff;">CAPABILITY</span>
             </div>
-            <h4 data-comment-anchor="99cfbe340f-h4">Terraform Reviewer</h4>
+            <h4>Terraform Reviewer</h4>
             <p>Grug reads your Terraform changes before you apply them. Yells if you're about to delete a database, change permissions, or break something already running.</p>
           </div>
           <div class="foot">
@@ -1233,7 +1233,7 @@
         <!-- GraphQL -->
         <article class="skill">
           <div class="body">
-            <div class="row1" data-comment-anchor="fd2469f278-div">
+            <div class="row1">
               <span class="tag-mini" style="background:var(--moss); color:#fff;">CAPABILITY</span>
             </div>
             <h4>API Breaking-Change Guard</h4>
@@ -1248,7 +1248,7 @@
         <!-- A11y -->
         <article class="skill">
           <div class="body">
-            <div class="row1" data-comment-anchor="abd482fb4c-div">
+            <div class="row1">
               <span class="tag-mini" style="background:var(--moss); color:#fff;">CAPABILITY</span>
             </div>
             <h4>Accessibility Checker</h4>
@@ -1267,7 +1267,7 @@
               <span class="tag-mini" style="background:var(--moss); color:#fff;">CAPABILITY</span>
             </div>
             <h4>Database Migration Sitter</h4>
-            <p data-comment-anchor="95924f301c-p">Reads your Postgres or MySQL migrations and warns about ones that lock big tables, can't be re-run, or have no rollback. Catches the migrations that take prod down at 2am.</p>
+            <p>Reads your Postgres or MySQL migrations and warns about ones that lock big tables, can't be re-run, or have no rollback. Catches the migrations that take prod down at 2am.</p>
           </div>
           <div class="foot">
             <span class="price">$5/mo</span>
@@ -1278,7 +1278,7 @@
         <!-- Classic -->
         <article class="skill">
           <div class="art" style="background:#fff3d6;">
-            <img src="assets/grug.png" alt="Classic Grug" style="width:92%; transform:rotate(-3deg); filter: drop-shadow(6px 7px 0 rgba(0,0,0,0.12));" data-comment-anchor="e4ae0eb0d1-img">
+            <img src="assets/grug.png" alt="Classic Grug" style="width:92%; transform:rotate(-3deg); filter: drop-shadow(6px 7px 0 rgba(0,0,0,0.12));">
           </div>
           <div class="body">
             <div class="row1">
@@ -1333,7 +1333,7 @@
         <!-- Custom -->
         <article class="skill">
           <div class="art" style="background:#e8e0ff;">
-            <img src="assets/grug_smile.png" alt="Custom Grug" style="width:92%; transform:rotate(3deg); filter: drop-shadow(6px 7px 0 rgba(0,0,0,0.12));" data-comment-anchor="c1ca69c95d-svg">
+            <img src="assets/grug_smile.png" alt="Custom Grug" style="width:92%; transform:rotate(3deg); filter: drop-shadow(6px 7px 0 rgba(0,0,0,0.12));">
           </div>
           <div class="body">
             <div class="row1">
@@ -1461,7 +1461,7 @@
           <div class="dash-col">
             <h5>Grug configuration</h5>
 
-            <div class="config-card" data-comment-anchor="1e94c5bd23-div">
+            <div class="config-card">
               <div class="label">Active skin</div>
               <div class="skin-pick">
                 <div class="skin-chip act" title="Classic Grug" style="overflow:hidden;">


### PR DESCRIPTION
## Summary

**The marketing landing + legal pages are already live in the Grug caveman-editorial design system** — this was the "next wave," but it's effectively already done: grug.lol/ renders the full design (persona roster, pricing, skills, dashboard mock), and the design bundle's `Grug.html`/`Privacy.html`/`Terms.html` diff **95%+ identical** to what's deployed (the bundle is a re-export of the live site, plus the prod-only Datadog RUM the mockup lacks). Verified live.

The one genuine cleanup: 18 `data-comment-anchor="…"` attributes — internal claude.ai/design comment markers — had leaked into the live `index.html`. Inert (browsers ignore unknown attrs) but shouldn't be on the public site. Stripped. Legal pages had none. The edit-mode Tweaks panel is left as-is (the bundle's prompt says to keep it; it's inert in prod — never renders without the design-tool parent handshake).

## Test plan
- [x] Diff design bundle vs live: 95%+ identical → pages already in the design system
- [x] grug.lol/ live-verified rendering the caveman-editorial design
- [x] `data-comment-anchor` count in index.html: 18 → 0; `<img>` tags intact (17); legal pages unaffected
- [ ] Post-deploy: grug.lol/ unchanged visually, no design-tool attrs in page source

## Out of scope
- A redesign of these pages — not needed, they're already this design
- Removing the inert edit-mode Tweaks panel (kept per the bundle prompt)

Size: XS