### PR TITLE
ci: repoint infra-public reusable pin to re-rooted commit

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         service: [webhook, api]
-    uses: githumps/infra-public/.github/workflows/_reusable.container-build.yml@d77dce3e0096674024e25c937e63addde7e86401  # infra-public main; bump deliberately
+    uses: githumps/infra-public/.github/workflows/_reusable.container-build.yml@41038951557478badb69ca2c34217f75825cfc2e  # infra-public main; bump deliberately
     with:
       runner: ubuntu-24.04-arm
       image: grug-${{ matrix.service }}


### PR DESCRIPTION
## Summary

The shared infra-public reusable-workflow library had its git history re-rooted to purge content that should not have been published. The prior pinned commit no longer exists, so this bumps the reusable pin(s) to the new root commit `4103895`. The reusable logic is byte-identical to what this repo already consumed — only the header comments and the upstream commit history changed.

## Test plan

- [ ] CI resolves the reusable at the new pin (no "workflow file not found" startup failure)
- [ ] PR build-only validation builds webhook+api arm64 via the re-rooted reusable
- [ ] grep shows no remaining reference to the old infra-public SHAs in `.github/workflows/`

## Out of scope

- Reusable behavior changes — content is identical.
- Deploy logic unchanged; pulumi up runs on merge.

Closes #295

Size: XS