### PR TITLE
feat(grug): voice the Elder in wise-caveman speech

### DIFF
--- a/services/api/code_review_prompt.py
+++ b/services/api/code_review_prompt.py
@@ -281,7 +281,8 @@ RULES: tuple[ReviewRule, ...] = (
 PromptVariant = Literal["v1", "v2"]
 
 _PREAMBLE_HEAD = (
-    "You are a senior code reviewer for the Grug bot. Review the supplied "
+    "You are Grug Elder, wisest of the cavemen and senior code reviewer for "
+    "the Grug bot. Review the supplied "
     "diff hunks against the rules below. Flag ONLY concrete, actionable "
     "instances you can point to a specific changed line for — not stylistic "
     "preferences. If the diff is clean, return an empty findings list.\n"
@@ -328,6 +329,34 @@ _OUTPUT_CONTRACT = (
     "markdown, no text outside the JSON object."
 )
 
+# VOICE — Grug is branded a caveman on every surface (the README's "one
+# grumpy caveman", the Caveman Editorial web), but the finding `message`
+# was plain professional English. This clause re-skins ONLY the `message`
+# field as Grug Elder: full caveman cadence, yet the WISE elder — grave,
+# measured, proverb-like. It lives in the SHARED prompt (both A/B arms)
+# so voice is constant across the #191 confidence experiment — the arms
+# still differ only by confidence bias, never by voice. Must not contain
+# the phrase "false negative" (the v1-only precision lever asserted absent
+# from v2 in test_prompt_variant). Technical tokens are spoken verbatim so
+# the wisdom stays machine-actionable.
+_VOICE = (
+    "VOICE — write every `message` as Grug Elder speaks: full caveman "
+    "cadence (short, plain clauses; first person 'Grug'; drop articles and "
+    "helper-verbs), yet ELEGANT and WISE — grave, measured, almost a "
+    "proverb, the voice of an elder who has seen many winters. Never silly, "
+    "never baby-talk. The wisdom must stay ACTIONABLE: name the exact defect "
+    "and the exact remedy. Keep ALL technical tokens verbatim and unaltered "
+    "— identifiers, exception/class names, function names, file paths, and "
+    "the rule name are spoken EXACTLY (write `OSError`, never 'os rock'). "
+    "Only the `message` value speaks this way; `path`, `line`, `rule`, and "
+    "`severity` stay precise machine values. Example — not 'Broad except "
+    "Exception masks programmer errors; catch OSError and ValueError', but: "
+    "'Grug see net cast too wide. `except Exception` catch every fish — even "
+    "the bugs you not mean. NameError, KeyError hide in the net, wear the "
+    "mask of success. Cast the narrow net: catch only `OSError` and "
+    "`ValueError`, the faults you truly await. So speaks Grug.'"
+)
+
 
 def _render_rule(r: ReviewRule) -> str:
     return (
@@ -352,4 +381,4 @@ def build_system_prompt(variant: PromptVariant = "v1") -> str:
         )
     preamble = _PREAMBLE_HEAD + _CONFIDENCE_CLAUSES[variant] + _PREAMBLE_TAIL
     rules_block = "\n".join(_render_rule(r) for r in RULES)
-    return f"{preamble}\n\nRULES:\n{rules_block}\n\n{_OUTPUT_CONTRACT}"
+    return f"{preamble}\n\n{_VOICE}\n\nRULES:\n{rules_block}\n\n{_OUTPUT_CONTRACT}"

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -189,15 +189,18 @@ def _summary_markdown(evaluation: CodeReviewEvaluation) -> tuple[str, str]:
     by severity. Operators read this when triaging in GH's Checks tab.
     """
     if evaluation.degraded_reason:
-        title = f"⚠️ Code review skipped ({evaluation.degraded_reason})"
+        title = f"⚠️ Grug eyes clouded ({evaluation.degraded_reason})"
         return title, (
-            "Elder code-reviewer could not run this pass. Reason: "
-            f"`{evaluation.degraded_reason}`. Advisory neutral — PR "
-            "merge is not blocked."
+            "Grug Elder could not see the diff this pass. The mist: "
+            f"`{evaluation.degraded_reason}`. Grug stay his club — this "
+            "only counsel, merge not blocked."
         )
     if not evaluation.findings:
-        title = "✅ Code review pass — no findings"
-        return title, "Elder reviewed the diff and found nothing actionable."
+        title = "✅ Grug find nothing — code good"
+        return title, (
+            "Grug Elder look long upon the diff and find nothing to fear. "
+            "Code walk steady. Grug nod."
+        )
 
     severity_icon = {
         "critical": "🛑", "high": "❌", "medium": "⚠️", "low": "ℹ️",
@@ -205,7 +208,10 @@ def _summary_markdown(evaluation: CodeReviewEvaluation) -> tuple[str, str]:
     blocking = sum(
         1 for f in evaluation.findings if f.severity in ("high", "critical")
     )
-    title = f"❌ {blocking} blocking · {len(evaluation.findings)} total findings"
+    title = (
+        f"❌ Grug see trouble — {blocking} blocking · "
+        f"{len(evaluation.findings)} finding(s) in all"
+    )
     rows = ["| Severity | File | Line | Rule | Message |", "|---|---|---|---|---|"]
     for f in evaluation.findings:
         icon = severity_icon.get(f.severity, "•")
@@ -299,7 +305,7 @@ def _build_review_result(
         event=event,
         body=(
             f'<img src="{_PERSONA_PORTRAIT}" width="46" align="left" alt="Grug {_PERSONA}" />'
-            f"\n\n**Grug {_PERSONA}** reviewed your PR · {len(comments)} finding(s)"
+            f"\n\n**Grug {_PERSONA}** gaze upon your PR · {len(comments)} finding(s)"
         ),
         comments=comments,
     )

--- a/services/webhook/code_review_prompt.py
+++ b/services/webhook/code_review_prompt.py
@@ -281,7 +281,8 @@ RULES: tuple[ReviewRule, ...] = (
 PromptVariant = Literal["v1", "v2"]
 
 _PREAMBLE_HEAD = (
-    "You are a senior code reviewer for the Grug bot. Review the supplied "
+    "You are Grug Elder, wisest of the cavemen and senior code reviewer for "
+    "the Grug bot. Review the supplied "
     "diff hunks against the rules below. Flag ONLY concrete, actionable "
     "instances you can point to a specific changed line for — not stylistic "
     "preferences. If the diff is clean, return an empty findings list.\n"
@@ -328,6 +329,34 @@ _OUTPUT_CONTRACT = (
     "markdown, no text outside the JSON object."
 )
 
+# VOICE — Grug is branded a caveman on every surface (the README's "one
+# grumpy caveman", the Caveman Editorial web), but the finding `message`
+# was plain professional English. This clause re-skins ONLY the `message`
+# field as Grug Elder: full caveman cadence, yet the WISE elder — grave,
+# measured, proverb-like. It lives in the SHARED prompt (both A/B arms)
+# so voice is constant across the #191 confidence experiment — the arms
+# still differ only by confidence bias, never by voice. Must not contain
+# the phrase "false negative" (the v1-only precision lever asserted absent
+# from v2 in test_prompt_variant). Technical tokens are spoken verbatim so
+# the wisdom stays machine-actionable.
+_VOICE = (
+    "VOICE — write every `message` as Grug Elder speaks: full caveman "
+    "cadence (short, plain clauses; first person 'Grug'; drop articles and "
+    "helper-verbs), yet ELEGANT and WISE — grave, measured, almost a "
+    "proverb, the voice of an elder who has seen many winters. Never silly, "
+    "never baby-talk. The wisdom must stay ACTIONABLE: name the exact defect "
+    "and the exact remedy. Keep ALL technical tokens verbatim and unaltered "
+    "— identifiers, exception/class names, function names, file paths, and "
+    "the rule name are spoken EXACTLY (write `OSError`, never 'os rock'). "
+    "Only the `message` value speaks this way; `path`, `line`, `rule`, and "
+    "`severity` stay precise machine values. Example — not 'Broad except "
+    "Exception masks programmer errors; catch OSError and ValueError', but: "
+    "'Grug see net cast too wide. `except Exception` catch every fish — even "
+    "the bugs you not mean. NameError, KeyError hide in the net, wear the "
+    "mask of success. Cast the narrow net: catch only `OSError` and "
+    "`ValueError`, the faults you truly await. So speaks Grug.'"
+)
+
 
 def _render_rule(r: ReviewRule) -> str:
     return (
@@ -352,4 +381,4 @@ def build_system_prompt(variant: PromptVariant = "v1") -> str:
         )
     preamble = _PREAMBLE_HEAD + _CONFIDENCE_CLAUSES[variant] + _PREAMBLE_TAIL
     rules_block = "\n".join(_render_rule(r) for r in RULES)
-    return f"{preamble}\n\nRULES:\n{rules_block}\n\n{_OUTPUT_CONTRACT}"
+    return f"{preamble}\n\n{_VOICE}\n\nRULES:\n{rules_block}\n\n{_OUTPUT_CONTRACT}"

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -189,15 +189,18 @@ def _summary_markdown(evaluation: CodeReviewEvaluation) -> tuple[str, str]:
     by severity. Operators read this when triaging in GH's Checks tab.
     """
     if evaluation.degraded_reason:
-        title = f"⚠️ Code review skipped ({evaluation.degraded_reason})"
+        title = f"⚠️ Grug eyes clouded ({evaluation.degraded_reason})"
         return title, (
-            "Elder code-reviewer could not run this pass. Reason: "
-            f"`{evaluation.degraded_reason}`. Advisory neutral — PR "
-            "merge is not blocked."
+            "Grug Elder could not see the diff this pass. The mist: "
+            f"`{evaluation.degraded_reason}`. Grug stay his club — this "
+            "only counsel, merge not blocked."
         )
     if not evaluation.findings:
-        title = "✅ Code review pass — no findings"
-        return title, "Elder reviewed the diff and found nothing actionable."
+        title = "✅ Grug find nothing — code good"
+        return title, (
+            "Grug Elder look long upon the diff and find nothing to fear. "
+            "Code walk steady. Grug nod."
+        )
 
     severity_icon = {
         "critical": "🛑", "high": "❌", "medium": "⚠️", "low": "ℹ️",
@@ -205,7 +208,10 @@ def _summary_markdown(evaluation: CodeReviewEvaluation) -> tuple[str, str]:
     blocking = sum(
         1 for f in evaluation.findings if f.severity in ("high", "critical")
     )
-    title = f"❌ {blocking} blocking · {len(evaluation.findings)} total findings"
+    title = (
+        f"❌ Grug see trouble — {blocking} blocking · "
+        f"{len(evaluation.findings)} finding(s) in all"
+    )
     rows = ["| Severity | File | Line | Rule | Message |", "|---|---|---|---|---|"]
     for f in evaluation.findings:
         icon = severity_icon.get(f.severity, "•")
@@ -299,7 +305,7 @@ def _build_review_result(
         event=event,
         body=(
             f'<img src="{_PERSONA_PORTRAIT}" width="46" align="left" alt="Grug {_PERSONA}" />'
-            f"\n\n**Grug {_PERSONA}** reviewed your PR · {len(comments)} finding(s)"
+            f"\n\n**Grug {_PERSONA}** gaze upon your PR · {len(comments)} finding(s)"
         ),
         comments=comments,
     )


### PR DESCRIPTION
## Why

The Elder (code-reviewer) persona is branded a grumpy caveman on every surface — the portrait, the "Grug Elder reviewed your PR" header — yet its actual review prose shipped as plain professional English (e.g. "Broad except Exception catches too many exception types"). The wrapper was in character; the payload was not. Root cause: the system prompt opened "You are a senior code reviewer" with no voice instruction, and `dispatch.py`'s status lines were neutral. This voices the Elder consistently so every word it says is in character, without sacrificing the actionability a code review needs.

## Acceptance criteria

- [ ] Every finding `message` renders in Grug Elder's voice — full caveman cadence but grave/proverb-like (the "wise elder"), driven by a shared `_VOICE` clause in `code_review_prompt.py`.
- [ ] All technical tokens (exception/class/function names, file paths, the rule name) are preserved verbatim in the voiced output so findings stay machine-actionable (`OSError`, never "os rock").
- [ ] The voice is in the SHARED prompt, applied identically to both #191 A/B confidence arms — voice is not the experiment variable, so v1/v2 still differ only by confidence bias (`build_system_prompt("v1") != build_system_prompt("v2")`, `"false negative"` still absent from v2).
- [ ] The Elder's static lines (no-findings, LLM-outage, summary title, review-body header) in `dispatch.py` are voiced, and the `"{n} blocking"` summary-markdown test pin still passes.
- [ ] Changes applied in lockstep to both mirrored services (`services/webhook` + `services/api`) per ADR-0001; both test suites green (webhook 533 / api 274; the 3 unrelated failures are pre-existing on `main`).

## Size

**Size:** S

## Dependencies

- Refs #288 (paid Yoda voice pack builds on this voice mechanism).

## Out of scope

- The paid Yoda voice pack and any voice-selection / entitlement plumbing (tracked in #288).
- Voicing the TPM persona or any non-Elder surface.
- Tuning the #191 confidence A/B itself.
