### PR TITLE
fix(grug): Elder falls back to the other backend on ANY failure

### DIFF
--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -595,6 +595,11 @@ def review_diff(
     pr_tags = _llmobs_tags(pr_context)
 
     last_error = ""
+    # The FIRST 200-but-unparseable response, if any. Kept so that when BOTH
+    # backends fail we can still surface the specific `parse_failed` kind
+    # (caller posts an advisory check-run) attributed to the primary, rather
+    # than collapsing to `all_failed`.
+    first_parse_fail = None
     for backend in (primary, secondary):
         config = _BACKEND_CONFIGS[backend]
         # Open one LLM Obs span per backend attempt. Annotate on every
@@ -695,26 +700,37 @@ def review_diff(
                 review_span_context=span_context,
             )
         if resp.status_code == 200:
-            # 200 + parse failure — the LLM returned but we can't use
-            # the content. Don't fall back (the other backend would
-            # likely produce the same prose). Surface the parse failure
-            # directly so the caller can post an advisory check-run.
+            # 200 + parse failure — the LLM responded but the content wasn't
+            # usable JSON. FALL BACK to the other backend: the two backends run
+            # DIFFERENT models (OpenRouter=claude, Poolside=laguna), so a parse
+            # failure on one does NOT predict the other (the old "same prose"
+            # assumption is stale post the per-backend model split). Record the
+            # FIRST parse failure so a both-fail outcome still returns the
+            # specific `parse_failed` kind (caller posts an advisory check-run).
             log.warning(
                 "llm_response_parse_failed",
                 extra={"backend": backend.value, "model": model, "error": err},
             )
-            return LlmReviewResponse(
-                kind="parse_failed",
-                backend_used=backend,
-                model_name=model,
-                error=err,
-            )
+            if first_parse_fail is None:
+                first_parse_fail = (backend, model, err)
+            last_error = f"{backend.value}: parse_failed: {err}"
+            continue
         log.warning(
             "llm_backend_http_failed",
             extra={"backend": backend.value, "status": resp.status_code, "error": err},
         )
         last_error = f"{backend.value}: {err}"
 
+    # Every backend failed. Prefer the specific parse_failed kind (a backend
+    # DID respond, just unparseably) over the generic all_failed.
+    if first_parse_fail is not None:
+        pf_backend, pf_model, pf_err = first_parse_fail
+        return LlmReviewResponse(
+            kind="parse_failed",
+            backend_used=pf_backend,
+            model_name=pf_model,
+            error=pf_err,
+        )
     return LlmReviewResponse(
         kind="all_failed",
         error=last_error or "both backends failed",

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -595,6 +595,11 @@ def review_diff(
     pr_tags = _llmobs_tags(pr_context)
 
     last_error = ""
+    # The FIRST 200-but-unparseable response, if any. Kept so that when BOTH
+    # backends fail we can still surface the specific `parse_failed` kind
+    # (caller posts an advisory check-run) attributed to the primary, rather
+    # than collapsing to `all_failed`.
+    first_parse_fail = None
     for backend in (primary, secondary):
         config = _BACKEND_CONFIGS[backend]
         # Open one LLM Obs span per backend attempt. Annotate on every
@@ -695,26 +700,37 @@ def review_diff(
                 review_span_context=span_context,
             )
         if resp.status_code == 200:
-            # 200 + parse failure — the LLM returned but we can't use
-            # the content. Don't fall back (the other backend would
-            # likely produce the same prose). Surface the parse failure
-            # directly so the caller can post an advisory check-run.
+            # 200 + parse failure — the LLM responded but the content wasn't
+            # usable JSON. FALL BACK to the other backend: the two backends run
+            # DIFFERENT models (OpenRouter=claude, Poolside=laguna), so a parse
+            # failure on one does NOT predict the other (the old "same prose"
+            # assumption is stale post the per-backend model split). Record the
+            # FIRST parse failure so a both-fail outcome still returns the
+            # specific `parse_failed` kind (caller posts an advisory check-run).
             log.warning(
                 "llm_response_parse_failed",
                 extra={"backend": backend.value, "model": model, "error": err},
             )
-            return LlmReviewResponse(
-                kind="parse_failed",
-                backend_used=backend,
-                model_name=model,
-                error=err,
-            )
+            if first_parse_fail is None:
+                first_parse_fail = (backend, model, err)
+            last_error = f"{backend.value}: parse_failed: {err}"
+            continue
         log.warning(
             "llm_backend_http_failed",
             extra={"backend": backend.value, "status": resp.status_code, "error": err},
         )
         last_error = f"{backend.value}: {err}"
 
+    # Every backend failed. Prefer the specific parse_failed kind (a backend
+    # DID respond, just unparseably) over the generic all_failed.
+    if first_parse_fail is not None:
+        pf_backend, pf_model, pf_err = first_parse_fail
+        return LlmReviewResponse(
+            kind="parse_failed",
+            backend_used=pf_backend,
+            model_name=pf_model,
+            error=pf_err,
+        )
     return LlmReviewResponse(
         kind="all_failed",
         error=last_error or "both backends failed",

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -361,9 +361,9 @@ def test_transport_failure_on_both_backends_returns_all_failed(monkeypatch) -> N
 def test_parse_failed_attributes_secondary_backend(monkeypatch) -> None:
     """If the primary backend transport-fails and the secondary returns
     200 + non-JSON content, parse_failed must report the secondary as
-    `backend_used`. Comment in review_diff explicitly says don't fall
-    back further; verify the attribution still points at whoever actually
-    responded."""
+    `backend_used`. (The secondary is the only backend that produced a 200,
+    so there's nothing further to fall back to.) Verify the attribution
+    points at whoever actually responded."""
     monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
     parse_fail_envelope = _openai_json_response("sorry, I cannot do that")
 
@@ -378,6 +378,45 @@ def test_parse_failed_attributes_secondary_backend(monkeypatch) -> None:
     assert out.kind == "parse_failed"
     assert out.backend_used == Backend.OPENROUTER
     assert "parse" in out.error.lower()
+
+
+def test_parse_failure_on_primary_falls_back_to_secondary(monkeypatch) -> None:
+    """A 200-but-unparseable response from the PRIMARY must fall back to the
+    secondary — the two backends run different models (claude vs laguna), so a
+    parse failure on one doesn't predict the other. Primary parse-fails,
+    secondary returns clean JSON → kind=reviewed, attributed to the secondary.
+    """
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    good = _openai_json_response(
+        '{"findings":[{"path":"x.py","line":1,"rule":"ok",'
+        '"severity":"low","message":"m"}]}'
+    )
+    bad = _openai_json_response("sorry, no JSON here")
+
+    def staged(url, *args, **kwargs):
+        # installation_id=1 is odd -> OpenRouter primary, Poolside secondary.
+        if "openrouter" in url:
+            return httpx.Response(200, json=bad)
+        return httpx.Response(200, json=good)
+
+    with patch.object(httpx, "post", side_effect=staged):
+        out = review_diff([_hunk()], installation_id=1)
+
+    assert out.kind == "reviewed"
+    assert out.backend_used == Backend.POOLSIDE
+    assert len(out.findings) == 1
+
+
+def test_both_parse_fail_returns_parse_failed_attributed_to_primary(monkeypatch) -> None:
+    """When BOTH backends return 200-but-unparseable, fall back is exhausted;
+    surface the specific parse_failed kind (not all_failed), attributed to the
+    PRIMARY (the first parse failure)."""
+    monkeypatch.setattr(lc, "_RETRY_SLEEP", lambda s: None)
+    bad = httpx.Response(200, json=_openai_json_response("nope, prose only"))
+    with patch.object(httpx, "post", return_value=bad):
+        out = review_diff([_hunk()], installation_id=1)  # odd -> OpenRouter primary
+    assert out.kind == "parse_failed"
+    assert out.backend_used == Backend.OPENROUTER
 
 
 def test_non_dict_finding_entries_dropped() -> None:


### PR DESCRIPTION
## Why

You asked Elder to fall back from OpenRouter to Poolside on failure. The transport-error and non-200 (e.g. OpenRouter `402`) paths already fell back — but a **200-but-unparseable** response did NOT: it early-returned `parse_failed` without trying the other backend, on a now-stale rationale ("the other backend would produce the same prose"). That assumption predates the per-backend model split — OpenRouter runs claude, Poolside runs laguna, so a parse failure on one does not predict the other. This closes that last gap so **any** single-backend failure mode falls through to the other backend.

## Acceptance criteria

- [ ] A 200-but-unparseable response from the primary backend falls back to the secondary; if the secondary returns clean JSON, the result is `kind=reviewed` attributed to the secondary.
- [ ] If BOTH backends return unparseable 200s, the result is the specific `kind=parse_failed` (not `all_failed`), attributed to the primary (first parse failure) so the caller still posts the right advisory check-run.
- [ ] Existing fallback paths unchanged: transport error and non-200 still fall back; a clean review on the primary still short-circuits without calling the secondary.
- [ ] Existing attribution tests preserved (`test_malformed_*` → primary; `test_parse_failed_attributes_secondary_backend` → the only responder).
- [ ] Mirrored across `services/{webhook,api}/llm_client.py` per ADR-0001; `webhook 108` + `api 24` llm_client/dispatch tests pass.

## Size

**Size:** S

## Dependencies

- Builds on #298 (Poolside thinking disabled) — together, every backend failure mode (transport, 402, unparseable) now recovers via the other backend.

## Out of scope

- Streaming responses / per-backend timeouts.
- The OpenRouter credit top-up (orthogonal billing).
