### PR TITLE
fix(cave): results-queue visibility 60s -> 420s for the ESM (#310 deploy fix)

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -221,7 +221,12 @@ _cave_results_queue = aws.sqs.Queue(
     fifo_queue=True,
     content_based_deduplication=True,   # results keyed by content; connector needn't mint an id
     message_retention_seconds=1209600,
-    visibility_timeout_seconds=60,
+    # AWS requires an SQS→Lambda event-source-mapping queue's visibility timeout
+    # to be >= the consuming function's timeout. The webhook Lambda is 420s
+    # (shared with the Elder async path), so this MUST be >= 420 or
+    # CreateEventSourceMapping 400s (InvalidParameterValueException). The result
+    # handler itself is fast; this ceiling just satisfies the ESM constraint.
+    visibility_timeout_seconds=420,
     tags={"app": "grug", "service": "grug-cave"},
 )
 # Connector principal (grug-cave-connector, #316): consume jobs + send results,


### PR DESCRIPTION
## Why

The #310 deploy's `grug-cave-results-esm` event-source-mapping create **400'd**: `Queue visibility timeout: 60 seconds is less than Function timeout: 420 seconds`. AWS requires an SQS→Lambda ESM queue's visibility timeout to be **≥ the consuming function's timeout**; the webhook Lambda is 420s but I set the results queue to 60s. The queues + IAM + connector created fine on the prior re-run (the #323 SQS grant worked); only the ESM failed. `pulumi preview` can't catch this — it's an apply-time Lambda validation.

## What changed

`grug-cave-results` `visibility_timeout_seconds` 60 → 420. The result handler itself is fast; this ceiling only satisfies the ESM constraint.

## Acceptance criteria

- [ ] `grug-cave-results.fifo` visibility timeout is 420s (≥ the 420s webhook Lambda)
- [ ] `grug-cave-results-esm` event-source-mapping creates successfully
- [ ] The webhook Lambda env update (GRUG_CAVE_JOBS_QUEUE_URL) applies
- [ ] `pulumi up` (prod) goes fully green

## Size: XS

## Out of scope

The cave feature (merged #322) and the deploy-role SQS grant (merged #323). Tuning the visibility timeout below 420 (would need the webhook Lambda timeout lowered, which the Elder async path needs).