### PR TITLE
chore: repoint infra-public reusables to verb-first names

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         service: [webhook, api]
-    uses: githumps/infra-public/.github/workflows/_reusable.container-build.yml@41038951557478badb69ca2c34217f75825cfc2e  # infra-public main; bump deliberately
+    uses: githumps/infra-public/.github/workflows/build.container.yml@cd83e5727c0a7b904f780960664a51b3a3a0c685  # infra-public main; bump deliberately
     with:
       runner: ubuntu-24.04-arm
       image: grug-${{ matrix.service }}


### PR DESCRIPTION
## Why

The infra-public reusable workflows were renamed to a consistent verb-first `<verb>.<scope>` scheme (build./check./verify./deploy./ship.) so the step-vs-pipeline tier is obvious. This repoints this repo's pins to the new names + the post-rename SHA. No behavior change — the reusables are byte-identical, only renamed.

## Acceptance criteria

- [ ] Every `_reusable.*` ref points to its new verb-first name
- [ ] Pinned to the post-rename infra-public SHA (cd83e57)
- [ ] No remaining `_reusable.` references

Size: S

## Out of scope

- Behavior/interface changes to the reusables (none).