### PR TITLE
fix(iam): grant the deploy role sqs:* on grug-* queues (#310 deploy fix)

### DIFF
--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -204,6 +204,19 @@ def create(
                             "arn:aws:dynamodb:*:*:table/grug-main/*",
                         ],
                     },
+                    {
+                        # SQS for the cave-fallback airlock (#310) + the future
+                        # rerun queue (#305). `pulumi preview` passes with admin
+                        # creds, but the SCOPED deploy role 403'd on
+                        # sqs:CreateQueue at apply time (deploy run 27137871238 —
+                        # an apply-time auth check preview can't see). Scoped to
+                        # grug-* queues, not "*". (lambda:* above already covers
+                        # the event-source mapping; iam:* covers the connector
+                        # user + policy.)
+                        "Effect": "Allow",
+                        "Action": "sqs:*",
+                        "Resource": "arn:aws:sqs:*:*:grug-*",
+                    },
                 ],
             },
         )


### PR DESCRIPTION
## Why

The #310 cave-fallback deploy failed at `pulumi up`: `grug-gha-deploy` got **403 AccessDenied on `sqs:CreateQueue`** for `grug-cave-jobs.fifo`/`grug-cave-results.fifo`. The scoped deploy role had `lambda:*`/`iam:*`/`ssm`/`dynamodb` but **no `sqs`** at all. `pulumi preview` passed locally because it ran with admin creds — the scoped CI role only fails at apply time (same class as the `dynamodb:UpdateTimeToLive` gap already documented in this file). Prod is stable (the queue's dependents didn't apply; the fallback flag defaults off).

## What changed

Add a scoped `sqs:*` statement (`arn:aws:sqs:*:*:grug-*`) to the deploy role — covers #310's airlock now + #305's rerun queue later. `lambda:*` already covers the event-source mapping; `iam:*` covered the connector user (which did create).

## Acceptance criteria

- [ ] `grug-gha-deploy` can `sqs:CreateQueue` / `TagQueue` / `SetQueueAttributes` on `grug-*`
- [ ] Re-deploy creates `grug-cave-jobs.fifo` + `grug-cave-results.fifo` + the event-source mapping
- [ ] The webhook Lambda env update (GRUG_CAVE_JOBS_QUEUE_URL) applies and the deploy goes green
- [ ] Scope stays on `grug-*` queues (not `Resource: "*"`)

## Size: XS

## Out of scope

The cave feature itself (merged #322). Tightening the pre-existing broad `Resource:*` grants (a Slice-1 posture already noted in the file).