### PR TITLE
[grug] fix(api): cap _resolve_repo pagination at 10 pages

### DIFF
--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -544,7 +544,13 @@ def fix_enforcement(
 def _resolve_repo(
     token: str, install_id: int, repo_id: int,
 ) -> tuple[str, str] | None:
-    """Find repo full_name + default_branch from the installation's repos."""
+    """Find repo full_name + default_branch from the installation's repos.
+
+    Capped at 10 pages (1000 repos) — same limit as `_fetch` — so a
+    large install can't exhaust the api Lambda's 15s budget on a repo
+    not found in its first N pages. Logs a warning when the cap is hit
+    so an over-large install is visible in DD.
+    """
     with httpx.Client(timeout=10) as client:
         page = 1
         while True:
@@ -564,3 +570,9 @@ def _resolve_repo(
             if len(body.get("repositories", [])) < 100:
                 return None
             page += 1
+            if page > 10:  # 1000 repos is plenty for v1; same cap as _fetch
+                log.warning(
+                    "resolve_repo_pagination_cap",
+                    extra={"install_id": install_id, "repo_id": repo_id},
+                )
+                return None


### PR DESCRIPTION
## Why

`_resolve_repo` paginates `GET /installation/repositories` in an unbounded `while True` loop. The adjacent `_fetch` helper (used by `list_install_repos`) caps at 10 pages (1000 repos) with a logged warning — `_resolve_repo` has no equivalent guard.

For an install with many repos, a repo-not-found search scans every page: N pages × 10s per-request timeout can exhaust the api Lambda's 15-second budget and surface as an opaque 500 instead of a clean 404.

## Change

Add `if page > 10: log.warning(...); return None` — identical to the established `_fetch` pattern in the same file. Single file, 8 lines added, trivially verifiable.

## Acceptance criteria

- [ ] `_resolve_repo` stops after 10 pages (1000 repos) and returns `None`.
- [ ] Over-cap hits log `resolve_repo_pagination_cap` with `install_id` + `repo_id`.
- [ ] Happy-path (repo found within 1–2 pages) is unchanged.

Size: XS

## Out of scope

- Pagination caps for any other loops in the file — only `_resolve_repo` is addressed; `_fetch` already caps.
- Making the page bound configurable — the 10-page / 1000-repo cap intentionally mirrors the existing `_fetch` constant.

Closes #332

---
_Generated by nightly maintenance bot._