### PR TITLE
feat(elder): add 5 high-value rule classes (#338)

### DIFF
--- a/services/api/code_review_prompt.py
+++ b/services/api/code_review_prompt.py
@@ -37,7 +37,7 @@ _RULE_NAME_RE = re.compile(r"[A-Za-z0-9_-]+")
 _BUG_CLASSES: frozenset[str] = frozenset((
     "silent failure", "correctness", "async blocker", "concurrency",
     "test fidelity", "robustness", "security", "type design",
-    "maintainability", "test coverage",
+    "maintainability", "test coverage", "performance",  # #338
 ))
 
 
@@ -275,6 +275,59 @@ RULES: tuple[ReviewRule, ...] = (
         bad_example="asyncio.create_task(send())  # never awaited",
         good_example="task = asyncio.create_task(send()); await task",
         severity="medium",
+    ),
+    # ── #338: high-value bug classes a strong reviewer must catch ──
+    ReviewRule(
+        name="missing-await",
+        bug_class="async blocker",
+        description="An `async def` coroutine called WITHOUT `await` (and not "
+        "handed to gather/create_task) — the body never runs, the return is a "
+        "coroutine object, and the bug is silent. Distinct from "
+        "sync-io-in-async (this is the forgotten-await class).",
+        bad_example="result = fetch_user(id)  # fetch_user is async; never runs",
+        good_example="result = await fetch_user(id)",
+        severity="high",
+    ),
+    ReviewRule(
+        name="query-in-loop",
+        bug_class="performance",
+        description="A database or network call inside a loop/comprehension "
+        "over a collection — the classic N+1. Each iteration round-trips; the "
+        "fix is one batched/bulk call or a join.",
+        bad_example="for u in users: rows.append(db.get(u.id))  # N queries",
+        good_example="rows = db.get_many([u.id for u in users])  # 1 query",
+        severity="medium",
+    ),
+    ReviewRule(
+        name="missing-timeout",
+        bug_class="robustness",
+        description="A network call (requests/httpx/urllib/socket) with no "
+        "timeout — a hung peer blocks the caller forever, exhausting the "
+        "worker/Lambda budget. Every outbound call needs an explicit timeout.",
+        bad_example="requests.get(url)  # no timeout — hangs on a dead peer",
+        good_example="requests.get(url, timeout=10)",
+        severity="medium",
+    ),
+    ReviewRule(
+        name="unbounded-growth",
+        bug_class="robustness",
+        description="A cache/list/dict/accumulator that grows on each call or "
+        "iteration with no eviction or size cap — an OOM/leak that only fires "
+        "under sustained load. A long-lived collection needs a bound (maxsize, "
+        "LRU, TTL).",
+        bad_example="_CACHE[key] = val  # module-level dict, never evicted",
+        good_example="_CACHE = LRUCache(maxsize=1000)",
+        severity="medium",
+    ),
+    ReviewRule(
+        name="missing-pagination",
+        bug_class="correctness",
+        description="Consuming a paginated API/list endpoint as if page one is "
+        "the whole set — silently drops every item past the first page. Loop "
+        "until the response is short, or follow the `next` link/cursor.",
+        bad_example="items = api.list()  # only page 1; rest silently dropped",
+        good_example="items = []  # loop until a short page / no cursor",
+        severity="high",
     ),
 )
 

--- a/services/webhook/code_review_prompt.py
+++ b/services/webhook/code_review_prompt.py
@@ -37,7 +37,7 @@ _RULE_NAME_RE = re.compile(r"[A-Za-z0-9_-]+")
 _BUG_CLASSES: frozenset[str] = frozenset((
     "silent failure", "correctness", "async blocker", "concurrency",
     "test fidelity", "robustness", "security", "type design",
-    "maintainability", "test coverage",
+    "maintainability", "test coverage", "performance",  # #338
 ))
 
 
@@ -275,6 +275,59 @@ RULES: tuple[ReviewRule, ...] = (
         bad_example="asyncio.create_task(send())  # never awaited",
         good_example="task = asyncio.create_task(send()); await task",
         severity="medium",
+    ),
+    # ── #338: high-value bug classes a strong reviewer must catch ──
+    ReviewRule(
+        name="missing-await",
+        bug_class="async blocker",
+        description="An `async def` coroutine called WITHOUT `await` (and not "
+        "handed to gather/create_task) — the body never runs, the return is a "
+        "coroutine object, and the bug is silent. Distinct from "
+        "sync-io-in-async (this is the forgotten-await class).",
+        bad_example="result = fetch_user(id)  # fetch_user is async; never runs",
+        good_example="result = await fetch_user(id)",
+        severity="high",
+    ),
+    ReviewRule(
+        name="query-in-loop",
+        bug_class="performance",
+        description="A database or network call inside a loop/comprehension "
+        "over a collection — the classic N+1. Each iteration round-trips; the "
+        "fix is one batched/bulk call or a join.",
+        bad_example="for u in users: rows.append(db.get(u.id))  # N queries",
+        good_example="rows = db.get_many([u.id for u in users])  # 1 query",
+        severity="medium",
+    ),
+    ReviewRule(
+        name="missing-timeout",
+        bug_class="robustness",
+        description="A network call (requests/httpx/urllib/socket) with no "
+        "timeout — a hung peer blocks the caller forever, exhausting the "
+        "worker/Lambda budget. Every outbound call needs an explicit timeout.",
+        bad_example="requests.get(url)  # no timeout — hangs on a dead peer",
+        good_example="requests.get(url, timeout=10)",
+        severity="medium",
+    ),
+    ReviewRule(
+        name="unbounded-growth",
+        bug_class="robustness",
+        description="A cache/list/dict/accumulator that grows on each call or "
+        "iteration with no eviction or size cap — an OOM/leak that only fires "
+        "under sustained load. A long-lived collection needs a bound (maxsize, "
+        "LRU, TTL).",
+        bad_example="_CACHE[key] = val  # module-level dict, never evicted",
+        good_example="_CACHE = LRUCache(maxsize=1000)",
+        severity="medium",
+    ),
+    ReviewRule(
+        name="missing-pagination",
+        bug_class="correctness",
+        description="Consuming a paginated API/list endpoint as if page one is "
+        "the whole set — silently drops every item past the first page. Loop "
+        "until the response is short, or follow the `next` link/cursor.",
+        bad_example="items = api.list()  # only page 1; rest silently dropped",
+        good_example="items = []  # loop until a short page / no cursor",
+        severity="high",
     ),
 )
 

--- a/services/webhook/tests/test_code_review_prompt.py
+++ b/services/webhook/tests/test_code_review_prompt.py
@@ -181,3 +181,15 @@ def test_prompt_teaches_path_is_not_secret():
     p = crp.build_system_prompt()
     assert "KUBECONFIG=/tmp/x" in p
     assert "not the secret value" in p
+
+
+def test_new_high_value_rules_present(monkeypatch):
+    """#338: the Elder gained 5 high-value bug classes the audit flagged
+    as missing from the taxonomy."""
+    names = {r.name for r in crp.RULES}
+    for rule in ("missing-await", "query-in-loop", "missing-timeout",
+                 "unbounded-growth", "missing-pagination"):
+        assert rule in names, f"{rule} missing from RULES"
+    p = crp.build_system_prompt()
+    assert "missing-await" in p and "query-in-loop" in p
+    assert "performance" in crp._BUG_CLASSES  # query-in-loop's class


### PR DESCRIPTION
## Why
A full-project audit found the Elder's 18-rule taxonomy missing several high-value, low-false-positive bug classes a strong reviewer must catch — real-world top bugs the Elder was simply blind to. This is the most direct "make Grug smarter" lever: each rule is one tuple that flows into the prompt automatically.

## Summary
Adds 5 rules + the `performance` bug class: `missing-await` (forgotten await → coroutine never runs, silent), `query-in-loop` (N+1 DB/HTTP), `missing-timeout` (outbound call with no timeout hangs the worker), `unbounded-growth` (uncapped cache/accumulator → OOM under load), `missing-pagination` (consuming page 1 as the whole set silently drops data). Each carries a bad/good example. Mirrored to `services/api` (ADR-0001).

## Acceptance criteria
- [x] 5 new `ReviewRule`s added with bad/good examples + appropriate severities
- [x] `performance` added to the closed `_BUG_CLASSES` taxonomy (query-in-loop's class)
- [x] Rules render into the system prompt automatically (verified)
- [x] Mirror preserved; `check-mirrored-files.sh` → 27 pairs verified

## Test plan
- [x] New test asserts all 5 rules are in `RULES` + the prompt + `performance` in the taxonomy
- [x] 23 rules total, names unique; 92 prompt/llm tests pass
- [x] `__post_init__` taxonomy validation passes for every rule

## Out of scope
- Wiring the judge to actually FILTER false positives (a separate judgment call the audit flagged — adds a synchronous LLM call, risks suppressing real bugs; owner's decision).

Size: S

closes #338
