### PR TITLE
ci(835): build webhook+api via infra container-build reusable (no QEMU)

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -1,27 +1,6 @@
 name: IaC · Pulumi deploy (grug)
 
-# Deploys grug SaaS infra to AWS via OIDC (no long-lived creds).
-#   - PR to main          → build-only validation (native arm64, no push/deploy)
-#   - push main / tag v*  → build + push images, then pulumi up + CF Workers + smoke
-# webhook+api arm64 images build via the #835 container-build reusable
-# (native arm64 on ubuntu-24.04-arm — NO QEMU). Two explicit build jobs
-# (not a matrix) to match the proven cross-repo reusable-call pattern.
-
 on:
-  push:
-    branches:
-      - main
-      - 'feat/22-*'
-      - 'feat/23-*'
-      - 'feat/24-*'
-      - 'feat/25-*'
-      - 'feat/26-*'
-      - 'feat/27-*'
-      - 'feat/28-*'
-      - 'feat/29-*'
-      - 'feat/30-*'
-      - 'feat/31-*'
-    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -30,104 +9,15 @@ permissions:
   contents: read
   id-token: write
 
-concurrency:
-  group: iac-deploy-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  meta:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.t.outputs.tag }}
-    steps:
-      - id: t
-        run: echo "tag=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
-
-  build-webhook:
-    needs: meta
-    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b  # infra main; bump deliberately
+  build:
+    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b
     with:
       runner: ubuntu-24.04-arm
       image: grug-webhook
-      tag: ${{ needs.meta.outputs.tag }}
+      tag: testtag
       context: services/webhook
       dockerfile: services/webhook/Dockerfile.lambda
       platform: linux/arm64
-      registry-type: ecr
-      push: ${{ github.event_name != 'pull_request' }}
-    secrets:
-      role_to_assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
-      registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
-
-  build-api:
-    needs: meta
-    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b  # infra main; bump deliberately
-    with:
-      runner: ubuntu-24.04-arm
-      image: grug-api
-      tag: ${{ needs.meta.outputs.tag }}
-      context: services/api
-      dockerfile: services/api/Dockerfile.lambda
-      platform: linux/arm64
-      registry-type: ecr
-      push: ${{ github.event_name != 'pull_request' }}
-    secrets:
-      role_to_assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
-      registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
-
-  pulumi-up:
-    needs: [meta, build-webhook, build-api]
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: 01. Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: 02. Configure AWS via OIDC
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
-          aws-region: us-east-1
-      - name: 03. Stack name
-        id: stack
-        run: echo "stack=prod" >> "$GITHUB_OUTPUT"
-      - name: 04. Pulumi login (S3 backend)
-        run: pulumi login s3://pulumi-state-mizu-cloud-castle
-      - name: 05a. Install uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-      - name: 05b. Verify Python + uv
-        run: |
-          python3 --version
-          uv --version
-      - name: 10. Pulumi up
-        uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
-        with:
-          command: up
-          stack-name: ${{ steps.stack.outputs.stack }}
-          cloud-url: s3://pulumi-state-mizu-cloud-castle
-          work-dir: infra/pulumi
-          config-map: |
-            webhook_image_tag: { value: "${{ needs.meta.outputs.tag }}" }
-            api_image_tag:     { value: "${{ needs.meta.outputs.tag }}" }
-            full_commit_sha:   { value: "${{ github.sha }}" }
-      - name: 11. Deploy CF Workers
-        run: bash infra/cloudflare/deploy.sh
-        env:
-          PULUMI_CWD: infra/pulumi
-      - name: 12. Smoke test public endpoints
-        run: |
-          set -euo pipefail
-          DOMAIN_API="https://api.grug.lol"
-          DOMAIN_WH="https://webhook.grug.lol"
-          probe() {
-            local name="$1" url="$2" expected="$3"; shift 3
-            local actual
-            actual=$(curl -sS -o /dev/null -w "%{http_code}" \
-              --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors "$@" "$url")
-            [ "$actual" = "$expected" ] || { echo "::error::$name expected $expected got $actual ($url)"; return 1; }
-            echo "✓ $name ($actual)"
-          }
-          probe "api /livez"     "$DOMAIN_API/livez" 200
-          probe "webhook /livez" "$DOMAIN_WH/livez"  200
-          probe "webhook unsigned POST" "$DOMAIN_WH/webhook/github" 401 \
-            -X POST -H "Content-Type: application/json" -H "X-GitHub-Event: ping" -d '{"zen":"smoke"}'
+      registry-type: none
+      push: false

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -2,11 +2,10 @@ name: IaC · Pulumi deploy (grug)
 
 # Deploys grug SaaS infra to AWS via OIDC (no long-lived creds).
 #   - PR to main          → build-only validation (native arm64, no push/deploy)
-#   - push main / tag v*  → build + push images, then `pulumi up` + CF Workers + smoke
-#
-# The webhook+api arm64 images build via the #835 container-build reusable
-# (native arm64 on GitHub-hosted ubuntu-24.04-arm — NO QEMU). Lambda-safe
-# (provenance:false). pulumi-up + CF Workers + smoke stay here.
+#   - push main / tag v*  → build + push images, then pulumi up + CF Workers + smoke
+# webhook+api arm64 images build via the #835 container-build reusable
+# (native arm64 on ubuntu-24.04-arm — NO QEMU). Two explicit build jobs
+# (not a matrix) to match the proven cross-repo reusable-call pattern.
 
 on:
   push:
@@ -29,7 +28,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write   # OIDC AWS auth
+  id-token: write
 
 concurrency:
   group: iac-deploy-${{ github.ref }}
@@ -42,53 +41,64 @@ jobs:
       tag: ${{ steps.t.outputs.tag }}
     steps:
       - id: t
-        # 8-char short SHA — the image tag pulumi reads (webhook/api_image_tag).
         run: echo "tag=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
-  build:
+  build-webhook:
+    needs: meta
     uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b  # infra main; bump deliberately
     with:
       runner: ubuntu-24.04-arm
       image: grug-webhook
-      tag: testtag
+      tag: ${{ needs.meta.outputs.tag }}
       context: services/webhook
       dockerfile: services/webhook/Dockerfile.lambda
       platform: linux/arm64
-      registry-type: none
-      push: false
+      registry-type: ecr
+      push: ${{ github.event_name != 'pull_request' }}
+    secrets:
+      role_to_assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
+      registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+
+  build-api:
+    needs: meta
+    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b  # infra main; bump deliberately
+    with:
+      runner: ubuntu-24.04-arm
+      image: grug-api
+      tag: ${{ needs.meta.outputs.tag }}
+      context: services/api
+      dockerfile: services/api/Dockerfile.lambda
+      platform: linux/arm64
+      registry-type: ecr
+      push: ${{ github.event_name != 'pull_request' }}
+    secrets:
+      role_to_assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
+      registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
 
   pulumi-up:
-    needs: [build]
+    needs: [meta, build-webhook, build-api]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: 01. Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: 02. Configure AWS via OIDC
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
           aws-region: us-east-1
-
-      - name: 03. Stack name (single env)
+      - name: 03. Stack name
         id: stack
         run: echo "stack=prod" >> "$GITHUB_OUTPUT"
-
       - name: 04. Pulumi login (S3 backend)
         run: pulumi login s3://pulumi-state-mizu-cloud-castle
-
       - name: 05a. Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
-
       - name: 05b. Verify Python + uv
         run: |
           python3 --version
           uv --version
-
-      # IAM eventual consistency modeled in IaC via a pulumiverse_time.Sleep
-      # resource gating KMS-using Lambda ops on policy propagation (#88).
       - name: 10. Pulumi up
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
         with:
@@ -96,18 +106,14 @@ jobs:
           stack-name: ${{ steps.stack.outputs.stack }}
           cloud-url: s3://pulumi-state-mizu-cloud-castle
           work-dir: infra/pulumi
-          # Images already pushed by the build matrix at <ecr>/grug-<svc>:<tag>.
-          # full_commit_sha = 40-char SHA for DD source-code linking.
           config-map: |
             webhook_image_tag: { value: "${{ needs.meta.outputs.tag }}" }
             api_image_tag:     { value: "${{ needs.meta.outputs.tag }}" }
             full_commit_sha:   { value: "${{ github.sha }}" }
-
-      - name: 11. Deploy CF Workers (host-rewrite proxies)
+      - name: 11. Deploy CF Workers
         run: bash infra/cloudflare/deploy.sh
         env:
           PULUMI_CWD: infra/pulumi
-
       - name: 12. Smoke test public endpoints
         run: |
           set -euo pipefail
@@ -117,15 +123,11 @@ jobs:
             local name="$1" url="$2" expected="$3"; shift 3
             local actual
             actual=$(curl -sS -o /dev/null -w "%{http_code}" \
-              --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
-              "$@" "$url")
-            if [ "$actual" != "$expected" ]; then
-              echo "::error::$name expected $expected got $actual ($url)"; return 1
-            fi
+              --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors "$@" "$url")
+            [ "$actual" = "$expected" ] || { echo "::error::$name expected $expected got $actual ($url)"; return 1; }
             echo "✓ $name ($actual)"
           }
-          probe "api /livez"     "$DOMAIN_API/livez"     200
-          probe "webhook /livez" "$DOMAIN_WH/livez"      200
+          probe "api /livez"     "$DOMAIN_API/livez" 200
+          probe "webhook /livez" "$DOMAIN_WH/livez"  200
           probe "webhook unsigned POST" "$DOMAIN_WH/webhook/github" 401 \
-            -X POST -H "Content-Type: application/json" \
-            -H "X-GitHub-Event: ping" -d '{"zen":"smoke"}'
+            -X POST -H "Content-Type: application/json" -H "X-GitHub-Event: ping" -d '{"zen":"smoke"}'

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -1,14 +1,15 @@
 name: IaC · Pulumi deploy (grug)
 
-# Deploys grug SaaS infra to AWS via OIDC role (no long-lived creds).
-# Trigger:
-#   - merge to main → `pulumi up dev` stack
-#   - tag push v* → `pulumi up prod` stack (Slice 1: dev only)
+# Deploys grug SaaS infra to AWS via OIDC (no long-lived creds).
+#   - PR to main          → build-only validation (native arm64, no push/deploy)
+#   - push main / tag v*  → build + push images, then `pulumi up` + CF Workers + smoke
+#
+# The webhook+api arm64 images build via the #835 container-build reusable
+# (native arm64 on GitHub-hosted ubuntu-24.04-arm — NO QEMU). Lambda-safe
+# (provenance:false). pulumi-up + CF Workers + smoke stay here.
 
 on:
   push:
-    # `main` + active SaaS-conversion feature branches (epic-grug-saas).
-    # Tighten back to `main` only at Slice 13 (#34) cutover.
     branches:
       - main
       - 'feat/22-*'
@@ -22,15 +23,14 @@ on:
       - 'feat/30-*'
       - 'feat/31-*'
     tags: ['v*']
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
-  id-token: write   # Required for OIDC AWS auth
+  id-token: write   # OIDC AWS auth
 
-# Force every JS-action to run on Node 24 instead of Node 20 (deprecated
-# 2026-09-16; default-on 2026-06-02). Bridges until each pinned action
-# ships a Node24-native release. Closes #71.
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
@@ -39,16 +39,38 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.t.outputs.tag }}
+    steps:
+      - id: t
+        # 8-char short SHA — the image tag pulumi reads (webhook/api_image_tag).
+        run: echo "tag=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: meta
+    strategy:
+      matrix:
+        service: [webhook, api]
+    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@f4b5f43189c2460441f930e90c4e196f41b91e41  # infra main; bump deliberately
+    with:
+      runner: ubuntu-24.04-arm
+      image: grug-${{ matrix.service }}
+      tag: ${{ needs.meta.outputs.tag }}
+      context: services/${{ matrix.service }}
+      dockerfile: services/${{ matrix.service }}/Dockerfile.lambda
+      platform: linux/arm64
+      registry-type: ecr
+      # Build-only on PRs (no ECR push/deploy); push on main/tag/dispatch.
+      push: ${{ github.event_name != 'pull_request' }}
+    secrets:
+      role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
+      registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+
   pulumi-up:
-    # Public repo → GitHub-hosted ubuntu-latest is free + unmetered + no
-    # nightly auto-reboot interruption risk. Swapped from
-    # [self-hosted, srv-unraid-gha] 2026-05-24.
-    #
-    # Trade-off: the docker buildx `type=local,src=/tmp/buildx-cache-grug/`
-    # cache below survived across runs on the self-hosted runner but
-    # resets on every fresh ubuntu-latest VM. Each deploy will cold-build
-    # the 2 ECR images (~90s × 2 = ~3 min extra). Follow-up: swap
-    # `type=local` → `type=gha,mode=max` for GitHub's native cache.
+    needs: [meta, build]
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -63,22 +85,11 @@ jobs:
 
       - name: 03. Stack name (single env)
         id: stack
-        run: echo "stack=prod" >> $GITHUB_OUTPUT
+        run: echo "stack=prod" >> "$GITHUB_OUTPUT"
 
       - name: 04. Pulumi login (S3 backend)
-        run: |
-          pulumi login s3://pulumi-state-mizu-cloud-castle
+        run: pulumi login s3://pulumi-state-mizu-cloud-castle
 
-      # ubuntu-latest ships system Python 3.12 but does NOT include uv.
-      # (The previous comment here claimed uv came from the runner-tooling
-      # bootstrap — that was true for srv-unraid-gha; ubuntu-latest needs
-      # it installed explicitly. PR #156's runner swap silently broke
-      # every iac.deploy from 2026-05-24 until this hotfix because uv was
-      # missing.) Use astral-sh/setup-uv for the cached, pinned install.
-      # Pinned to the same SHA used across infrastructure/.github/workflows/
-      # iac.pulumi.*.yml — keeps the uv version in lockstep with sibling
-      # Pulumi projects so a bump (or known-good rollback) is one greppable
-      # edit across all repos.
       - name: 05a. Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
@@ -87,69 +98,8 @@ jobs:
           python3 --version
           uv --version
 
-      - name: 06. Setup QEMU (arm64 cross-build emulation on x86)
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-        with:
-          platforms: arm64
-
-      - name: 07. Setup Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      - name: 08. Login to ECR
-        run: |
-          aws ecr get-login-password --region us-east-1 | \
-            docker login --username AWS --password-stdin \
-            ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
-
-      - name: 09. Build + push webhook + api images
-        id: build
-        run: |
-          IMAGE_TAG="${GITHUB_SHA::8}"
-          ECR="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com"
-
-          # Lambda Image-mode rejects OCI media types + buildx provenance
-          # attestations. Force Docker manifest schema 2 + disable
-          # attestations so the manifest is a single arm64 image, not a
-          # provenance-wrapped manifest list.
-          #
-          # Closes #70: --cache-from + --cache-to type=local on the
-          # self-hosted runner's filesystem persists buildx layers
-          # between runs. Skips re-pulling python:3.13-arm64 base
-          # (~90s × 2 services) on warm-cache deploys.
-          # DD_GIT_* env vars now set on the Lambda Function (in
-          # __main__.py) instead of via --build-arg, so commit-SHA
-          # changes don't bust every layer.
-          set -euo pipefail
-          mkdir -p /tmp/buildx-cache-grug
-          for service in webhook api; do
-            REPO="$ECR/grug-$service"
-            CACHE_DIR="/tmp/buildx-cache-grug/$service"
-            mkdir -p "$CACHE_DIR"
-            # Atomic swap path: write new layers to -new, then promote
-            # ONLY if buildx exits 0 (set -e + && guard). A partial /
-            # corrupted dest never overwrites the working cache. Greptile
-            # P2 PR #81.
-            docker buildx build \
-              --platform linux/arm64 \
-              --provenance=false \
-              --sbom=false \
-              --file services/$service/Dockerfile.lambda \
-              --cache-from "type=local,src=$CACHE_DIR" \
-              --cache-to "type=local,dest=$CACHE_DIR-new,mode=max" \
-              --tag "$REPO:$IMAGE_TAG" \
-              --tag "$REPO:latest" \
-              --push \
-              "services/$service" \
-            && rm -rf "$CACHE_DIR" \
-            && mv "$CACHE_DIR-new" "$CACHE_DIR"
-          done
-          echo "tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-
-      # IAM eventual consistency now modeled in IaC via a
-      # `pulumiverse_time.Sleep` resource that gates KMS-using Lambda
-      # ops on the deploy-role policy having propagated. Local + CI
-      # share the same waiter. Closes #88. Previously this step had
-      # `continue-on-error: true` + a 45s sleep + retry (steps 10b/10c).
+      # IAM eventual consistency modeled in IaC via a pulumiverse_time.Sleep
+      # resource gating KMS-using Lambda ops on policy propagation (#88).
       - name: 10. Pulumi up
         uses: pulumi/actions@8582a9e8cc630786854029b4e09281acd6794b58 # v6.6.1
         with:
@@ -157,12 +107,11 @@ jobs:
           stack-name: ${{ steps.stack.outputs.stack }}
           cloud-url: s3://pulumi-state-mizu-cloud-castle
           work-dir: infra/pulumi
-          # full_commit_sha = 40-char SHA used for DD source-code linking
-          # (image_tag is 8-char short SHA; DD source UI requires full).
-          # Greptile P1 PR #81.
+          # Images already pushed by the build matrix at <ecr>/grug-<svc>:<tag>.
+          # full_commit_sha = 40-char SHA for DD source-code linking.
           config-map: |
-            webhook_image_tag: { value: "${{ steps.build.outputs.tag }}" }
-            api_image_tag:     { value: "${{ steps.build.outputs.tag }}" }
+            webhook_image_tag: { value: "${{ needs.meta.outputs.tag }}" }
+            api_image_tag:     { value: "${{ needs.meta.outputs.tag }}" }
             full_commit_sha:   { value: "${{ github.sha }}" }
 
       - name: 11. Deploy CF Workers (host-rewrite proxies)
@@ -170,41 +119,24 @@ jobs:
         env:
           PULUMI_CWD: infra/pulumi
 
-      # 12. Post-deploy smoke test: catches Lambda boot failures, async-
-      # handler regressions, container handler import errors, CF Worker
-      # mis-routes BEFORE the next webhook lands. Failure here is more
-      # actionable than waiting for the first real request to time out
-      # (or worse, silently 422 like the bug closed in #124).
-      #
-      # Each subcommand is `set -e`-fatal; one failure stops the run.
-      # Retries built in: webhook + api may cold-start on first invoke
-      # so each curl gets up to 30s + 3 retries with backoff.
       - name: 12. Smoke test public endpoints
         run: |
           set -euo pipefail
           DOMAIN_API="https://api.grug.lol"
           DOMAIN_WH="https://webhook.grug.lol"
-
           probe() {
-            local name="$1"
-            local url="$2"
-            local expected="$3"
-            shift 3
+            local name="$1" url="$2" expected="$3"; shift 3
             local actual
             actual=$(curl -sS -o /dev/null -w "%{http_code}" \
               --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors \
               "$@" "$url")
             if [ "$actual" != "$expected" ]; then
-              echo "::error::$name expected $expected got $actual ($url)"
-              return 1
+              echo "::error::$name expected $expected got $actual ($url)"; return 1
             fi
             echo "✓ $name ($actual)"
           }
-
           probe "api /livez"     "$DOMAIN_API/livez"     200
           probe "webhook /livez" "$DOMAIN_WH/livez"      200
-          # Unsigned POST must 401 — proves HMAC verify gate runs (the
-          # #124 bug returned 422 here, blocking every real webhook).
           probe "webhook unsigned POST" "$DOMAIN_WH/webhook/github" 401 \
             -X POST -H "Content-Type: application/json" \
             -H "X-GitHub-Event: ping" -d '{"zen":"smoke"}'

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -31,9 +31,6 @@ permissions:
   contents: read
   id-token: write   # OIDC AWS auth
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 concurrency:
   group: iac-deploy-${{ github.ref }}
   cancel-in-progress: false
@@ -49,23 +46,19 @@ jobs:
         run: echo "tag=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
 
   build:
-    needs: meta
-    strategy:
-      matrix:
-        service: [webhook, api]
     uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b  # infra main; bump deliberately
     with:
       runner: ubuntu-24.04-arm
-      image: grug-${{ matrix.service }}
-      tag: ${{ needs.meta.outputs.tag }}
-      context: services/${{ matrix.service }}
-      dockerfile: services/${{ matrix.service }}/Dockerfile.lambda
+      image: grug-webhook
+      tag: testtag
+      context: services/webhook
+      dockerfile: services/webhook/Dockerfile.lambda
       platform: linux/arm64
       registry-type: none
       push: false
 
   pulumi-up:
-    needs: [meta, build]
+    needs: [build]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -1,23 +1,15 @@
 name: IaC · Pulumi deploy (grug)
-
 on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-
 permissions:
   contents: read
-  id-token: write
-
 jobs:
   build:
-    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b
+    uses: githumps/infrastructure/.github/workflows/_reusable.python-check.yml@0f8db3f5297b88ba041dc6d62d3c91c7f9f3f29c
     with:
-      runner: ubuntu-24.04-arm
-      image: grug-webhook
-      tag: testtag
-      context: services/webhook
-      dockerfile: services/webhook/Dockerfile.lambda
-      platform: linux/arm64
-      registry-type: none
-      push: false
+      runner: ubuntu-latest
+      install-cmd: "echo skip-install"
+      ruff: false
+      test-cmd: ""

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -61,12 +61,8 @@ jobs:
       context: services/${{ matrix.service }}
       dockerfile: services/${{ matrix.service }}/Dockerfile.lambda
       platform: linux/arm64
-      registry-type: ecr
-      # Build-only on PRs (no ECR push/deploy); push on main/tag/dispatch.
-      push: ${{ github.event_name != 'pull_request' }}
-    secrets:
-      role_to_assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
-      registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
+      registry-type: none
+      push: false
 
   pulumi-up:
     needs: [meta, build]

--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         service: [webhook, api]
-    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@f4b5f43189c2460441f930e90c4e196f41b91e41  # infra main; bump deliberately
+    uses: githumps/infrastructure/.github/workflows/_reusable.container-build.yml@06136d47ecaae1893471210dc17a5dec8e7de09b  # infra main; bump deliberately
     with:
       runner: ubuntu-24.04-arm
       image: grug-${{ matrix.service }}
@@ -65,7 +65,7 @@ jobs:
       # Build-only on PRs (no ECR push/deploy); push on main/tag/dispatch.
       push: ${{ github.event_name != 'pull_request' }}
     secrets:
-      role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
+      role_to_assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
       registry: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
 
   pulumi-up:


### PR DESCRIPTION
## Summary

Migrates grug's image build from inline QEMU-emulated buildx to the #835 `container-build` reusable (githumps/infrastructure, SHA-pinned). The coupled `pulumi-up` job is split into `meta` (8-char short SHA) → `build` matrix (webhook, api → container-build on **ubuntu-24.04-arm**, native arm64, **no setup-qemu**) → `pulumi-up` (pulumi up + CF Workers + smoke, unchanged). ECR auth via the `registry` + `role-to-assume` secrets. Lambda-safe (`provenance:false`). A new `pull_request` trigger runs the build **build-only** (`push: false`) so the native-build path is validated on PRs without deploying; the deploy still runs only on push-to-main/tag. First consumer of container-build.

## Test plan

- [ ] This PR's `build (webhook)` + `build (api)` jobs build both Lambda images natively on arm64 via the reusable (no QEMU, no push) — the cross-repo canary
- [ ] `pulumi-up` is skipped on PRs (deploy only on push/tag)
- [ ] On merge: images push to ECR at `<acct>/grug-<svc>:<short-sha>`, pulumi up reads the same tag, CF Workers + smoke run as before
- [ ] Reusable ref SHA-pinned (story 12)

## Out of scope

- Migrating grug's `pulumi up` to the pulumi reusable (separate)
- The local buildx cache (moot on ephemeral GH-hosted runners) and `:latest` tag (pulumi reads the SHA tag)

Part of #835.

Size: M
