### PR TITLE
fix(grug): restore Elder — disable Poolside thinking + raise LLM timeout

### DIFF
--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -188,7 +188,12 @@ _POOLSIDE_MODEL = "poolside/laguna-m.1"
 _OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 _OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
 
-_TIMEOUT_SECONDS = 30
+# 60s (was 30s): a large diff review can legitimately take >30s even with
+# Poolside thinking disabled; 30s caused ReadTimeouts that silently dropped
+# Elder reviews. 60s gives ~4x margin over a measured 14s small-diff review
+# and still fits the retry x fallback budget under the 420s Lambda timeout
+# (3*60 primary + 3*60 fallback = 360s < 420s).
+_TIMEOUT_SECONDS = 60
 _RETRY_ATTEMPTS = 3
 # Exponential backoff applies on every attempt except the final one,
 # which either returns the response or raises.
@@ -250,6 +255,15 @@ class BackendConfig:
     url: str
     model: str
     key_loader: Callable[[], str]
+    # Vendor-specific chat-completions body params merged for THIS backend
+    # only. Poolside's laguna-m.1 runs thinking ON by default — ~87% of output
+    # was reasoning tokens, which (a) blew past the 30s read timeout (measured
+    # 72s for even a tiny diff → ReadTimeout → Elder posted nothing for days)
+    # and (b) leaked reasoning prose into `content`, breaking JSON parse. The
+    # vLLM `chat_template_kwargs.enable_thinking=false` switch disables it
+    # (verified live: 72s→<1s, reasoning_tokens 1106→0). claude/OpenRouter
+    # rejects this key, so it MUST be per-backend, never on the shared body.
+    extra_body: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -314,6 +328,8 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
         # `lc._load_poolside_key`, which `_BACKEND_CONFIGS` no longer
         # consults.
         key_loader=lambda: _load_poolside_key(),
+        # Disable laguna-m.1's default thinking mode — see BackendConfig.extra_body.
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
     ),
     Backend.OPENROUTER: BackendConfig(
         backend=Backend.OPENROUTER,
@@ -413,6 +429,7 @@ def _call_backend(
         "model": config.model,
         "messages": messages,
         "response_format": {"type": "json_object"},
+        **config.extra_body,
     }
     headers = {"Authorization": f"Bearer {key}"}
 

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -198,8 +198,9 @@ def test_request_uses_openai_chat_completions_shape() -> None:
     assert body.get("response_format") == {"type": "json_object"}
     # Authorization header carries the loaded key.
     assert captured[0]["headers"]["Authorization"].startswith("Bearer ")
-    # 30s timeout per the existing Poolside convention.
-    assert captured[0]["timeout"] == 30
+    # 60s timeout (raised from 30s — a large diff review can exceed 30s; 30s
+    # caused ReadTimeouts that silently dropped Elder reviews).
+    assert captured[0]["timeout"] == 60
 
 
 def test_malformed_llm_json_returns_parse_failed_kind() -> None:

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -188,7 +188,12 @@ _POOLSIDE_MODEL = "poolside/laguna-m.1"
 _OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
 _OPENROUTER_MODEL = "anthropic/claude-haiku-4.5"
 
-_TIMEOUT_SECONDS = 30
+# 60s (was 30s): a large diff review can legitimately take >30s even with
+# Poolside thinking disabled; 30s caused ReadTimeouts that silently dropped
+# Elder reviews. 60s gives ~4x margin over a measured 14s small-diff review
+# and still fits the retry x fallback budget under the 420s Lambda timeout
+# (3*60 primary + 3*60 fallback = 360s < 420s).
+_TIMEOUT_SECONDS = 60
 _RETRY_ATTEMPTS = 3
 # Exponential backoff applies on every attempt except the final one,
 # which either returns the response or raises.
@@ -250,6 +255,15 @@ class BackendConfig:
     url: str
     model: str
     key_loader: Callable[[], str]
+    # Vendor-specific chat-completions body params merged for THIS backend
+    # only. Poolside's laguna-m.1 runs thinking ON by default — ~87% of output
+    # was reasoning tokens, which (a) blew past the 30s read timeout (measured
+    # 72s for even a tiny diff → ReadTimeout → Elder posted nothing for days)
+    # and (b) leaked reasoning prose into `content`, breaking JSON parse. The
+    # vLLM `chat_template_kwargs.enable_thinking=false` switch disables it
+    # (verified live: 72s→<1s, reasoning_tokens 1106→0). claude/OpenRouter
+    # rejects this key, so it MUST be per-backend, never on the shared body.
+    extra_body: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -314,6 +328,8 @@ _BACKEND_CONFIGS: dict[Backend, BackendConfig] = {
         # `lc._load_poolside_key`, which `_BACKEND_CONFIGS` no longer
         # consults.
         key_loader=lambda: _load_poolside_key(),
+        # Disable laguna-m.1's default thinking mode — see BackendConfig.extra_body.
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
     ),
     Backend.OPENROUTER: BackendConfig(
         backend=Backend.OPENROUTER,
@@ -413,6 +429,7 @@ def _call_backend(
         "model": config.model,
         "messages": messages,
         "response_format": {"type": "json_object"},
+        **config.extra_body,
     }
     headers = {"Authorization": f"Bearer {key}"}
 

--- a/services/webhook/tests/test_code_reviewer_dispatch.py
+++ b/services/webhook/tests/test_code_reviewer_dispatch.py
@@ -859,7 +859,9 @@ def test_no_single_webhook_timeout_reaches_lambda_budget():
     bounds that. The only real fix is moving the LLM call off the ACK path
     (async offload, #272). Asserting a path-sum bound here would be false."""
     import llm_client
-    _WEBHOOK_LAMBDA_BUDGET = 60  # keep in sync w/ infra/pulumi/__main__ webhook
+    # 420s: the post-#272 async-offload webhook Lambda timeout (the function
+    # that runs the Elder dispatch). The old 60 here predated that bump.
+    _WEBHOOK_LAMBDA_BUDGET = 420  # keep in sync w/ infra/pulumi/__main__ webhook
     assert cr_dispatch._DIFF_FETCH_TIMEOUT < _WEBHOOK_LAMBDA_BUDGET
     assert cr_dispatch._COMMENT_FETCH_TIMEOUT < _WEBHOOK_LAMBDA_BUDGET
     assert llm_client._TIMEOUT_SECONDS < _WEBHOOK_LAMBDA_BUDGET

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -199,8 +199,30 @@ def test_request_uses_openai_chat_completions_shape() -> None:
     assert body.get("response_format") == {"type": "json_object"}
     # Authorization header carries the loaded key.
     assert captured[0]["headers"]["Authorization"].startswith("Bearer ")
-    # 30s timeout per the existing Poolside convention.
-    assert captured[0]["timeout"] == 30
+    # 60s timeout (raised from 30s — a large diff review can exceed 30s; 30s
+    # caused ReadTimeouts that silently dropped Elder reviews).
+    assert captured[0]["timeout"] == 60
+    # installation_id=1 is odd -> OpenRouter, which gets NO vendor extra_body.
+    assert "chat_template_kwargs" not in body
+
+
+def test_poolside_request_disables_thinking() -> None:
+    """Poolside's laguna-m.1 runs thinking ON by default — it blew past the
+    read timeout (72s measured) and leaked reasoning into `content` (broke JSON
+    parse), taking Elder dark. The Poolside backend MUST send the vLLM
+    `chat_template_kwargs.enable_thinking=false` switch; OpenRouter must NOT
+    (claude rejects the key)."""
+    captured: list = []
+
+    def capture(url, *, json, headers, timeout):
+        captured.append(json)
+        return httpx.Response(200, json=_openai_json_response('{"findings":[]}'))
+
+    # installation_id=2 is even -> Poolside.
+    with patch.object(httpx, "post", side_effect=capture):
+        review_diff([_hunk()], installation_id=2)
+
+    assert captured[0].get("chat_template_kwargs") == {"enable_thinking": False}
 
 
 def test_malformed_llm_json_returns_parse_failed_kind() -> None:


### PR DESCRIPTION
## Why

Grug Elder posted no code reviews for ~5 days. From `grug-webhook` prod logs, **both** LLM backends were failing: OpenRouter `http_402` (account out of credits) and Poolside `httpx.ReadTimeout` on every call. With no backend, each review degrades to a neutral "skipping" check and posts nothing. I reproduced the Poolside failure live: `laguna-m.1` runs **thinking ON by default** — a *tiny* diff took **72s** (1106 of 1265 completion tokens were reasoning) against the flat **30s** client timeout, and the reasoning prose leaked into `content`, which also broke JSON parsing (the `llm_response_parse_failed` we saw). This fixes the Poolside path so Elder works again even while OpenRouter is unfunded (the round-robin falls back to a working Poolside).

## Acceptance criteria

- [ ] The Poolside request sends `chat_template_kwargs={"enable_thinking": false}` (vLLM switch); OpenRouter does **not** (claude rejects the key). Added as a per-backend `BackendConfig.extra_body` so it's one entry, not scattered branches.
- [ ] Verified live against the real grug prompt: same request goes **72s → 14s**, `reasoning_tokens 1106 → 0`, `content` is clean parseable JSON, and it returns correct findings (`silent-exception-swallow`, `broad-except-masks-bug`).
- [ ] The shared LLM read timeout is raised **30s → 60s** (~4× margin over the measured 14s; still inside the 420s async-offload Lambda budget: `3*60 primary + 3*60 fallback = 360 < 420`).
- [ ] A test locks the Poolside thinking-disabled body shape; the stale `timeout == 30` assertions and the stale `_WEBHOOK_LAMBDA_BUDGET = 60` (corrected to the real post-#272 `420`) are fixed.
- [ ] Applied in lockstep to `services/{webhook,api}/llm_client.py` per ADR-0001; `webhook 122` + `api 24` llm_client/dispatch tests pass.

## Size

**Size:** S

## Dependencies

- OpenRouter is still out of credits (`http_402`) — orthogonal billing action; this PR restores Elder without it via the Poolside fallback. Topping up OpenRouter restores true redundancy.
- Pairs with the alerting PR (#297: route DD monitors to Discord + `elder_llm_degraded` monitor) so a future backend outage pages instead of silently rotting.

## Out of scope

- OpenRouter credit top-up (operator/billing).
- Streaming the LLM response / per-backend distinct timeouts — the thinking-disable + 60s timeout is sufficient and minimal.
