### PR TITLE
fix(monitors): read Discord webhook from a plain SSM path, not Pulumi config

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -565,19 +565,11 @@ _dd_provider = _datadog.Provider(
 # Elder LLM outage ran ~5 days with no page). Register a real DD webhook
 # integration that POSTs to the pre-existing Discord webhook secret, and route
 # all monitors at it. `@webhook-<name>` is how a DD monitor references a webhook
-# integration entry.
-#
-# The SSM path for that webhook is operator-specific (it embeds a private
-# Discord identifier), so it's read from Pulumi config rather than hardcoded:
-#   pulumi config set grug:discord_alerts_ssm_param /infra/discord/<id>/monitoring-alerts
-# The placeholder default keeps mocked synth green; a real deploy requires the
-# config (a missing SSM param fails fast at `pulumi up`).
-_discord_alerts_ssm_param = (
-    config.get("discord_alerts_ssm_param") or "/infra/discord/monitoring-alerts"
-)
+# integration entry. The webhook URL is an SSM SecureString (set out-of-band,
+# like the other `/infra/*` shared params) — one param, all stacks.
 _discord_webhook_url = pulumi.Output.secret(
     aws.ssm.get_parameter(
-        name=_discord_alerts_ssm_param,
+        name="/infra/discord/monitoring-alerts",
         with_decryption=True,
     ).value
 )


### PR DESCRIPTION
## Why

Reverts the Pulumi-`config` indirection I wrongly added to the Discord webhook lookup in the scrub (#320). The standard here is **SSM-backed config** — one param, all stacks — like every other `/infra/*` param the DD provider reads. Pulumi config is per-stack and non-standard for this repo.

## What changed

- Read the Discord webhook URL from a plain hardcoded SSM path `/infra/discord/monitoring-alerts` (no guild id in the path — leak stays fixed), matching the existing `aws.ssm.get_parameter` pattern.
- Removed the `config.get("discord_alerts_ssm_param")` + placeholder cruft.
- The SSM param `/infra/discord/monitoring-alerts` is already set (SecureString), so `pulumi up` resolves it — no per-stack Pulumi config needed.

## Acceptance criteria

- [ ] No `config.get("discord...")` in `__main__.py`
- [ ] Discord webhook read from `/infra/discord/monitoring-alerts` (no guild id)
- [ ] `pulumi up` (prod) resolves the param and deploys green

## Size: XS

## Out of scope

The original scrub (merged in #320). The Elder cave-fallback feature (#310).