### PR TITLE
chore(ci): scrub internal names from public workflows

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -3,9 +3,8 @@ name: IaC · Pulumi deploy (grug)
 # Deploys grug SaaS infra to AWS via OIDC (no long-lived creds).
 #   - PR to main          → build-only validation (native arm64, no push/deploy)
 #   - push main / tag v*  → build + push images, then pulumi up + CF Workers + smoke
-# webhook+api arm64 images build via the #835 container-build reusable in
-# githumps/infra-public (PUBLIC — grug is public, so it can't call the private
-# infra repo's reusable). Native arm64 on ubuntu-24.04-arm — NO QEMU.
+# webhook+api arm64 images build via the shared container-build reusable in
+# githumps/infra-public. Native arm64 on ubuntu-24.04-arm — NO QEMU.
 
 on:
   push:
@@ -48,7 +47,7 @@ jobs:
     strategy:
       matrix:
         service: [webhook, api]
-    uses: githumps/infra-public/.github/workflows/_reusable.container-build.yml@d27416e63a9e14c626ae728f65ab0287eac6d78c  # infra-public main; bump deliberately
+    uses: githumps/infra-public/.github/workflows/_reusable.container-build.yml@d77dce3e0096674024e25c937e63addde7e86401  # infra-public main; bump deliberately
     with:
       runner: ubuntu-24.04-arm
       image: grug-${{ matrix.service }}
@@ -79,7 +78,9 @@ jobs:
         id: stack
         run: echo "stack=prod" >> "$GITHUB_OUTPUT"
       - name: 04. Pulumi login (S3 backend)
-        run: pulumi login s3://pulumi-state-mizu-cloud-castle
+        env:
+          PULUMI_BACKEND_URL: ${{ secrets.PULUMI_BACKEND_URL }}
+        run: pulumi login "$PULUMI_BACKEND_URL"
       - name: 05a. Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
       - name: 05b. Verify Python + uv
@@ -91,7 +92,7 @@ jobs:
         with:
           command: up
           stack-name: ${{ steps.stack.outputs.stack }}
-          cloud-url: s3://pulumi-state-mizu-cloud-castle
+          cloud-url: ${{ secrets.PULUMI_BACKEND_URL }}
           work-dir: infra/pulumi
           config-map: |
             webhook_image_tag: { value: "${{ needs.meta.outputs.tag }}" }

--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -34,8 +34,8 @@ env:
 jobs:
   build-and-deploy:
     # Public repo → GitHub-hosted ubuntu-latest is free + unmetered + no
-    # nightly auto-reboot interruption risk. Swapped from
-    # [self-hosted, srv-unraid-gha] 2026-05-24.
+    # nightly auto-reboot interruption risk. Swapped from a self-hosted
+    # runner 2026-05-24.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary

grug is a public repo and its workflow files carried internal references: internal tracker issue numbers, a mention of the private infra repo, a self-hosted runner host name, and the Pulumi S3 state-bucket URL in functional lines. This scrubs the comments to be generic and moves the backend URL into the masked `PULUMI_BACKEND_URL` secret (referenced by `pulumi login` + `cloud-url`). The container-build reusable pin is bumped to the scrubbed infra-public SHA. No behavioral change.

## Test plan

- [ ] PR build-only validation builds the webhook+api arm64 images via the bumped reusable pin (native arm64, no QEMU)
- [ ] On merge, `pulumi login` + `pulumi up` succeed using the `PULUMI_BACKEND_URL` secret (S3 backend reachable)
- [ ] No internal identifiers remain in `.github/workflows/` (grep clean)

## Out of scope

- Rewriting git history to purge old blobs (the leaked content is internal names, not credentials).
- Functional changes to the deploy logic.

Part of #835

Size: S