### PR TITLE
chore(privacy): scrub personal/private-infra identifiers from the public repo

### DIFF
--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -88,9 +88,9 @@ If anything broke, re-add `.github/workflows/grug.pr-gate.yml` from
 git history and revert step 3's branch protection change. Cutover is
 fully reversible until step 4 lands on default branch.
 
-## Slice 11 — canary on `githumps/infrastructure`
+## Slice 11 — canary on a private repo you own
 
-Use this repo first. Smallest blast radius, you own it, can iterate.
+Use a private repo you own first. Smallest blast radius, you control it, can iterate.
 Steps 1-5 above. Confirm everything green for ~24h before bulk-cutover.
 
 ## Slice 12 — bulk-cutover remaining 9 repos

--- a/docs/NETWORK-TOPOLOGY.md
+++ b/docs/NETWORK-TOPOLOGY.md
@@ -11,7 +11,7 @@ External SaaS the stack depends on (flat dependencies, not topology):
 - **AWS us-east-1** account `317164914846` — Lambda, DDB, KMS, SSM, ECR, CloudWatch Logs
 - **Datadog US1** — APM + Logs + RUM + Monitors + Synthetics
 - **GitHub** — App registration `grug-tribe` (webhook source + OAuth identity provider) + Actions OIDC (deploys)
-- **Pulumi Cloud** — `pulumi_ehumps_me/grug/{dev,prod}` stacks (no passphrase)
+- **Pulumi Cloud** — `<pulumi-org>/grug/{dev,prod}` stacks (no passphrase)
 
 ---
 
@@ -175,7 +175,7 @@ sequenceDiagram
     end
 ```
 
-**Runner-swap gotcha** (memory: `feedback_runner_swap_check_preinstalled_tools`): when iac.deploy was swapped from `srv-unraid-gha` to `ubuntu-latest` (PR #156), the workflow assumed `uv` was preinstalled — true for the self-hosted runner, false for ubuntu-latest. Pulumi silently no-op'd for 24h until PR #166 added an explicit `astral-sh/setup-uv` step.
+**Runner-swap gotcha** (memory: `feedback_runner_swap_check_preinstalled_tools`): when iac.deploy was swapped from `the self-hosted CI runner` to `ubuntu-latest` (PR #156), the workflow assumed `uv` was preinstalled — true for the self-hosted runner, false for ubuntu-latest. Pulumi silently no-op'd for 24h until PR #166 added an explicit `astral-sh/setup-uv` step.
 
 ---
 
@@ -267,15 +267,14 @@ flowchart LR
 | 2026-05-17 | DD APP key leaked into `pulumi preview` output (unwrapped `aws.ssm.get_parameter().value`) | Every SSM read for a secret now `pulumi.Output.secret()`-wrapped before being passed to providers. Memory: `feedback_pulumi_preview_secret_leak_guard` |
 | 2026-05-24 | Design handoff regressions on grug.lol — `/apps/grug` 404 + mailto: CTAs + URL slug `/Grug` | PRs #157 + #160 fixed the symptoms; spec 0012 (Landing) + 3 attesters now block this class of regression in CI |
 | 2026-05-24 | DD APP key per-project SSM path — `/shared/datadog-app-key` cross-repo path was stale after rotation; every `pulumi up` 403'd | Split into `/shared/datadog-app-key/github-grug` so per-repo rotations don't clobber siblings (PR #155) |
-| 2026-05-24 | iac.deploy silently no-op'd for 24h after the `[self-hosted, srv-unraid-gha]` → `ubuntu-latest` runner swap (PR #156) — workflow comment claimed `uv` was preinstalled (true for old runner, false for new) | PR #166 added `astral-sh/setup-uv@v5` (same SHA the infrastructure repo uses). Memory: `feedback_runner_swap_check_preinstalled_tools` |
+| 2026-05-24 | iac.deploy silently no-op'd for 24h after the self-hosted → `ubuntu-latest` runner swap (PR #156) — workflow comment claimed `uv` was preinstalled (true for old runner, false for new) | PR #166 added `astral-sh/setup-uv@v5`. Memory: `feedback_runner_swap_check_preinstalled_tools` |
 | 2026-05-24 | RUM first-light cascade — 5 sequential 403s as each layer surfaced its next missing permission: `rum_apps_*` scopes → `product_analytics_apps_write` scope → `ssm:PutParameter` on `/grug/*` → IAM propagation race | DD UI scope additions (×2) + PR #171 (deploy role grant) + one-shot re-trigger (IAM propagation). RUM live in DD ~14:30 UTC after the cascade cleared |
 
 ---
 
 ## L. Cross-references
 
-- [`infrastructure/docs/network-topology.md`](https://github.com/githumps/infrastructure/blob/main/docs/network-topology.md) — k8s-ts cluster topology (sibling doc; this one is the SaaS-side equivalent)
-- [`infrastructure/docs/PULUMI-TOPOLOGY.md`](https://github.com/githumps/infrastructure/blob/main/docs/PULUMI-TOPOLOGY.md) — cross-repo Pulumi project graph (grug is one of 7 projects)
+- The operator's private infra repo holds the sibling cluster-topology + cross-repo Pulumi-project-graph docs (not linked from this public repo).
 - [`docs/HITL_PREREQUISITES.md`](HITL_PREREQUISITES.md) — every SSM parameter that must exist before first `pulumi up`
 - [`docs/RUNBOOK.md`](RUNBOOK.md) — operational procedures for live grug.lol
 - [`specs/0012-landing/`](../specs/0012-landing/) — Landing IOA spec + 3 grounding attesters (CTAs, install URL, slug)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -120,7 +120,7 @@ Shared across all projects. Coordinate with somatic-scripts before rotating.
 | Webhook returns 403 with `{"Message":null}` (CF) | CF Worker proxied the request but origin Lambda Function URL rejected mismatched Host header | DNS proxied=False (loses CF) OR Worker upload broken — re-run `deploy.sh` |
 | Lambda invocation fails with `entrypoint requires the handler name to be the first argument` | Lambda image is bootstrap (bare AWS Python base) | CI didn't push image OR Pulumi rolled back to `:bootstrap` config. Trigger `gh workflow run iac.deploy.yml` |
 | Pulumi up fails: `script already exists` (CF) | CF Worker manually uploaded but not in Pulumi state | Drop `cloudflare:WorkerScript`/`WorkerRoute` from `__main__.py` (we now manage Worker via `infra/cloudflare/deploy.sh`) |
-| CI fails: `aws: command not found` on srv-unraid-gha | Runner missing tooling | Re-run `ansible-playbook production/playbooks/gha_runner_tooling.yml --limit srv-unraid-gha` from `githumps/infrastructure` |
+| CI fails: `aws: command not found` on the self-hosted CI runner | Runner missing tooling | Re-provision the self-hosted runner's tooling from your private infra repo |
 | CF Worker upload fails: `code 10021: No such module: worker.js` | Upload form-field name doesn't match metadata.main_module | Use `/tmp/worker.js` as path (basename `worker.js` matches main_module) — `deploy.sh` does this |
 
 ## Tear-down + rebuild
@@ -153,7 +153,7 @@ State that lives outside Pulumi (and persists across destroy):
 - **DD APM:** <https://app.datadoghq.com/apm/services?service=grug-webhook>
 - **DD Logs:** <https://app.datadoghq.com/logs?query=service%3Agrug-webhook>
 - **CloudWatch Logs:** `aws logs tail /aws/lambda/grug-webhook --region us-east-1 --since 5m`
-- **Pulumi state:** <https://app.pulumi.com/pulumi_ehumps_me/grug/dev>
+- **Pulumi state:** <https://app.pulumi.com/<pulumi-org>/grug/dev>
 - **CF dashboard:** <https://dash.cloudflare.com/<your-cf-account-id>/workers/services/view/grug-webhook-host-rewrite>
 
 ## Service tags

--- a/docs/adr/0004-rerun-via-sqs.md
+++ b/docs/adr/0004-rerun-via-sqs.md
@@ -13,7 +13,7 @@ Re-run must run the persona's LLM review, which needs the webhook Lambda's 420s 
 Options considered for the hand-off/queue:
 
 - **Fire-and-forget `lambda.invoke(Event)`** (what the #272 offload does today) — no durability/visibility; drops on throttle (the `elder_enqueue_failed` monitor exists precisely because of this). Bad for batch backfill.
-- **Self-hosted k8s worker over Tailscale** — the homelab cluster. Splits the architecture across AWS↔tailnet, adds a network dependency + failure mode, and buys nothing: re-run work is **I/O-bound** (waiting on the LLM HTTP call), not compute-bound, so the cluster's power sits idle.
+- **Self-hosted worker over a private network** — the operator's own cluster. Splits the architecture across AWS↔private-network, adds a network dependency + failure mode, and buys nothing: re-run work is **I/O-bound** (waiting on the LLM HTTP call), not compute-bound, so the cluster's power sits idle.
 - **Kafka / MSK** — built for high-throughput streaming/replay. Massive overkill for dozens of human-triggered jobs/month, at real cost (MSK $$) or ops burden (self-host).
 - **SQS** — managed queue with native Lambda integration, DLQ, FIFO dedup, retry.
 

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -82,8 +82,8 @@ cf_provider = cloudflare.Provider(
 )
 
 # Datadog API key — the shared INFRA DD key (`/infra/datadog/api_key`), the
-# same pair the homelab infrastructure Pulumi uses. Consolidated here (#258
-# follow-up) so grug doesn't maintain its own DD credentials: the prior
+# same pair the operator's shared infrastructure Pulumi uses. Consolidated here
+# (#258 follow-up) so grug doesn't maintain its own DD credentials: the prior
 # `/shared/datadog-*` keys were revoked out-of-band and grug had no reason to
 # carry a separate key. Lambda extension reads DD_API_KEY to ship traces/logs.
 _dd_api_key = aws.ssm.get_parameter(
@@ -546,8 +546,8 @@ cloudflare_dns.create_proxied_cname(
 
 # Datadog monitors (Slice 9 #30). Provider reads DD creds from SSM — the
 # shared INFRA DD app key (`/infra/datadog/app_key`), paired with the infra
-# API key above. One DD key pair for the homelab rather than a grug-specific
-# one (the old per-project `/shared/datadog-app-key/github-grug` was revoked
+# API key above. One shared DD key pair rather than a grug-specific one (the
+# old per-project `/shared/datadog-app-key/github-grug` was revoked
 # out-of-band; consolidating removes a key grug had no reason to own).
 _dd_app_key = aws.ssm.get_parameter(
     name="/infra/datadog/app_key", with_decryption=True,
@@ -559,17 +559,25 @@ _dd_provider = _datadog.Provider(
     api_url="https://api.datadoghq.com/",
 )
 
-# Notification routing → Discord #monitoring-alerts (channel
-# 1501743643965394974 in guild 781626163591249930 — where the homelab's
-# migration-watcher already posts). The old `/grug/dd-notify-handle` was the
-# placeholder `@grug-stub`, which Datadog does not recognise as any target —
-# so EVERY monitor notified into the void (the Elder LLM outage ran ~5 days
-# with no page). Register a real DD webhook integration that POSTs to the
-# pre-existing Discord webhook secret, and route all monitors at it.
-# `@webhook-<name>` is how a DD monitor references a webhook integration entry.
+# Notification routing → a Discord webhook the operator already runs. The old
+# `/grug/dd-notify-handle` was the placeholder `@grug-stub`, which Datadog does
+# not recognise as any target — so EVERY monitor notified into the void (the
+# Elder LLM outage ran ~5 days with no page). Register a real DD webhook
+# integration that POSTs to the pre-existing Discord webhook secret, and route
+# all monitors at it. `@webhook-<name>` is how a DD monitor references a webhook
+# integration entry.
+#
+# The SSM path for that webhook is operator-specific (it embeds a private
+# Discord identifier), so it's read from Pulumi config rather than hardcoded:
+#   pulumi config set grug:discord_alerts_ssm_param /infra/discord/<id>/monitoring-alerts
+# The placeholder default keeps mocked synth green; a real deploy requires the
+# config (a missing SSM param fails fast at `pulumi up`).
+_discord_alerts_ssm_param = (
+    config.get("discord_alerts_ssm_param") or "/infra/discord/monitoring-alerts"
+)
 _discord_webhook_url = pulumi.Output.secret(
     aws.ssm.get_parameter(
-        name="/infra/discord/781626163591249930/monitoring-alerts",
+        name=_discord_alerts_ssm_param,
         with_decryption=True,
     ).value
 )

--- a/infra/pulumi/components/dd_monitors.py
+++ b/infra/pulumi/components/dd_monitors.py
@@ -11,9 +11,8 @@ so it can never drift. Tag matrix is identical across all monitors:
     team:grug
 
 Notification handle = an SNS topic ARN OR a `@user@host`-style mention
-that DD knows how to route. v1 uses Discord webhook because that's the
-existing notify path in the homelab (see
-`infrastructure/production/scripts/llm-analysis-daemon`).
+that DD knows how to route. v1 uses a Discord webhook because that's the
+operator's existing notify path.
 """
 
 from __future__ import annotations

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -105,7 +105,7 @@ def create(
     # creation) + SSM read + CloudWatch + Cloudflare-via-API.
     #
     # SSM read explicitly includes `/shared/*` so CI can fetch the
-    # cross-repo Pulumi access token (per githumps/infrastructure#164
+    # cross-repo Pulumi access token (per the operator's private infra
     # SSM convention — `/shared/<token>` is the cross-cutting namespace).
     deploy_policy_doc = json.dumps(
             {


### PR DESCRIPTION
## Why

`githumps/grug` is a **public** repo and was leaking the operator's private infrastructure across docs + Pulumi comments: the private infra repo name + GitHub links, "homelab" references, the self-hosted runner hostname, the Pulumi org slug, private cluster names, tailnet/Tailscale mentions (in ADR-0004's historical record), and a **Discord guild/channel ID**. None are needed for the public project to make sense.

## What changed

- **Docs** (`NETWORK-TOPOLOGY.md`, `CUTOVER.md`, `RUNBOOK.md`, `adr/0004`): private-infra identifiers → generic ("the operator's private infra repo / cluster / self-hosted runner", `<pulumi-org>`). Removed the two cross-repo links to the private infra repo.
- **`infra/pulumi` comments** (`__main__.py`, `dd_monitors.py`, `oidc_role.py`): "homelab" / private-repo refs abstracted.
- **Discord SSM path** (`__main__.py`): the hardcoded `/infra/discord/<guild-id>/monitoring-alerts` is now `config.get("discord_alerts_ssm_param")` with a neutral placeholder default. The guild ID leaves the source.

## ⚠️ Operator action before next deploy

Set the real Discord-alerts SSM path as config (per stack), or monitor notifications break:
```
pulumi config set grug:discord_alerts_ssm_param /infra/discord/<your-guild-id>/monitoring-alerts
```
(Mocked synth CI stays green via the placeholder; a real `pulumi up` needs the config — a missing SSM param fails fast.)

## Acceptance criteria

- [ ] `git grep` for the private identifiers returns nothing in `docs/` + `infra/`
- [ ] Discord guild/channel IDs no longer appear in source
- [ ] Synth/lint CI green (placeholder default)

## Size: S

## Out of scope

The Elder cave-fallback artifacts (already anonymized separately). Any rename of the SSM parameters themselves (operator-side).
