### PR TITLE
chore(monitors): re-scope Elder-degraded alert to the owned fallback (no credit top-up)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -368,6 +368,19 @@ async worker (`async_dispatch.run_elder_job`) is idempotent on the
   original ran via `elder_job_done`.
 - AWS async retries are disabled (`maximum_retry_attempts=0`) — the worker
   owns idempotency + degrade, so AWS retries would only risk a storm.
+- **Monitor `[grug-webhook] Elder cloud LLMs down — fallback gap`** fires on
+  `code_review_llm_degraded` (BOTH cloud backends — OpenRouter + Poolside —
+  failed for ≥2 reviews in 1h). **The runbook is: do NOT top up credits.**
+  The SaaS backends are unfunded by deliberate choice; topping up
+  OpenRouter/Poolside is an explicit non-strategy. The fix is Elder's owned
+  fallback to the Cave (the operator's self-hosted LLM) (ADR-0005, slices #310 → #316 →
+  #313). Severity is conditional:
+  - **Before the fallback is live:** dropped reviews are a known, accepted
+    gap — the monitor is informational (P4). No action.
+  - **After the fallback is live:** this firing means the Cave ALSO failed
+    (clouds-down is the normal trigger; the fallback should have healed it)
+    — investigate the Cave / the `grug-cave-connector` / the SQS airlock,
+    and the monitor should be restored to P2.
 
 ### Elder prompt A/B experiment (#191)
 

--- a/infra/pulumi/components/dd_monitors.py
+++ b/infra/pulumi/components/dd_monitors.py
@@ -160,27 +160,40 @@ def create_all(
         opts=opts,
     )
 
-    # 3b) Elder LLM degraded — reviews silently dropped. The offload monitor
+    # 3b) Elder LLM degraded — both CLOUD backends down. The offload monitor
     #     above watches the async PLUMBING (enqueue/worker crash); it cannot
-    #     see the failure that actually took Elder down for ~5 days — EVERY
-    #     LLM backend (OpenRouter 402 + Poolside ReadTimeout) failing, which
-    #     is logged at warn as `code_review_llm_degraded` and returns
-    #     gracefully (no crash, no offload failure). Same shape as the poller's
-    #     all-failed monitor: a handled systemic failure needs a LOG alert, not
-    #     a crash/metric one. `>= 2` in 1h ignores a lone transient blip but
-    #     trips on a sustained both-backends-down outage.
+    #     see EVERY LLM backend (OpenRouter + Poolside) failing, which is
+    #     logged at warn as `code_review_llm_degraded` and returns gracefully
+    #     (no crash, no offload failure). `>= 2` in 1h ignores a lone transient
+    #     blip but trips on a sustained both-backends-down outage.
+    #
+    #     RE-SCOPED (ADR-0005): the operator deliberately does NOT fund the
+    #     SaaS backends — topping up OpenRouter/Poolside is an explicit
+    #     non-strategy. The fix is Elder's OWNED fallback to the Cave (the
+    #     operator's self-hosted LLM; slices #310 -> #316 -> #313). So this monitor's
+    #     severity is now CONDITIONAL on whether that fallback is live:
+    #       - BEFORE the fallback ships: both clouds down → reviews dropped is
+    #         a KNOWN, ACCEPTED gap → informational (priority 4), do not page.
+    #       - AFTER the fallback ships: this firing means the Cave ALSO failed
+    #         (clouds down is normal; the fallback is what should have saved
+    #         it) → restore priority=2 and treat as a real outage.
+    #     When #310/#316/#313 land, bump priority back to 2 + update the
+    #     message's "until the fallback is live" framing.
     elder_llm_degraded = datadog.Monitor(
         "grug-webhook-elder-llm-degraded",
         type="log alert",
-        name="[grug-webhook] Elder LLM degraded — reviews dropped (1h)",
+        name="[grug-webhook] Elder cloud LLMs down — fallback gap (1h)",
         message=(
             f"{notify_handle}\n"
-            "Grug Elder could not reach ANY LLM backend (all of OpenRouter + "
-            "Poolside failed) for >= 2 code reviews in the last hour — those "
-            "PRs got NO review, only a neutral 'skipping' check. Check provider "
-            "credits (OpenRouter `http_402` = out of credits) and timeouts "
-            "(Poolside `ReadTimeout`). Invisible to the offload monitor because "
-            "the async path succeeds; only the LLM call fails.\n"
+            "Grug Elder could not reach any CLOUD LLM backend (OpenRouter + "
+            "Poolside both failed) for >= 2 reviews in the last hour. "
+            "**This is expected — the SaaS backends are unfunded by design; do "
+            "NOT top up OpenRouter/Poolside.** The fix is Elder's owned fallback "
+            "to the Cave — the operator's self-hosted LLM (ADR-0005, slices "
+            "#310 -> #316 -> #313). Until that fallback is live these reviews "
+            "are dropped (known gap, informational). ONCE it is live, this "
+            "firing means the Cave ALSO failed — investigate then and restore "
+            "this monitor to P2.\n"
             "Runbook: docs/RUNBOOK.md#elder-async-offload"
         ),
         query=(
@@ -189,7 +202,9 @@ def create_all(
         ),
         tags=_common_tags(env, "grug-webhook"),
         notify_no_data=False,
-        priority=2,
+        # Informational until the cave fallback lands — see comment above.
+        # Restore to 2 when #310/#316/#313 ship.
+        priority=4,
         opts=opts,
     )
 


### PR DESCRIPTION
## Why

The `[grug-webhook] Elder LLM degraded` monitor (P2) instructs the operator to "check provider credits (OpenRouter `http_402` = out of credits)" and top up — but funding the SaaS LLM backends is a deliberate non-strategy. The real fix is Elder's owned fallback to a self-hosted LLM ("the Cave", ADR-0005, slices #310 → #316 → #313). So the monitor was paging toward an action that will never be taken, and at the wrong severity for an accepted gap.

## What changed

- Rename: `Elder LLM degraded — reviews dropped` → `Elder cloud LLMs down — fallback gap`.
- Message: rewritten to say **do NOT top up OpenRouter/Poolside** and point at the owned fallback + ADR-0005.
- **Conditional severity** — `priority` 2 → **4** (informational) *until the fallback ships*; once #310/#316/#313 land, a firing means the Cave **also** failed, so restore to P2. Encoded in the inline comment + message.
- `docs/RUNBOOK.md#elder-async-offload` updated with the same guidance.

## Acceptance criteria

- [ ] Monitor renamed + message no longer mentions topping up credits
- [ ] `priority=4` with an inline note to restore P2 when the fallback ships
- [ ] Runbook documents the conditional severity + no-top-up strategy
- [ ] `pulumi preview` shows an in-place update to the existing monitor (not a replace)

## Size: XS

## Out of scope

The fallback itself (#310/#316/#313) and the fallback-specific monitors (DLQ depth, queue age — #312). This PR only re-scopes the existing degraded-alert.
