### PR TITLE
feat(dor): tolerate a qualifier suffix on required headers

### DIFF
--- a/services/api/personas/tpm/dor_checks.py
+++ b/services/api/personas/tpm/dor_checks.py
@@ -59,15 +59,33 @@ _ISSUE_LINK_PAT = re.compile(
 )
 
 
+def _heading_matches(heading: str, name: str) -> bool:
+    """True if a `## ` heading IS the canonical `name`, tolerating a trailing
+    qualifier separated by a non-word boundary.
+
+    So `## Out of scope (→ #828)`, `## Test plan — manual`, and `## Why this
+    matters` all match their canonical names, while `## Summarytext` does NOT —
+    the char right after the name must be non-alphanumeric. This replaces the
+    brittle exact-equality match that failed otherwise-correct PRs whose authors
+    appended a parenthetical/qualifier to a required header.
+    """
+    h = heading.lower().strip()
+    n = name.lower().strip()
+    if h == n:
+        return True
+    return h.startswith(n) and len(h) > len(n) and not h[len(n)].isalnum()
+
+
 def _section_text(body: str, *names: str) -> str | None:
     """Return text under the first matching ## section, or None.
 
-    Matches case-insensitively; `names` provided in priority order.
+    Matches case-insensitively and tolerates a trailing qualifier on the heading
+    (see `_heading_matches`); `names` provided in priority order.
     """
     sections = list(_SECTION_PAT.finditer(body))
     for name in names:
         for i, m in enumerate(sections):
-            if m.group(1).lower().strip() == name.lower().strip():
+            if _heading_matches(m.group(1), name):
                 start = m.end()
                 end = sections[i + 1].start() if i + 1 < len(sections) else len(body)
                 return body[start:end].strip()

--- a/services/webhook/personas/tpm/dor_checks.py
+++ b/services/webhook/personas/tpm/dor_checks.py
@@ -59,15 +59,33 @@ _ISSUE_LINK_PAT = re.compile(
 )
 
 
+def _heading_matches(heading: str, name: str) -> bool:
+    """True if a `## ` heading IS the canonical `name`, tolerating a trailing
+    qualifier separated by a non-word boundary.
+
+    So `## Out of scope (→ #828)`, `## Test plan — manual`, and `## Why this
+    matters` all match their canonical names, while `## Summarytext` does NOT —
+    the char right after the name must be non-alphanumeric. This replaces the
+    brittle exact-equality match that failed otherwise-correct PRs whose authors
+    appended a parenthetical/qualifier to a required header.
+    """
+    h = heading.lower().strip()
+    n = name.lower().strip()
+    if h == n:
+        return True
+    return h.startswith(n) and len(h) > len(n) and not h[len(n)].isalnum()
+
+
 def _section_text(body: str, *names: str) -> str | None:
     """Return text under the first matching ## section, or None.
 
-    Matches case-insensitively; `names` provided in priority order.
+    Matches case-insensitively and tolerates a trailing qualifier on the heading
+    (see `_heading_matches`); `names` provided in priority order.
     """
     sections = list(_SECTION_PAT.finditer(body))
     for name in names:
         for i, m in enumerate(sections):
-            if m.group(1).lower().strip() == name.lower().strip():
+            if _heading_matches(m.group(1), name):
                 start = m.end()
                 end = sections[i + 1].start() if i + 1 < len(sections) else len(body)
                 return body[start:end].strip()

--- a/services/webhook/tests/test_dor_checks.py
+++ b/services/webhook/tests/test_dor_checks.py
@@ -136,3 +136,33 @@ def test_run_all_returns_5():
     assert {r.name for r in results} == {
         "why", "acceptance", "estimate", "scope-fence", "issue-link",
     }
+
+
+# --- Tolerant heading matching (qualifier suffix after the canonical name) ---
+
+def test_scope_fence_tolerates_parenthetical_suffix():
+    # `## Out of scope (→ #828 go-live)` should satisfy scope-fence — the
+    # brittle exact-match used to fail this otherwise-correct header.
+    assert check_scope_fence("## Out of scope (→ #828 go-live)\n\nDeferred.").passed
+
+
+def test_scope_fence_tolerates_dash_suffix():
+    assert check_scope_fence("## Out of scope — later\n\nNot now.").passed
+
+
+def test_why_tolerates_trailing_words():
+    body = "## Why this matters\n\nbecause the bill must trend toward zero over time"
+    assert check_why(body).passed
+
+
+def test_acceptance_tolerates_test_plan_qualifier():
+    body = "## Test plan (manual)\n\n- [ ] a\n- [ ] b\n- [ ] c\n"
+    assert check_acceptance(body).passed
+
+
+def test_heading_suffix_requires_word_boundary_no_false_match():
+    # `## Summarytext` must NOT match `Summary` (no boundary char after the
+    # name) — guards against the prefix match being too loose.
+    assert not check_why("## Summarytext\n\nplenty of words here to clear five").passed
+    # but a real `## Summary ...` still works
+    assert check_why("## Summary of the change\n\nfive or more words present here").passed


### PR DESCRIPTION
## Why

The DoR section-header check matched required headers (`## Why`, `## Acceptance criteria` / `## Test plan`, `## Out of scope`) by exact case-insensitive equality. A PR whose author appends a qualifier to an otherwise-correct header — `## Out of scope (see follow-up)`, `## Test plan (manual)`, `## Why this matters` — fails DoR even though the section is present, which is a confusing false-negative that sends authors hunting for a section they already wrote.

## What changed

Adds `_heading_matches(heading, name)` and routes `_section_text` through it. A heading matches when it equals the canonical name OR starts with it followed by a **non-word boundary**. So a parenthetical/dash qualifier passes, while `## Summarytext` still does NOT match `Summary` (the char after the name must be non-alphanumeric — the prefix match can't over-match into a longer word). Mirrored byte-identical to both webhook + api modules; the 5-rule invariant is untouched (both attestation scripts pass).

## Test plan

- [ ] `pytest tests/test_dor_checks.py` passes (25 tests; +5 new for suffix tolerance)
- [ ] `attest_dor_checks_mirror.py` confirms the two modules stay body-identical
- [ ] `attest_dor_checks_five_rules.py` confirms exactly 5 checks remain
- [ ] Negative case covered: `## Summarytext` must NOT satisfy the Why check

## Out of scope

LLM-based / fuzzy semantic header matching — this stays a deterministic static check.

Size: XS

Closes #350