### PR TITLE
fix: enforcement ruleset 422 + landing 404 + guarded/enforced clarity

### DIFF
--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -175,8 +175,14 @@ def create_ruleset(
                 "type": "required_status_checks",
                 "parameters": {
                     "strict_required_status_checks_policy": False,
+                    # OMIT integration_id — GitHub's ruleset schema rejects a
+                    # null integration_id ("Invalid property /rules/0: data
+                    # matches no possible input", 422), which broke every
+                    # enforcement "fix". integration_id is optional; sending
+                    # just {context} requires the check by name regardless of
+                    # which app reports it.
                     "required_status_checks": [
-                        {"context": ctx, "integration_id": None}
+                        {"context": ctx}
                         for ctx in status_check_contexts
                     ],
                 },

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -175,8 +175,14 @@ def create_ruleset(
                 "type": "required_status_checks",
                 "parameters": {
                     "strict_required_status_checks_policy": False,
+                    # OMIT integration_id — GitHub's ruleset schema rejects a
+                    # null integration_id ("Invalid property /rules/0: data
+                    # matches no possible input", 422), which broke every
+                    # enforcement "fix". integration_id is optional; sending
+                    # just {context} requires the check by name regardless of
+                    # which app reports it.
                     "required_status_checks": [
-                        {"context": ctx, "integration_id": None}
+                        {"context": ctx}
                         for ctx in status_check_contexts
                     ],
                 },

--- a/services/webhook/tests/test_github_rulesets_client.py
+++ b/services/webhook/tests/test_github_rulesets_client.py
@@ -68,6 +68,10 @@ def test_create_ruleset_body_shape():
     checks = rules[0]["parameters"]["required_status_checks"]
     assert len(checks) == 1
     assert checks[0]["context"] == "Grug — Definition of Ready"
+    # integration_id must be OMITTED, not null: GitHub's ruleset schema 422s
+    # on `integration_id: null` ("data matches no possible input"), which
+    # broke every enforcement "fix".
+    assert "integration_id" not in checks[0]
 
 
 def test_create_ruleset_multiple_contexts():

--- a/web/src/routes/Admin.tsx
+++ b/web/src/routes/Admin.tsx
@@ -38,10 +38,10 @@ export function Admin() {
 
       <header className="nav">
         <div className="nav-inner">
-          <Link className="brand" to="/">
+          <a className="brand" href="/">
             <span className="brand-mark"><img src="/assets/grug-angry.png" alt="" /></span>
             <span>grug</span>
-          </Link>
+          </a>
           <nav className="links">
             <Link to="/dashboard">Dashboard</Link>
             <Link to="/admin" className="active">Admin</Link>

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -139,10 +139,10 @@ export function Dashboard() {
 
       <header className="nav">
         <div className="nav-inner">
-          <Link className="brand" to="/">
+          <a className="brand" href="/">
             <span className="brand-mark"><img src="/assets/grug-angry.png" alt="" /></span>
             <span>grug</span>
-          </Link>
+          </a>
           <nav className="links">
             <a className={panel !== "activity" ? "active" : ""} onClick={() => setPanel("repos")}>Dashboard</a>
             <a className={panel === "activity" ? "active" : ""} onClick={() => setPanel("activity")}>Activity</a>
@@ -289,24 +289,24 @@ function RepoRow({ repo, installId, onToggle, onFix, fixPending, fixError }: {
   const state = enforcement.data?.enforcement_state;
   const degraded = enforcement.data?.degraded === true;
 
-  let enf: { cls: string; label: string } | null = null;
+  let enf: { cls: string; label: string; title: string } | null = null;
   if (on) {
-    if (degraded && (state === "grug_managed" || state === "external")) enf = { cls: "unknown", label: "unconfirmed" };
-    else if (state === "grug_managed") enf = { cls: "live", label: "ENFORCED" };
-    else if (state === "external") enf = { cls: "live", label: "EXTERNAL" };
-    else if (state === "none") enf = { cls: "warn", label: "⚠ not enforced" };
-    else if (state === "unknown") enf = { cls: "unknown", label: "unknown" };
+    if (degraded && (state === "grug_managed" || state === "external")) enf = { cls: "unknown", label: "unconfirmed", title: "Last-known state — GitHub was rate-limited and couldn't confirm. Refresh to re-check." };
+    else if (state === "grug_managed") enf = { cls: "live", label: "ENFORCED", title: "Grug's DoR check is REQUIRED to merge — a Grug-managed ruleset blocks PRs that fail it." };
+    else if (state === "external") enf = { cls: "live", label: "EXTERNAL", title: "The check is required by a non-Grug ruleset or branch protection." };
+    else if (state === "none") enf = { cls: "warn", label: "⚠ not enforced", title: "Grug reviews PRs here, but its check is NOT required to merge — a failing PR can still be merged. Click 'fix' to make it required (blocking)." };
+    else if (state === "unknown") enf = { cls: "unknown", label: "unknown", title: "Couldn't reach GitHub to determine enforcement. Refresh." };
   }
 
   return (
     <div className="repo">
       <div className="org">{(owner || "?").slice(0, 2).toUpperCase()}</div>
       <div className="name"><b>{name}</b><span>{owner}/ · {repo.private ? "private" : "public"}</span></div>
-      {enf && <span className={`state ${enf.cls}`}>{enf.label}</span>}
-      {on && state === "none" && !fixPending && <button className="fixbtn" onClick={onFix}>fix</button>}
+      {enf && <span className={`state ${enf.cls}`} title={enf.title}>{enf.label}</span>}
+      {on && state === "none" && !fixPending && <button className="fixbtn" onClick={onFix} title="Create a branch ruleset that REQUIRES Grug's check to pass before a PR can merge.">fix</button>}
       {fixPending && <span className="state paused">fixing…</span>}
       {fixError && !fixPending && <span className="fixerr" title={fixError}>⚠ fix failed</span>}
-      <span className={`state ${on ? "live" : "paused"}`}>{on ? "GUARDED" : "PAUSED"}</span>
+      <span className={`state ${on ? "live" : "paused"}`} title={on ? "GUARDED: Grug watches this repo and posts a Check Run on every PR. Toggle off to silence Grug here." : "PAUSED: Grug is asleep on this repo. Toggle on to guard it."}>{on ? "GUARDED" : "PAUSED"}</span>
       <div className={`sw${on ? " on" : ""}`} onClick={() => onToggle(!on)} role="switch" aria-checked={on}></div>
     </div>
   );

--- a/web/src/routes/NotFound.tsx
+++ b/web/src/routes/NotFound.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import "./dashboard-grug.css";
 
 export function NotFound() {
@@ -6,12 +5,12 @@ export function NotFound() {
     <div className="grug-dash">
       <header className="nav">
         <div className="nav-inner">
-          <Link className="brand" to="/">
+          <a className="brand" href="/">
             <span className="brand-mark"><img src="/assets/grug-angry.png" alt="" /></span>
             <span>grug</span>
-          </Link>
+          </a>
           <nav className="links">
-            <Link to="/">Home</Link>
+            <a href="/">Home</a>
             <a href="https://github.com/githumps/grug">Docs</a>
           </nav>
         </div>
@@ -22,7 +21,7 @@ export function NotFound() {
           <span className="eyebrow"><span className="blob"></span>404 · lost in cave</span>
           <h1>Grug <em>no find</em> page.</h1>
           <p className="signin-sub">// This path not in cave. Maybe bad link. Maybe Grug eat it. Go back to safe ground.</p>
-          <Link className="btn primary lg signin-cta" to="/">← Back to splash</Link>
+          <a className="btn primary lg signin-cta" href="/">← Back to splash</a>
         </div>
       </div>
 

--- a/web/src/routes/Signin.tsx
+++ b/web/src/routes/Signin.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { Link } from "react-router-dom";
 import { API_BASE } from "../lib/api";
 import "./dashboard-grug.css";
 
@@ -25,12 +24,12 @@ export function Signin() {
 
       <header className="nav">
         <div className="nav-inner">
-          <Link className="brand" to="/">
+          <a className="brand" href="/">
             <span className="brand-mark"><img src="/assets/grug-angry.png" alt="" /></span>
             <span>grug</span>
-          </Link>
+          </a>
           <nav className="links">
-            <Link to="/">Home</Link>
+            <a href="/">Home</a>
             <a href="https://github.com/githumps/grug">Docs</a>
           </nav>
         </div>


### PR DESCRIPTION
## Summary

Three issues you hit on the dashboard:

1. **"fix" failed on every repo → nothing enforced.** `create_ruleset` sent `{"context": ctx, "integration_id": None}`; GitHub's ruleset schema **rejects a null integration_id** — *"Invalid property /rules/0: data matches no possible input"* (422), which the `create_ruleset_rejected` log (added in #282) finally captured. `integration_id` is optional → **omit it**. Now "fix" creates the ruleset and the repo becomes **ENFORCED**. Mirrored api+webhook; regression test asserts it's absent.
2. **grug.lol/ showed the SPA 404.** The static landing is fine — the bug was the in-SPA brand / Home / "back to splash" links using client-side `<Link to="/">`, but `/` isn't an SPA route so React Router rendered NotFound. Switched landing-targeting links to full-nav `<a href="/">` across Dashboard/Signin/Admin/NotFound.
3. **"what does guarded mean?"** — added tooltips: **GUARDED** = Grug watches the repo + posts a Check Run on every PR (the `tpm` toggle); **ENFORCED / not enforced** = whether that check is *required to merge* (a ruleset). A repo can be GUARDED (reviewed) but not ENFORCED (non-blocking) — which is what "fix" changes.

## Test plan
- [x] Root cause from prod log: GitHub 422 `integration_id: null` on the conducted "fix"
- [x] rulesets+enforcement 45 pass (incl. new `integration_id` absent guard); installations 12; drift-lint 26; web build clean
- [ ] Post-deploy: "fix" on a repo → 200 → ENFORCED (verify a Grug ruleset appears on GitHub); grug.lol/ brand click → landing (not 404)

## Out of scope
- The hallucinated-FP precision (separate, #191 A/B)

Size: S