### PR TITLE
feat(rerun): re-run one errored row — SQS + consumer + ↻ button (#305)

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -299,6 +299,31 @@ aws.iam.UserPolicy(
     ),
 )
 
+# --- Re-run queue (#305, ADR-0004): operator backfill for `errored` rows -----
+# api → enqueue, webhook → consume (event-source mapping). FIFO content-dedup on
+# (install,repo,pr,persona) drops a double-click; MessageGroupId=install_id
+# rate-controls a batch backfill. DLQ + redrive (maxReceiveCount=3) so a stuck
+# re-run pages instead of vanishing.
+_rerun_dlq = aws.sqs.Queue(
+    "grug-rerun-jobs-dlq",
+    name="grug-rerun-jobs-dlq.fifo",
+    fifo_queue=True,
+    message_retention_seconds=1209600,  # 14d to inspect a stuck re-run
+    tags={"app": "grug", "service": "grug-rerun"},
+)
+_rerun_jobs_queue = aws.sqs.Queue(
+    "grug-rerun-jobs",
+    name="grug-rerun-jobs.fifo",
+    fifo_queue=True,
+    content_based_deduplication=False,  # api supplies MessageDeduplicationId
+    # >= the webhook Lambda timeout (the SQS→Lambda ESM rule, learned #310).
+    visibility_timeout_seconds=420,
+    redrive_policy=_rerun_dlq.arn.apply(
+        lambda arn: json.dumps({"deadLetterTargetArn": arn, "maxReceiveCount": 3})
+    ),
+    tags={"app": "grug", "service": "grug-rerun"},
+)
+
 webhook = lambda_service.create(
     name="grug-webhook",
     ecr_repo=webhook_ecr,
@@ -455,6 +480,35 @@ aws.lambda_.EventSourceMapping(
     batch_size=1,
 )
 
+# Webhook role: consume the re-run queue (#305). lambda_handler routes the
+# grug-rerun-jobs ESM (by queue ARN) to rerun.handle_rerun_jobs.
+aws.iam.RolePolicy(
+    "grug-webhook-rerun-sqs",
+    role=webhook.role.id,
+    policy=_rerun_jobs_queue.arn.apply(
+        lambda arn: json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+                        "Resource": arn,
+                    }
+                ],
+            }
+        )
+    ),
+)
+aws.lambda_.EventSourceMapping(
+    "grug-rerun-jobs-esm",
+    event_source_arn=_rerun_jobs_queue.arn,
+    function_name=webhook.function.name,
+    # batch_size=1: one job → one re-run. Unlike the cave handler, a failed
+    # rerun job RAISES so the ESM retries (visibility timeout) → DLQ.
+    batch_size=1,
+)
+
 # Webhook role gains kms:Decrypt on the grug-tokens CMK — required so
 # the Lambda runtime can unwrap encrypted env vars at cold start
 # BEFORE the DD extension or our handler boots. Scoped via
@@ -524,6 +578,9 @@ api_lambda = lambda_service.create(
         "GRUG_DOMAIN": domain,
         "GRUG_DDB_TABLE": grug_main_table.name,
         "GRUG_KMS_CMK_ARN": grug_tokens_cmk.arn,
+        # Re-run queue (#305): the api enqueues, the webhook consumes. Unset =>
+        # the rerun endpoint 503s (a real misconfig, not a silent drop).
+        "GRUG_RERUN_QUEUE_URL": _rerun_jobs_queue.url,
         "GRUG_CF_SHARED_SECRET_SSM": cf_secret.ssm_parameter.name,
         "GITHUB_APP_WEBHOOK_SECRET_SSM": secrets["github-app-webhook-secret"].name,
         # OAuth (Slice 3 #24 consumes)
@@ -586,6 +643,27 @@ kms_cmk.grant_use_to_role(
     cmk=grug_tokens_cmk,
     role=api_lambda.role,
     statement_id="grug-api-kms-policy",
+)
+
+# api role: send to the re-run queue (#305). The api enqueues; the webhook
+# consumes via the grug-rerun-jobs ESM above.
+aws.iam.RolePolicy(
+    "grug-api-rerun-sqs",
+    role=api_lambda.role.id,
+    policy=_rerun_jobs_queue.arn.apply(
+        lambda arn: json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["sqs:SendMessage", "sqs:GetQueueAttributes"],
+                        "Resource": arn,
+                    }
+                ],
+            }
+        )
+    ),
 )
 
 # DDB IAM for api Lambda (read+write for v1; tighten per access pattern
@@ -779,6 +857,30 @@ _cave_jobs_age_monitor = _datadog.Monitor(
     tags=[f"env:{env}", "service:grug-webhook", "team:grug"],
     notify_no_data=False,
     priority=4,
+    opts=pulumi.ResourceOptions(provider=_dd_provider),
+)
+
+# Re-run DLQ depth (#305): a job that failed maxReceiveCount times (GitHub fetch
+# failing, or a malformed job) lands here — the operator's re-run didn't
+# complete. Any message is worth a look.
+_rerun_dlq_monitor = _datadog.Monitor(
+    "grug-rerun-dlq-depth",
+    type="metric alert",
+    name="[grug] Re-run DLQ has messages",
+    message=(
+        f"{_dd_notify}\n"
+        "grug-rerun-jobs-dlq has messages — a re-run job exhausted its retries "
+        "(GitHub fetch failing, or a malformed job). The operator's re-run did "
+        "not complete; inspect the DLQ message.\n"
+        "Runbook: docs/RUNBOOK.md#elder-async-offload"
+    ),
+    query=(
+        "max(last_15m):max:aws.sqs.approximate_number_of_messages_visible"
+        "{queuename:grug-rerun-jobs-dlq.fifo} > 0"
+    ),
+    tags=[f"env:{env}", "service:grug-api", "team:grug"],
+    notify_no_data=False,
+    priority=3,
     opts=pulumi.ResourceOptions(provider=_dd_provider),
 )
 

--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -60,6 +60,16 @@ class RepoConfigPayload(BaseModel):
     tpm_enabled: bool = Field(default=True)
 
 
+class RerunRequest(BaseModel):
+    """SPA → api POST .../rerun payload (#305). Keyed by `repo` ("owner/name",
+    what the Activity row carries). `extra='forbid'` 422s typos; `repo` +
+    `persona` are pattern-constrained so junk can't reach the queue."""
+    model_config = ConfigDict(extra="forbid")
+    repo: str = Field(pattern=r"^[^/\s]+/[^/\s]+$")  # owner/name
+    pr_number: int
+    persona: str = Field(pattern=r"^(elder|code_reviewer|chief|tpm)$")
+
+
 def _ensure_can_access(install: dict[str, Any], user: UserIdentity) -> None:
     """Caller must own the install OR be admin. Raises 403 otherwise."""
     if user.role == "admin":
@@ -259,6 +269,43 @@ def list_activity(
         if len(out) >= limit:
             break
     return {"activity": out}
+
+
+@router.post(
+    "/installations/{install_id}/rerun",
+    status_code=status.HTTP_202_ACCEPTED,
+)
+def rerun_check(
+    install_id: int,
+    body: RerunRequest,
+    user: UserIdentity = Depends(require_authenticated),
+) -> dict[str, str]:
+    """Re-run one persona's check on a PR (#305, ADR-0004). Enqueues to
+    `grug-rerun-jobs` and returns 202; the webhook re-runs on the PR's CURRENT
+    head and upserts the verdict (heal-in-place / append). Caller must own the
+    install. The re-run acts with the INSTALL's GitHub token, so it can only
+    touch repos that install can reach (the bound on a user-supplied repo)."""
+    install = get_installation(install_id)
+    if not install:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="install not found")
+    _ensure_can_access(install, user)
+
+    from rerun import enqueue_rerun
+
+    try:
+        enqueue_rerun(
+            install_id=install_id,
+            repo=body.repo,
+            pr_number=body.pr_number,
+            persona=body.persona,
+        )
+    except RuntimeError as e:
+        log.error("rerun_enqueue_misconfigured", extra={"detail": str(e)})
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="re-run queue not available",
+        ) from e
+    return {"status": "queued"}
 
 
 @router.put("/installations/{install_id}/repos/{repo_id}/config")

--- a/services/api/rerun.py
+++ b/services/api/rerun.py
@@ -1,0 +1,62 @@
+# API-ONLY (NOT mirrored): the enqueue side of operator-triggered re-runs
+# (#305, ADR-0004). The webhook has its OWN consumer (services/webhook/rerun.py)
+# — the api never runs the persona dispatch, so the two `rerun.py` files share a
+# name but not content (allowlisted to diverge; not in check-mirrored-files.sh).
+"""Re-run enqueuer (#305, ADR-0004) — the api side.
+
+`POST /installations/{id}/repos/{repo_id}/rerun` validates + calls
+`enqueue_rerun`, which sends a `RerunJob` to `grug-rerun-jobs` (SQS FIFO). The
+api Lambda is 15s and can't run the review itself, so it hands off to the
+durable queue; the webhook consumes + re-runs the persona on the 420s budget.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+import boto3
+
+log = logging.getLogger("grug.api.rerun")
+
+_sqs = boto3.client("sqs")
+
+# Queue URL injected by Pulumi. Unset in local/dev/tests; the endpoint surfaces
+# a 503 (a real misconfig) rather than silently dropping the re-run.
+_RERUN_QUEUE_URL = os.getenv("GRUG_RERUN_QUEUE_URL", "")
+
+SCHEMA_VERSION = 1
+
+
+def enqueue_rerun(
+    *, install_id: int, repo: str, pr_number: int, persona: str
+) -> None:
+    """Send a `RerunJob` to `grug-rerun-jobs`. Raises `RuntimeError` when the
+    queue isn't configured (the endpoint maps it to a 503).
+
+    Keyed by `repo` ("owner/name") — what the Activity row carries. FIFO
+    content-dedup on `(install, repo, pr, persona)` — a double-click within the
+    5-min window is dropped for free (ADR-0004). `head_sha` is deliberately NOT
+    in the key: a re-run always targets the PR's CURRENT head, so two clicks on
+    the same errored row ARE the same job. `MessageGroupId = install_id`
+    serializes a batch backfill at a controlled rate (protects rate limits)."""
+    if not _RERUN_QUEUE_URL:
+        raise RuntimeError("GRUG_RERUN_QUEUE_URL not configured")
+    _sqs.send_message(
+        QueueUrl=_RERUN_QUEUE_URL,
+        MessageBody=json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "install_id": install_id,
+                "repo": repo,
+                "pr_number": pr_number,
+                "persona": persona,
+            }
+        ),
+        MessageGroupId=str(install_id),
+        MessageDeduplicationId=f"{install_id}:{repo}:{pr_number}:{persona}",
+    )
+    log.info(
+        "rerun_enqueued",
+        extra={"install_id": install_id, "repo": repo, "pr": pr_number, "persona": persona},
+    )

--- a/services/api/tests/test_rerun.py
+++ b/services/api/tests/test_rerun.py
@@ -1,0 +1,93 @@
+"""Tests for the re-run enqueuer + endpoint (#305, ADR-0004).
+
+The endpoint enforces: install exists (404), caller owns it (403), queue
+configured (503), else enqueue + 202. The enqueuer sends a FIFO message keyed
+by repo "owner/name" with the (install,repo,pr,persona) dedup id. Deps patched.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+import installations as inst
+import rerun
+from adapters.user_store import UserIdentity
+
+
+def _user(user_id="100", role="user"):
+    return UserIdentity(
+        github_user_id=user_id, login="evan", role=role, tier="free",
+        allowlisted=True, created_at="",
+        allowlisted_at=None, allowlisted_by=None,
+    )
+
+
+def _install(owner_id="100"):
+    return {"install_id": 11, "installed_by_user_id": owner_id}
+
+
+# --- enqueuer -------------------------------------------------------------
+
+
+def test_enqueue_rerun_sends_fifo_with_content_dedup(monkeypatch):
+    monkeypatch.setattr(rerun, "_RERUN_QUEUE_URL", "https://sqs/grug-rerun-jobs.fifo")
+    with patch.object(rerun._sqs, "send_message") as send:
+        rerun.enqueue_rerun(install_id=11, repo="myorg/myrepo", pr_number=7, persona="elder")
+    kw = send.call_args.kwargs
+    assert kw["QueueUrl"] == "https://sqs/grug-rerun-jobs.fifo"
+    assert kw["MessageGroupId"] == "11"  # per-install serialization
+    # Dedup on (install,repo,pr,persona) — NO head_sha (re-run targets current head).
+    assert kw["MessageDeduplicationId"] == "11:myorg/myrepo:7:elder"
+    body = json.loads(kw["MessageBody"])
+    assert body == {"schema_version": 1, "install_id": 11, "repo": "myorg/myrepo", "pr_number": 7, "persona": "elder"}
+
+
+def test_enqueue_rerun_raises_when_queue_unconfigured(monkeypatch):
+    monkeypatch.setattr(rerun, "_RERUN_QUEUE_URL", "")
+    with pytest.raises(RuntimeError):
+        rerun.enqueue_rerun(install_id=1, repo="a/b", pr_number=3, persona="elder")
+
+
+# --- endpoint -------------------------------------------------------------
+
+_BODY = inst.RerunRequest(repo="myorg/myrepo", pr_number=7, persona="elder")
+
+
+def test_rerun_endpoint_unknown_install_404():
+    with patch("installations.get_installation", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            inst.rerun_check(install_id=999, body=_BODY, user=_user())
+    assert exc.value.status_code == 404
+
+
+def test_rerun_endpoint_not_owner_403():
+    with patch("installations.get_installation", return_value=_install(owner_id="999")):
+        with pytest.raises(HTTPException) as exc:
+            inst.rerun_check(install_id=11, body=_BODY, user=_user(user_id="100"))
+    assert exc.value.status_code == 403
+
+
+def test_rerun_endpoint_enqueues_and_returns_queued():
+    with patch("installations.get_installation", return_value=_install(owner_id="100")), \
+         patch("rerun.enqueue_rerun") as enq:
+        out = inst.rerun_check(install_id=11, body=_BODY, user=_user(user_id="100"))
+    enq.assert_called_once_with(install_id=11, repo="myorg/myrepo", pr_number=7, persona="elder")
+    assert out == {"status": "queued"}
+
+
+def test_rerun_endpoint_503_when_queue_unconfigured():
+    with patch("installations.get_installation", return_value=_install(owner_id="100")), \
+         patch("rerun.enqueue_rerun", side_effect=RuntimeError("no queue")):
+        with pytest.raises(HTTPException) as exc:
+            inst.rerun_check(install_id=11, body=_BODY, user=_user(user_id="100"))
+    assert exc.value.status_code == 503
+
+
+def test_rerun_request_rejects_junk_persona_and_repo():
+    with pytest.raises(Exception):
+        inst.RerunRequest(repo="myorg/myrepo", pr_number=1, persona="carrier-pigeon")
+    with pytest.raises(Exception):
+        inst.RerunRequest(repo="not-a-slug", pr_number=1, persona="elder")  # needs owner/name

--- a/services/webhook/lambda_handler.py
+++ b/services/webhook/lambda_handler.py
@@ -31,28 +31,41 @@ def handler(event: Any, context: Any) -> Any:
         # HTTP (sync) cold-start path.
         from async_dispatch import run_elder_job
         return run_elder_job(event)
-    if _is_sqs_event(event):
-        # SQS event-source mapping delivers the Cave connector's results
-        # (grug-cave-results) as a raw `Records` event — Mangum can't parse
-        # it, so route to the fallback result handler FIRST (#310, ADR-0005).
+    # Two SQS event-source mappings reach this Lambda, discriminated by which
+    # queue the batch came from (the `eventSourceARN`): the Cave connector's
+    # results (#310) and operator-triggered re-runs (#305). Mangum can't parse
+    # a raw `Records` event, so route SQS FIRST.
+    sqs_kind = _sqs_queue_kind(event)
+    if sqs_kind == "cave-results":
         from cave_fallback import handle_fallback_result
         return handle_fallback_result(event)
+    if sqs_kind == "rerun-jobs":
+        from rerun import handle_rerun_jobs
+        return handle_rerun_jobs(event)
     return _http_handler(event, context)
 
 
-def _is_sqs_event(event: Any) -> bool:
-    """True for an SQS event-source-mapping batch (`Records[*].eventSource ==
-    'aws:sqs'`). Defensive against non-dict events + empty/foreign Records so a
-    Function-URL HTTP event (which has no `Records`) never misroutes here."""
+def _sqs_queue_kind(event: Any) -> str | None:
+    """Classify an SQS event-source-mapping batch by its source queue:
+    `"cave-results"`, `"rerun-jobs"`, or `None` (not SQS / unknown queue → fall
+    through to Mangum). Requires EVERY record to be `aws:sqs` from the SAME
+    queue, so a Function-URL HTTP event (no `Records`) or a mixed/foreign batch
+    never misroutes."""
     if not isinstance(event, dict):
-        return False
+        return None
     records = event.get("Records")
     if not isinstance(records, list) or not records:
-        return False
-    # peer-review (OpenRouter + Poolside + Spark, CONFIRMED 3x): require EVERY
-    # record to be SQS, not just the first. batch_size=1 makes this moot today,
-    # but a future ESM reconfig (batch>1) or a mixed batch must not misroute a
-    # foreign record into handle_fallback_result.
-    return all(
+        return None
+    if not all(
         isinstance(r, dict) and r.get("eventSource") == "aws:sqs" for r in records
-    )
+    ):
+        return None
+    arns = {r.get("eventSourceARN", "") for r in records}
+    if len(arns) != 1:
+        return None  # a mixed batch (shouldn't happen) — don't guess
+    arn = arns.pop()
+    if arn.endswith(":grug-cave-results.fifo"):
+        return "cave-results"
+    if arn.endswith(":grug-rerun-jobs.fifo"):
+        return "rerun-jobs"
+    return None

--- a/services/webhook/rerun.py
+++ b/services/webhook/rerun.py
@@ -1,0 +1,127 @@
+# WEBHOOK-ONLY (NOT mirrored): the SQS consumer for operator-triggered re-runs
+# (#305, ADR-0004). The api service ENQUEUES (services/api/rerun.py); only the
+# webhook image carries the persona-dispatch + GitHub-App machinery, so the
+# consumer lives here — same split as the cave fallback (cave_fallback.py).
+"""Re-run consumer (#305, ADR-0004) — grug's backfill for a dropped/`errored`
+review.
+
+`lambda_handler.handler` routes the `grug-rerun-jobs` SQS event-source mapping
+here (discriminated from `grug-cave-results` by queue ARN). For each job the
+consumer fetches the PR's **current** head + diff and re-runs the named persona
+via the unchanged `dispatch_code_review`, which posts the check-run and upserts
+the `CheckVerdictRecord` — healing the `errored` row in place if the head is
+unchanged, appending a fresh row if the PR moved on.
+
+Failure semantics differ from the cave result handler ON PURPOSE: a transient
+infra failure (GitHub 5xx, fetch error) **raises** so the ESM retries via the
+visibility timeout and, after `maxReceiveCount`, lands in the DLQ — the
+operator-visible "this re-run is stuck" signal. (The *review* failing again —
+another LLM outage — is NOT an error: `dispatch_code_review` degrades to a
+published neutral/`errored` row and returns normally, so the job is "done".)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from adapters.install_store import get_repo_config  # type: ignore
+from github_app_auth import with_install_token_retry
+from personas.code_reviewer.dispatch import dispatch_code_review
+
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.rerun")
+
+_GH_API = "https://api.github.com"
+_FETCH_TIMEOUT = 15.0
+
+# Personas the re-run can drive today. The motivating case (the 2026-06 Elder
+# outage) is the LLM-driven code reviewer; the static TPM check doesn't error
+# from outages, so its re-run is a deliberate follow-up (logged + skipped here).
+_CODE_REVIEWER = frozenset({"elder", "code_reviewer"})
+
+
+def _gh_get(token: str, url: str) -> dict[str, Any]:
+    resp = httpx.get(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+        },
+        timeout=_FETCH_TIMEOUT,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _run_one(body: str) -> str:
+    """Re-run ONE job. Raises on a malformed message or an infra fetch failure
+    (→ ESM retry → DLQ). Returns a short status for the batch summary log.
+
+    Keyed by `repo` ("owner/name") — what the Activity row (the trigger) carries
+    — NOT a repo_id; the repo_id (for the RepoConfig lookup) is derived from the
+    PR's `base.repo.id` in the same fetch."""
+    job = json.loads(body)  # malformed → JSONDecodeError → retry → DLQ
+    install_id = int(job["install_id"])
+    repo_full = str(job["repo"])  # "owner/name"
+    pr_number = int(job["pr_number"])
+    persona = str(job.get("persona", "elder"))
+
+    if persona not in _CODE_REVIEWER:
+        # Not an infra failure — don't retry/DLQ a persona we don't drive yet.
+        log.info(
+            "rerun_unsupported_persona",
+            extra={"persona": persona, "repo": repo_full, "pr": pr_number},
+        )
+        return "skipped_persona"
+
+    owner, _, repo_name = repo_full.partition("/")
+    # Fetch the PR's CURRENT head (+ the repo id, for RepoConfig). A 5xx/
+    # RequestError raises → ESM retry → DLQ. with_install_token_retry refreshes
+    # a stale token once.
+    pr = with_install_token_retry(
+        install_id,
+        lambda tok: _gh_get(
+            tok, f"{_GH_API}/repos/{owner}/{repo_name}/pulls/{pr_number}"
+        ),
+    )
+    repo_id = int(pr["base"]["repo"]["id"])
+
+    payload = {
+        "action": "rerun",  # not a real GH action; dispatch only logs it
+        "installation": {"id": install_id},
+        "repository": {"id": repo_id, "name": repo_name, "owner": {"login": owner}},
+        "pull_request": {"number": pr_number, "head": {"sha": pr["head"]["sha"]}},
+    }
+    blocking = bool(get_repo_config(install_id, repo_id).get("code_reviewer_blocking", False))
+    # dispatch_code_review never raises a wire exception: it fetches the diff,
+    # re-runs Elder, dual-publishes, and upserts the verdict (heal-in-place on an
+    # unchanged head, append on a moved-on PR). A repeat LLM outage degrades to a
+    # published `errored` row — the job still completed.
+    dispatch_code_review(payload, blocking=blocking)
+    log.info(
+        "rerun_dispatched",
+        extra={"repo": f"{owner}/{repo_name}", "pr": pr_number, "persona": persona},
+    )
+    return "dispatched"
+
+
+def handle_rerun_jobs(event: dict[str, Any]) -> dict[str, int]:
+    """Consume `grug-rerun-jobs` SQS records (event-source mapping, batch 1).
+
+    Unlike the cave result handler, a failed job is allowed to RAISE so the ESM
+    retries it (visibility timeout) → DLQ after `maxReceiveCount`. With batch
+    size 1 each invocation owns exactly one message, so a raise re-drives only
+    that job. Returns a summary for the structured log on the success path."""
+    records = event.get("Records", []) if isinstance(event, dict) else []
+    statuses: list[str] = []
+    for rec in records:
+        body = rec.get("body", "") if isinstance(rec, dict) else ""
+        statuses.append(_run_one(body))  # may raise → ESM retry → DLQ
+    return {
+        "records": len(records),
+        "dispatched": statuses.count("dispatched"),
+        "skipped": statuses.count("skipped_persona"),
+    }

--- a/services/webhook/tests/test_lambda_handler_routing.py
+++ b/services/webhook/tests/test_lambda_handler_routing.py
@@ -41,15 +41,47 @@ def test_non_dict_event_routes_to_mangum():
     assert out == "ok"
 
 
-def test_sqs_event_routes_to_fallback_result_handler():
-    # #310 — the Cave connector's results arrive as an aws:sqs Records batch.
-    event = {"Records": [{"eventSource": "aws:sqs", "body": "{}"}]}
+_CAVE_ARN = "arn:aws:sqs:us-east-1:1:grug-cave-results.fifo"
+_RERUN_ARN = "arn:aws:sqs:us-east-1:1:grug-rerun-jobs.fifo"
+
+
+def test_cave_results_sqs_event_routes_to_fallback_handler():
+    # #310 — the Cave connector's results (discriminated by queue ARN, #305).
+    event = {"Records": [{"eventSource": "aws:sqs", "eventSourceARN": _CAVE_ARN, "body": "{}"}]}
     with patch("cave_fallback.handle_fallback_result", return_value={"healed": 1}) as mock_h, \
+         patch("rerun.handle_rerun_jobs") as mock_r, \
          patch.object(lh, "_http_handler") as mock_http:
         out = lh.handler(event, context=None)
     mock_h.assert_called_once_with(event)
+    mock_r.assert_not_called()
     mock_http.assert_not_called()  # Mangum never sees the raw SQS event
     assert out == {"healed": 1}
+
+
+def test_rerun_jobs_sqs_event_routes_to_rerun_consumer():
+    # #305 — re-run jobs go to the rerun consumer, NOT the cave handler.
+    event = {"Records": [{"eventSource": "aws:sqs", "eventSourceARN": _RERUN_ARN, "body": "{}"}]}
+    with patch("rerun.handle_rerun_jobs", return_value={"records": 1}) as mock_r, \
+         patch("cave_fallback.handle_fallback_result") as mock_h, \
+         patch.object(lh, "_http_handler") as mock_http:
+        out = lh.handler(event, context=None)
+    mock_r.assert_called_once_with(event)
+    mock_h.assert_not_called()
+    mock_http.assert_not_called()
+    assert out == {"records": 1}
+
+
+def test_unknown_queue_sqs_event_falls_through_to_mangum():
+    # An SQS event from a queue we don't recognize must not guess a handler.
+    event = {"Records": [{"eventSource": "aws:sqs", "eventSourceARN": "arn:aws:sqs:us-east-1:1:some-other.fifo", "body": "{}"}]}
+    with patch("cave_fallback.handle_fallback_result") as mock_h, \
+         patch("rerun.handle_rerun_jobs") as mock_r, \
+         patch.object(lh, "_http_handler", return_value="ok") as mock_http:
+        out = lh.handler(event, context=None)
+    mock_h.assert_not_called()
+    mock_r.assert_not_called()
+    mock_http.assert_called_once()
+    assert out == "ok"
 
 
 def test_non_sqs_records_event_falls_through_to_mangum():

--- a/services/webhook/tests/test_rerun.py
+++ b/services/webhook/tests/test_rerun.py
@@ -1,0 +1,85 @@
+"""Tests for the re-run consumer (#305, ADR-0004).
+
+External behavior: a job (keyed by repo "owner/name") re-fetches the PR's
+current head and dispatches the named persona; an unsupported persona is
+skipped (not retried); an infra failure RAISES so the ESM retries → DLQ.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import rerun
+
+
+def _job(**over) -> str:
+    d = {"schema_version": 1, "install_id": 11, "repo": "myorg/myrepo", "pr_number": 7, "persona": "elder"}
+    d.update(over)
+    return json.dumps(d)
+
+
+def _event(*bodies) -> dict:
+    return {"Records": [{"eventSource": "aws:sqs", "body": b} for b in bodies]}
+
+
+def _pr_response(head_sha="abc123", repo_id=222):
+    pr = MagicMock(spec=httpx.Response)
+    pr.raise_for_status = MagicMock()
+    pr.json = MagicMock(return_value={
+        "number": 7,
+        "head": {"sha": head_sha},
+        "base": {"repo": {"id": repo_id}},
+    })
+    return pr
+
+
+def test_rerun_dispatches_persona_on_current_head():
+    with patch.object(rerun, "with_install_token_retry", side_effect=lambda iid, fn: fn("tok")), \
+         patch("httpx.get", return_value=_pr_response(head_sha="deadbeef", repo_id=222)), \
+         patch.object(rerun, "get_repo_config", return_value={"code_reviewer_blocking": False}), \
+         patch.object(rerun, "dispatch_code_review") as disp:
+        out = rerun.handle_rerun_jobs(_event(_job()))
+    assert out == {"records": 1, "dispatched": 1, "skipped": 0}
+    payload, kwargs = disp.call_args.args[0], disp.call_args.kwargs
+    # Re-run targets the PR's CURRENT head (fetched), not the errored row's.
+    assert payload["pull_request"]["head"]["sha"] == "deadbeef"
+    assert payload["repository"]["owner"]["login"] == "myorg"  # from the repo string
+    assert payload["repository"]["name"] == "myrepo"
+    assert payload["repository"]["id"] == 222  # from pr.base.repo.id
+    assert payload["installation"]["id"] == 11
+    assert kwargs["blocking"] is False
+
+
+def test_rerun_blocking_flag_from_repo_config():
+    with patch.object(rerun, "with_install_token_retry", side_effect=lambda iid, fn: fn("tok")), \
+         patch("httpx.get", return_value=_pr_response()), \
+         patch.object(rerun, "get_repo_config", return_value={"code_reviewer_blocking": True}) as cfg, \
+         patch.object(rerun, "dispatch_code_review") as disp:
+        rerun.handle_rerun_jobs(_event(_job()))
+    cfg.assert_called_once_with(11, 222)  # repo_id derived from the PR fetch
+    assert disp.call_args.kwargs["blocking"] is True
+
+
+def test_rerun_skips_unsupported_persona_without_dispatch():
+    with patch.object(rerun, "dispatch_code_review") as disp, \
+         patch("httpx.get") as get:
+        out = rerun.handle_rerun_jobs(_event(_job(persona="chief")))
+    assert out == {"records": 1, "dispatched": 0, "skipped": 1}
+    disp.assert_not_called()
+    get.assert_not_called()  # never even fetches for a persona we don't drive
+
+
+def test_rerun_raises_on_github_fetch_failure_so_esm_retries():
+    # An infra failure must propagate → ESM retry (visibility timeout) → DLQ.
+    with patch.object(rerun, "with_install_token_retry",
+                      side_effect=httpx.RequestError("github down")):
+        with pytest.raises(httpx.RequestError):
+            rerun.handle_rerun_jobs(_event(_job()))
+
+
+def test_rerun_raises_on_malformed_message():
+    with pytest.raises(json.JSONDecodeError):
+        rerun.handle_rerun_jobs(_event("not json"))  # → DLQ after retries

--- a/specs/DESIGN.md
+++ b/specs/DESIGN.md
@@ -74,6 +74,17 @@ When **both** cloud LLM backends fail (`review_diff` → `kind=all_failed`), Eld
 | **`enqueue_fallback` (producer)** | `cave_fallback.enqueue_fallback` (webhook-only). Called from `dispatch_code_review` **only** when `llm_response.kind=="all_failed"` AND `secrets_loader.get_fallback_enabled()` is true (SSM `/grug/elder-fallback-enabled`, fallback-safe → `false`). `SendMessage` to `grug-cave-jobs` with `MessageDeduplicationId` from `(install,repo,pr,persona)` + `MessageGroupId=install_id`. **Best-effort / never raises** — a SendMessage failure logs `elder_fallback_enqueue_failed` and is swallowed (the degraded `errored` verdict was already published; the fallback re-triggers on the next push). The verdict stays `errored` until healed (the "no lies" rule). |
 | **`handle_fallback_result` (consumer)** | `cave_fallback.handle_fallback_result` (webhook-only). `lambda_handler.handler` routes the `aws:sqs` event (a `Records` list with `eventSource=="aws:sqs"`) to it **before** Mangum (which can't parse a non-HTTP event), alongside the existing `grug_async_job` sentinel. Parses a `FallbackResult`, `post_check_run` with the connector findings, then `record_check_verdict` — which upserts idempotently per `(persona, head_sha)`, **healing `errored` → `reviewed`** for the current head (a moved-on PR appends a fresh row). **Never raises back to the Lambda** (a raise would retry-storm the event-source mapping); a malformed/degraded result is logged and dropped. |
 
+## Re-run errored rows — SQS backfill (#305, ADR-0004)
+
+grug's backfill for a dropped/`errored` review (the 2026-06 Elder outage left reviews unre-runnable — webhook redelivery is a `claim_delivery` no-op). Reuses the cave SQS scaffolding + deploy-role grants.
+
+| Term | Definition |
+|---|---|
+| **`grug-rerun-jobs` (+ DLQ)** | SQS **FIFO** queue + DLQ (redrive `maxReceiveCount=3`, visibility 420s). api → enqueue (`rerun.enqueue_rerun`), webhook → consume (event-source mapping). Content-dedup on `(install, repo, pr, persona)` — a double-click drops; `MessageGroupId=install_id` rate-controls a batch backfill. DLQ-depth DD monitor. Keyed by **`repo`** ("owner/name", what the Activity row carries) — NOT a repo_id, which the verdict record doesn't store. |
+| **`POST /installations/{id}/rerun`** (api) | `{repo, pr_number, persona}` → **202** + enqueue. Auth via `_ensure_can_access` (owns install / admin). 503 if the queue isn't configured. The api Lambda is 15s, so it hands off to the durable queue; the webhook runs the review on its 420s budget. `RerunRequest` pattern-constrains `repo` + `persona` (422 junk). |
+| **`rerun.handle_rerun_jobs`** (webhook) | `lambda_handler` routes the `grug-rerun-jobs` ESM here (discriminated from `grug-cave-results` by queue ARN). Fetches the PR's CURRENT head (+ `base.repo.id` for RepoConfig) and re-runs the named persona via the unchanged `dispatch_code_review` — which upserts the verdict (heal-in-place on an unchanged head, append on a moved-on PR). Unlike the cave handler, a transient infra failure **RAISES** so the ESM retries (visibility) → DLQ; a repeat LLM outage degrades (published `errored`) and the job is "done". Code-reviewer persona only today; TPM rerun is a follow-up (the static check doesn't error from outages). |
+| **`↻` re-run button** (web) | On **`errored`** Activity rows only. Click → `RE-RUNNING…` + `useRerun` POST; the feed refreshes ~4s later to pick up the healed verdict. |
+
 ## Enforcement concepts
 
 | Term | Definition |

--- a/web/src/lib/installations.ts
+++ b/web/src/lib/installations.ts
@@ -151,3 +151,23 @@ export function useSetRepoConfig(installId: number) {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["installations", installId, "repos"] }),
   });
 }
+
+// Re-run one persona's check on a PR (#305). The api 202s + enqueues; the new
+// verdict lands asynchronously (webhook consumer), so we refresh the Activity
+// feed shortly after to pick up the healed row.
+export function useRerun(installId: number | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { repo: string; pr_number: number; persona: string }) =>
+      api(`/api/v1/installations/${installId}/rerun`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(vars),
+      }),
+    onSuccess: () =>
+      setTimeout(
+        () => qc.invalidateQueries({ queryKey: ["installations", installId, "activity"] }),
+        4000,
+      ),
+  });
+}

--- a/web/src/routes/Dashboard.tsx
+++ b/web/src/routes/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   useFixEnforcement,
   useSetRepoConfig,
   useActivity,
+  useRerun,
   type Repo,
 } from "../lib/installations";
 import "./dashboard-grug.css";
@@ -504,6 +505,16 @@ function ActivityPanel({ show, installId }: { show: boolean; installId?: number 
   // empty state — never fabricated.
   const activity = useActivity(installId, filter);
   const rows = activity.data?.activity ?? [];
+  // #305: re-run an errored row. Track which rows are mid-re-run so the ↻
+  // becomes RE-RUNNING until the feed refreshes with the healed verdict.
+  const rerun = useRerun(installId);
+  const [rerunning, setRerunning] = useState<Set<string>>(new Set());
+  const _rerunKey = (a: { repo: string; pr_number: number; persona: string }) =>
+    `${a.repo}#${a.pr_number}#${a.persona}`;
+  const doRerun = (a: { repo: string; pr_number: number; persona: string }) => {
+    setRerunning((s) => new Set(s).add(_rerunKey(a)));
+    rerun.mutate({ repo: a.repo, pr_number: a.pr_number, persona: a.persona });
+  };
   return (
     <section className={`panel${show ? " show" : ""}`}>
       <div className="panel-head">
@@ -528,6 +539,11 @@ function ActivityPanel({ show, installId }: { show: boolean; installId?: number 
               <div className="who2"><b>{_PERSONA_LABEL[a.persona] ?? a.persona}</b> <span className="repo2">{a.repo} · #{a.pr_number}</span><span className="msg">{a.summary}</span></div>
               <span className={`verdict ${a.verdict}`}>{a.verdict.toUpperCase()}</span>
               <span className="ago mono">{a.head_sha.slice(0, 7)}</span>
+              {a.verdict === "errored" && (
+                rerunning.has(_rerunKey(a))
+                  ? <span className="rerunning mono" title="Re-run queued">RE-RUNNING…</span>
+                  : <button className="rerun-btn" title="Re-run this check" aria-label="Re-run" onClick={() => doRerun(a)}>↻</button>
+              )}
             </div>
           ))}
           {!activity.isLoading && !activity.isError && rows.length === 0 && (

--- a/web/src/routes/dashboard-grug.css
+++ b/web/src/routes/dashboard-grug.css
@@ -277,3 +277,18 @@
   .grug-dash .plan-grid > div{ border-right:none; border-bottom:2px solid var(--ink); }
   .grug-dash .userchip .who{ display:none; }
 }
+
+/* #305 — re-run an errored Activity row */
+.afeed-row .rerun-btn {
+  background: none;
+  border: 1px solid var(--line, #333);
+  color: var(--muted, #888);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 2px 6px;
+  margin-left: 6px;
+}
+.afeed-row .rerun-btn:hover { color: var(--ink, #eee); border-color: var(--ink, #eee); }
+.afeed-row .rerunning { color: var(--amber, #e0a030); font-size: 11px; margin-left: 6px; letter-spacing: 0.5px; }


### PR DESCRIPTION
## Summary

Re-run **one** errored Activity row end-to-end (#305, ADR-0004) — grug's backfill for a dropped review (the 2026-06 Elder outage left failed reviews unre-runnable, since webhook redelivery is a `claim_delivery` no-op). Four surfaces, reusing the cave SQS scaffolding + deploy-role grants: a FIFO queue + DLQ, an api enqueue endpoint, a webhook SQS consumer that re-runs the persona on the PR's current head, and a `↻` button on errored rows.

## What changed

- **Infra:** `grug-rerun-jobs` FIFO + DLQ (`maxReceiveCount=3`) + IAM (api enqueue / webhook consume) + a 2nd webhook ESM + a DLQ-depth DD monitor. The deploy-role `sqs:*` from #310 already covers `grug-rerun-*`.
- **API:** `POST /installations/{id}/rerun {repo, pr_number, persona}` → 202 + enqueue; `_ensure_can_access` auth; 503 on misconfig. Keyed by `repo` ("owner/name", what the Activity row carries — the verdict record has no `repo_id`).
- **Webhook:** `lambda_handler` now routes the two SQS sources by **queue ARN**; the consumer re-fetches the PR's current head (+ `base.repo.id`) and re-runs via the unchanged `dispatch_code_review` (upsert/heal). It **raises** on infra failure → ESM retry → DLQ (opposite of the never-raise cave handler).
- **Web:** `↻` on `errored` rows → `RE-RUNNING…` → feed refresh (`useRerun`).

## Test plan

- [ ] Enqueuer: FIFO message with `(install,repo,pr,persona)` dedup id + `MessageGroupId=install_id`; raises when the queue URL is unset
- [ ] Endpoint: 404 unknown install, 403 not-owner, 503 queue-unconfigured, 202 + enqueue on success; junk `repo`/`persona` 422
- [ ] Consumer: re-fetches the PR's CURRENT head and dispatches with the repo's blocking flag; unsupported persona skipped (no retry); infra failure RAISES (→ DLQ); malformed message raises
- [ ] Routing: `grug-rerun-jobs` ARN → consumer, `grug-cave-results` ARN → cave handler, unknown queue → Mangum
- [ ] 20 backend tests pass; web typecheck clean; temper 18/18; mirror OK; `pulumi preview` clean

## Size: L

## Out of scope

TPM-persona re-run (the static check doesn't error from outages — a follow-up); the "Re-run all errored" batch button (#306); frontend unit tests (no web test harness exists).

closes #305
