### PR TITLE
fix(cf): add curl --max-time/--connect-timeout to pages-bootstrap api()

### DIFF
--- a/infra/cloudflare/pages-bootstrap.sh
+++ b/infra/cloudflare/pages-bootstrap.sh
@@ -26,7 +26,11 @@ APEX="grug.lol"
 PROD_BRANCH="main"
 
 api() {
-    curl -sS -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" "$@"
+    # --max-time/--connect-timeout give every CF Admin API call a per-call
+    # escape valve; on timeout curl exits 28 and `set -euo pipefail` aborts
+    # the bootstrap with a clear signal instead of hanging indefinitely (#340).
+    curl -sS --connect-timeout 10 --max-time 60 \
+        -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" "$@"
 }
 
 # Detect "missing Pages:Edit token perm" error 10000 + provide actionable


### PR DESCRIPTION
## Why

The `api()` helper in `infra/cloudflare/pages-bootstrap.sh` wrapped every Cloudflare Admin API call with `curl -sS` and **no** timeout. A stalled or slow CF response had no per-call escape valve, so the operator-run bootstrap could hang indefinitely, leaving the Pages project in an unknown state (project maybe created, apex maybe bound) with no timeout signal. This is the same class of defect already tracked for the sibling `deploy.sh` in #330.

This patch adds `--connect-timeout 10 --max-time 60` to the `api()` wrapper, so all four CF calls (`pages-bootstrap.sh:80,85,97,109`) inherit a bounded timeout. On timeout `curl` exits 28 and `set -euo pipefail` aborts with a clear, fast signal instead of hanging.

## Acceptance criteria

- The `api()` helper passes `--max-time` so every CF call through it has a timeout. ✅ (`--max-time 60`)
- A curl exceeding the limit exits 28 → `set -euo pipefail` aborts cleanly rather than hanging. ✅
- Idempotent happy-path re-run behavior is unchanged. ✅ (only the curl flags changed; `bash -n` passes)
- Connect phase is also bounded. ✅ (`--connect-timeout 10`)

## Size: XS

## Out of scope

- `infra/cloudflare/deploy.sh` (tracked in #330).
- Adding retries / circuit-breakers beyond `--max-time`.
- Refactoring the Pages bootstrap flow itself.

Closes #340

https://claude.ai/code/session_01K1PPFJuUDp2Rxe1BwJYhRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01K1PPFJuUDp2Rxe1BwJYhRs)_