### PR TITLE
docs(runbook): Elder prompt experiment arm-up record — all_v2, n=1 cell-balance finding (#276)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -435,6 +435,23 @@ view faceted on `@variant_id`, comparing the judge `is_real_bug` rate and the
 default is a future code slice (bake the winner into `build_system_prompt`'s
 default), not a toggle flip.
 
+**Arm-up record (2026-06-10, #276).** The cell-balance check found the live
+population is **one install** (`129256114` → the `poolside × v2` cell; the
+other three cells empty). `split` would therefore be a misleading rename of
+all-v2 — there is no within-population A/B at n=1. Decision: the toggle is set
+to **`all_v2`** and the experiment is a **temporal comparison** — v2 spans
+(post-flip) vs the all-v1 history (pre-flip) on the same judge/reaction
+metrics. Analysis surface: the [DD notebook "Grug Elder — Prompt v1 vs v2"
+(#14750419)](https://app.datadoghq.com/notebook/14750419), which also records
+the confounds: (a) the SaaS backends are unfunded by design, so arm sample
+accrues only when a cloud (in practice intermittent Poolside) answers; (b)
+**cave-fallback reviews carry no `variant_id`** — the `grug-cave-connector`
+uses its own prompt; exclude healed reviews from arm comparisons. The DD
+Playground side-by-side of the two arm prompts is a manual console step: paste
+`build_system_prompt("v1")` / `("v2")` outputs from `code_review_prompt.py`.
+Re-run the cell-balance check before ever switching to `split` — it only
+becomes meaningful once installs spread across all four cells.
+
 ### Rollback
 
 If Elder produces too many false positives or operationally misbehaves,


### PR DESCRIPTION
## Summary

Executes #276's operator-side tasks and records them in the runbook. The pre-launch cell-balance check (the codex WARN task) found the live population is **one install** — `129256114`, which `split` would pin permanently to the `poolside × v2` cell with the other three cells empty. At n=1 there is no within-population A/B, so `split` would be a misleading rename of all-v2. The toggle is flipped to **`all_v2`** and the experiment is a **temporal** comparison (v2 post-flip vs the all-v1 history) on the judge `is_real_bug` + `human_verdict` reaction metrics.

## What was done (operator actions, now recorded)

- SSM `/grug/elder-prompt-experiment` → `all_v2` (v2 live after warm containers recycle; mixed-mode window documented)
- DD analysis notebook **#14750419** created — experiment design, decision rule, volume/degraded-vs-healed context charts, and the confounds (arm sample accrues only when a cloud answers; cave-fallback reviews carry no `variant_id` and must be excluded)
- Runbook arm-up record appended to the existing #191 section (incl. the Playground manual step + re-check-cells-before-split note)

## Test plan

- [ ] SSM param reads `all_v2` (verified post-put)
- [ ] Notebook renders + links from the runbook
- [ ] Runbook section documents: the n=1 finding, the temporal design, both confounds, the Playground step
- [ ] Cell-balance command in the runbook reproduces the finding (1 install → poolside×v2)

## Size: XS

## Out of scope

Promoting a winning arm to default (future code slice once results accrue); any change to selection/bucketing/prompt code; tagging cave-fallback reviews with a variant (the connector prompt is deliberately separate).

closes #276