### PR TITLE
fix(grug): route DD alerts to Discord + add Elder LLM-degraded monitor

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -559,9 +559,32 @@ _dd_provider = _datadog.Provider(
     api_url="https://api.datadoghq.com/",
 )
 
-# Notification handle. SSM param `/grug/dd-notify-handle` MUST exist
-# before first pulumi up — pre-load it via HITL_PREREQUISITES.md §6.
-_dd_notify = aws.ssm.get_parameter(name="/grug/dd-notify-handle").value
+# Notification routing → Discord #monitoring-alerts (channel
+# 1501743643965394974 in guild 781626163591249930 — where the homelab's
+# migration-watcher already posts). The old `/grug/dd-notify-handle` was the
+# placeholder `@grug-stub`, which Datadog does not recognise as any target —
+# so EVERY monitor notified into the void (the Elder LLM outage ran ~5 days
+# with no page). Register a real DD webhook integration that POSTs to the
+# pre-existing Discord webhook secret, and route all monitors at it.
+# `@webhook-<name>` is how a DD monitor references a webhook integration entry.
+_discord_webhook_url = pulumi.Output.secret(
+    aws.ssm.get_parameter(
+        name="/infra/discord/781626163591249930/monitoring-alerts",
+        with_decryption=True,
+    ).value
+)
+_dd_discord = _datadog.Webhook(
+    "grug-discord-monitoring",
+    name="grug-discord-monitoring",
+    url=_discord_webhook_url,
+    encode_as="json",
+    # Discord's native webhook body. DD substitutes the $-variables at send
+    # time; keep it short — Discord rejects content > 2000 chars. `\n` in the
+    # source becomes a JSON newline escape Discord renders as a line break.
+    payload='{"content": "$EVENT_TITLE\\n$EVENT_MSG\\n$LINK"}',
+    opts=pulumi.ResourceOptions(provider=_dd_provider),
+)
+_dd_notify = "@webhook-grug-discord-monitoring"
 
 monitors = dd_monitors.create_all(
     env=env,
@@ -647,6 +670,8 @@ pulumi.export("monitor_api_5xx_id", monitors.api_5xx.id)
 pulumi.export("monitor_sig_verify_fail_id", monitors.sig_verify_fail.id)
 pulumi.export("monitor_cold_start_p99_id", monitors.cold_start_p99.id)
 pulumi.export("monitor_enforcement_gap_id", monitors.enforcement_gap.id)
+pulumi.export("monitor_elder_llm_degraded_id", monitors.elder_llm_degraded.id)
+pulumi.export("dd_discord_webhook_name", _dd_discord.name)
 pulumi.export("monitor_cf_secret_mismatch_id", monitors.cf_secret_mismatch.id)
 pulumi.export("synthetic_uptime_id", monitors.uptime.id)
 

--- a/infra/pulumi/components/dd_monitors.py
+++ b/infra/pulumi/components/dd_monitors.py
@@ -30,6 +30,7 @@ class _MonitorBundle:
     api_5xx: datadog.Monitor
     sig_verify_fail: datadog.Monitor
     elder_offload_fail: datadog.Monitor
+    elder_llm_degraded: datadog.Monitor
     cold_start_p99: datadog.Monitor
     enforcement_gap: datadog.Monitor
     cf_secret_mismatch: datadog.Monitor
@@ -152,6 +153,39 @@ def create_all(
             f'logs("service:grug-webhook env:{env} '
             '(elder_enqueue_failed OR elder_job_unhandled)").index("*")'
             '.rollup("count").last("15m") > 0'
+        ),
+        tags=_common_tags(env, "grug-webhook"),
+        notify_no_data=False,
+        priority=2,
+        opts=opts,
+    )
+
+    # 3b) Elder LLM degraded — reviews silently dropped. The offload monitor
+    #     above watches the async PLUMBING (enqueue/worker crash); it cannot
+    #     see the failure that actually took Elder down for ~5 days — EVERY
+    #     LLM backend (OpenRouter 402 + Poolside ReadTimeout) failing, which
+    #     is logged at warn as `code_review_llm_degraded` and returns
+    #     gracefully (no crash, no offload failure). Same shape as the poller's
+    #     all-failed monitor: a handled systemic failure needs a LOG alert, not
+    #     a crash/metric one. `>= 2` in 1h ignores a lone transient blip but
+    #     trips on a sustained both-backends-down outage.
+    elder_llm_degraded = datadog.Monitor(
+        "grug-webhook-elder-llm-degraded",
+        type="log alert",
+        name="[grug-webhook] Elder LLM degraded — reviews dropped (1h)",
+        message=(
+            f"{notify_handle}\n"
+            "Grug Elder could not reach ANY LLM backend (all of OpenRouter + "
+            "Poolside failed) for >= 2 code reviews in the last hour — those "
+            "PRs got NO review, only a neutral 'skipping' check. Check provider "
+            "credits (OpenRouter `http_402` = out of credits) and timeouts "
+            "(Poolside `ReadTimeout`). Invisible to the offload monitor because "
+            "the async path succeeds; only the LLM call fails.\n"
+            "Runbook: docs/RUNBOOK.md#elder-async-offload"
+        ),
+        query=(
+            f'logs("service:grug-webhook env:{env} code_review_llm_degraded")'
+            '.index("*").rollup("count").last("1h") >= 2'
         ),
         tags=_common_tags(env, "grug-webhook"),
         notify_no_data=False,
@@ -289,6 +323,7 @@ def create_all(
         api_5xx=api_5xx,
         sig_verify_fail=sig_verify_fail,
         elder_offload_fail=elder_offload_fail,
+        elder_llm_degraded=elder_llm_degraded,
         cold_start_p99=cold_start_p99,
         enforcement_gap=enforcement_gap,
         cf_secret_mismatch=cf_secret_mismatch,


### PR DESCRIPTION
## Why

Grug Elder silently stopped reviewing code for ~5 days. Root cause (from `grug-webhook` prod logs): **both** LLM backends were failing — OpenRouter returns `http_402` (account out of credits) and Poolside hits `ReadTimeout` at the flat 30s client timeout (`laguna-m.1` thinking-mode latency). With no backend, every review degrades to a neutral "skipping" check and posts nothing. **Nobody was paged**, because of two observability gaps this PR closes: (1) `/grug/dd-notify-handle` was the placeholder `@grug-stub` — Datadog doesn't recognise it, so every monitor notified into the void; (2) no monitor watched the actual failure signal (`code_review_llm_degraded`) — the existing `elder_offload_fail` only watches the async plumbing, not a handled all-backends-down degradation.

## Acceptance criteria

- [ ] A `datadog.Webhook` (`grug-discord-monitoring`) is registered, POSTing to the existing homelab Discord webhook for `#monitoring-alerts` (channel `1501743643965394974`, reused from `/infra/discord/781626163591249930/monitoring-alerts`); the URL stays a Pulumi secret (never in preview output).
- [ ] All grug monitors route at `@webhook-grug-discord-monitoring` instead of the dead `@grug-stub` (verified in `pulumi preview`: every monitor's handle flips).
- [ ] A new `elder_llm_degraded` monitor (log alert) fires when `code_review_llm_degraded` occurs `>= 2` times in 1h — catching a sustained both-backends-down outage while ignoring a lone transient.
- [ ] `pulumi preview` on prod shows: `+ Webhook`, `+ elder_llm_degraded Monitor`, `~ handle flips` — and no unintended resource deletions.
- [ ] Deployed via CI (not local `pulumi up`, which would revert Lambda `imageUri` to `bootstrap` — pre-existing local-vs-CI image-tag drift, called out in the commit).

## Size

**Size:** S

## Dependencies

- Reuses the existing `/infra/discord/.../monitoring-alerts` secret (no new Discord webhook needed). The deploy role already has `ssm:GetParameter*` + `kms:Decrypt` on `*`, so the cross-path read works with no IAM change.
- Does NOT restore Elder by itself — it makes the outage *visible*. The functional fix (raise the Poolside per-backend timeout above its thinking-mode latency, and/or top up OpenRouter credits) is a companion change.

## Out of scope

- The Elder recovery fix itself (Poolside timeout / OpenRouter funding) — separate PR.
- Per-backend (OpenRouter-only / Poolside-only) monitors — the aggregate degraded signal is the "Elder is dark" alert; per-backend warn monitors are a possible follow-up.
- The Lambda `imageUri` drift (pre-existing, CI-owned).
