### PR TITLE
[grug] fix(tpm): add gh subprocess timeouts + guard json.loads in tpm.py

### DIFF
--- a/scripts/tpm.py
+++ b/scripts/tpm.py
@@ -45,6 +45,11 @@ POOLSIDE_BASE = "https://inference.poolside.ai/v1"
 POOLSIDE_MODEL = "poolside/laguna-m.1"
 POOLSIDE_TIMEOUT_S = 30
 
+# Wall-clock cap for any `gh` CLI invocation. A hung `gh` (network stall,
+# upstream GitHub degradation) must not block the persona run until the
+# Actions job timeout reaps it — fail fast with a clear error instead.
+GH_TIMEOUT_S = 60
+
 
 # ─── DoR static checks ───────────────────────────────────────────────────
 
@@ -59,10 +64,24 @@ class DoRCheck:
 def _gh(*args: str, json_out: bool = False) -> Any:
     """gh CLI wrapper."""
     cmd = ["gh", *args]
-    out = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    try:
+        out = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, timeout=GH_TIMEOUT_S
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"gh {args} timed out after {GH_TIMEOUT_S}s"
+        ) from exc
     if out.returncode != 0:
         raise RuntimeError(f"gh {args} failed: {out.stderr.strip()}")
-    return json.loads(out.stdout) if json_out else out.stdout
+    if not json_out:
+        return out.stdout
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"gh {args} returned non-JSON output: {out.stdout!r}"
+        ) from exc
 
 
 def fetch_pr(repo: str, pr_number: int) -> dict[str, Any]:
@@ -550,6 +569,7 @@ def upsert_comment(repo: str, pr_number: int, body: str) -> None:
             ],
             check=True,
             capture_output=True,
+            timeout=GH_TIMEOUT_S,
         )
     else:
         subprocess.run(
@@ -564,6 +584,7 @@ def upsert_comment(repo: str, pr_number: int, body: str) -> None:
             ],
             check=True,
             capture_output=True,
+            timeout=GH_TIMEOUT_S,
         )
 
 


### PR DESCRIPTION
## Why

`scripts/tpm.py` shelled out to `gh` via `subprocess.run(...)` with no `timeout=`, so a hung `gh` (network stall / GitHub degradation) blocked the TPM persona run until the Actions job timeout reaped it — delaying or dropping PR Definition-of-Ready feedback. The `_gh` wrapper also parsed output with an unguarded `json.loads`, crashing the whole run with an opaque `JSONDecodeError` on non-JSON output.

This change makes **every** `gh` `subprocess.run` call in the file pass an explicit `timeout=GH_TIMEOUT_S` (60s) and surfaces `TimeoutExpired` as a clear `RuntimeError`:
- `_gh` wrapper (`scripts/tpm.py:64`) — timeout + `TimeoutExpired` handling + guarded `json.loads`.
- `upsert_comment` PATCH path (`scripts/tpm.py:560`) — timeout added.
- `upsert_comment` POST path (`scripts/tpm.py:574`) — timeout added.

## Acceptance criteria

- All `subprocess.run` calls to `gh` in `tpm.py` pass an explicit `timeout=` (60s via the shared `GH_TIMEOUT_S` constant).
- `subprocess.TimeoutExpired` is handled with a clear error instead of an opaque traceback.
- `json.loads(out.stdout)` is guarded so malformed `gh` output raises a contextual error (raw stdout included) instead of a bare `JSONDecodeError`.
- Happy-path behavior of `tpm.py` is unchanged.

Size: S

## Out of scope

- Migrating `tpm.py` logic into the SaaS (#25).
- The already-guarded JSON parse at `tpm.py:354`.

Closes #317

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8zkq1aYDrFGx3JJaSNBFU)_