### PR TITLE
fix(grug): sig-verify alert only on real GitHub rejections, not probes

### DIFF
--- a/services/webhook/main.py
+++ b/services/webhook/main.py
@@ -89,14 +89,28 @@ async def receive_github_webhook(
 
     secret = get_webhook_secret()
     if not verify_signature(secret, body, x_hub_signature_256):
-        log.warning(
-            "webhook_signature_invalid",
-            extra={
-                "delivery_id": x_github_delivery,
-                "event": x_github_event,
-                "body_len": len(body),
-            },
-        )
+        # Split the alert signal from internet noise. A genuine GitHub delivery
+        # being REJECTED (webhook secret rotated / SSM drift — actionable)
+        # ALWAYS carries an X-Hub-Signature-256 header; an unsigned scanner
+        # poking the public Function URL sends none. Only the signed-but-invalid
+        # case is `webhook_signature_invalid` (the monitored alert), so a
+        # rotated-secret outage pages while background probes (which dominate a
+        # public endpoint) stay out of the alert path as a quieter
+        # `webhook_unsigned_probe`. Both still 401.
+        if x_hub_signature_256:
+            log.warning(
+                "webhook_signature_invalid",
+                extra={
+                    "delivery_id": x_github_delivery,
+                    "event": x_github_event,
+                    "body_len": len(body),
+                },
+            )
+        else:
+            log.info(
+                "webhook_unsigned_probe",
+                extra={"event": x_github_event, "body_len": len(body)},
+            )
         # 401 — GitHub stops retrying after 4xx (vs 5xx which retries).
         # Bad signature = caller is broken (or hostile); no point in retry.
         raise HTTPException(

--- a/services/webhook/tests/test_main_webhook_receiver.py
+++ b/services/webhook/tests/test_main_webhook_receiver.py
@@ -65,6 +65,41 @@ def test_bad_signature_returns_401(_client):
     assert r.status_code == 401
 
 
+def test_unsigned_probe_logs_distinct_event_not_signature_invalid(_client, caplog):
+    """An unsigned request (no X-Hub-Signature-256) is an internet probe of the
+    public URL, NOT a GitHub delivery being rejected — it must log
+    `webhook_unsigned_probe`, never `webhook_signature_invalid` (the monitored
+    alert). Keeps the sig-verify monitor precise to real rotated-secret events."""
+    import logging
+    caplog.set_level(logging.INFO)
+    _client.post(
+        "/webhook/github",
+        content=b'{"action":"opened"}',
+        headers={"X-GitHub-Event": "pull_request"},
+    )
+    msgs = [r.getMessage() for r in caplog.records]
+    assert "webhook_unsigned_probe" in msgs
+    assert "webhook_signature_invalid" not in msgs
+
+
+def test_signed_but_invalid_logs_signature_invalid(_client, caplog):
+    """A request that carried a signature but failed verification is a real
+    rejection (rotated secret / forged delivery) — it must log the monitored
+    `webhook_signature_invalid`, not the quiet probe event."""
+    import logging
+    caplog.set_level(logging.WARNING)
+    _client.post(
+        "/webhook/github",
+        content=b'{"action":"opened"}',
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-Hub-Signature-256": "sha256=000000000000",
+        },
+    )
+    msgs = [r.getMessage() for r in caplog.records]
+    assert "webhook_signature_invalid" in msgs
+
+
 def test_signed_non_json_body_returns_400(_client):
     """silent-failure-hunter P1 #1: body that passes HMAC but fails
     JSON decode must 400 (not 200 'skip'), so DD alarms trigger."""


### PR DESCRIPTION
## Why

The `[grug-webhook] HMAC signature-verify failures` monitor flaps on internet noise. The public webhook Function URL gets scanned constantly, and every unsigned probe logged `webhook_signature_invalid` — the same event a genuine GitHub delivery logs when it's rejected for a rotated/stale secret. Confirmed live: the probe events carried `delivery_id=""` (no `X-GitHub-Delivery`), and the alert **self-recovered** once scanning stopped — classic noise, not a real outage. (It only became visible after the alert-routing fix flipped the notify handle off `@grug-stub`.)

## Acceptance criteria

- [ ] An unsigned request (no `X-Hub-Signature-256`) logs `webhook_unsigned_probe` (info) and does NOT log `webhook_signature_invalid` — so it can't trip the monitor.
- [ ] A request that carried a signature but failed verification (rotated secret / forged delivery) still logs the monitored `webhook_signature_invalid` (warning).
- [ ] Both cases still return 401 (behavior unchanged for the caller).
- [ ] The monitor query is unchanged — it's now precise by construction (only real rejections emit the watched event); no DD facet-filter guesswork.
- [ ] Tests cover both branches; `services/webhook` receiver tests pass.

## Size

**Size:** XS

## Dependencies

- Follows the alerting-routing fix (#297) that made this monitor's output visible in Discord.

## Out of scope

- Rate-limiting / WAF on the public webhook URL (the probes themselves are harmless 401s).
- `main.py` is webhook-only, not a mirrored module — no `services/api` change.
