### PR TITLE
fix(ecr): keep-last-N rule to cap SHA-tagged image accumulation

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -149,11 +149,14 @@ grug_tokens_cmk = kms_cmk.create("grug-tokens")
 # avoids a second `pulumi up` to wire the env var after the secret lands.
 cf_secret = cf_shared_secret.create()
 
-# ECR repo for the webhook Lambda image. Lifecycle: untagged images expire
-# after 14 days (avoids ~$0.10/GB/mo image graveyard).
+# ECR repo for the webhook Lambda image. Lifecycle: untagged expire after 14d
+# AND keep only the last 20 images — CI SHA-tags every build, so without the
+# count rule tagged images accumulated to 215 (the bulk of the repo's billed
+# storage). 20 = current deploy + generous rollback headroom.
 webhook_ecr = ecr_repo.create(
     name="grug-webhook",
     untagged_expire_days=14,
+    keep_last_images=20,
     # dev needs force_delete=True for `make rebuild` (Slice 10 #31).
     # prod stays False so `pulumi destroy --stack prod` cannot wipe
     # production images. Greptile P2 PR #59.
@@ -589,6 +592,7 @@ cloudflare_dns.create_proxied_cname(
 api_ecr = ecr_repo.create(
     name="grug-api",
     untagged_expire_days=14,
+    keep_last_images=20,  # See webhook_ecr — caps the SHA-tagged build accumulation.
     force_delete=(env == "dev"),  # See webhook_ecr above.
 )
 

--- a/infra/pulumi/components/ecr_repo.py
+++ b/infra/pulumi/components/ecr_repo.py
@@ -12,12 +12,59 @@ import pulumi
 import pulumi_aws as aws
 
 
+def lifecycle_rules(
+    untagged_expire_days: int, keep_last_images: int | None
+) -> list[dict]:
+    """PURE: build the ECR lifecycle rule list (no Pulumi/AWS) so the policy
+    shape is unit-testable. Rule 1 prunes the untagged graveyard; rule 2 (only
+    when keep_last_images is set) caps total images via a `tagStatus: any`
+    count rule — which ECR requires to carry the highest rulePriority."""
+    rules: list[dict] = [
+        {
+            "rulePriority": 1,
+            "description": (
+                f"Expire untagged images older than {untagged_expire_days} days"
+            ),
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": untagged_expire_days,
+            },
+            "action": {"type": "expire"},
+        },
+    ]
+    if keep_last_images is not None:
+        rules.append(
+            {
+                "rulePriority": 2,
+                "description": f"Keep only the last {keep_last_images} images (any tag)",
+                "selection": {
+                    "tagStatus": "any",
+                    "countType": "imageCountMoreThan",
+                    "countNumber": keep_last_images,
+                },
+                "action": {"type": "expire"},
+            }
+        )
+    return rules
+
+
 def create(
     name: str,
     untagged_expire_days: int = 14,
+    keep_last_images: int | None = None,
     force_delete: bool = False,
 ) -> aws.ecr.Repository:
     """Create a private ECR repo with lifecycle pruning.
+
+    `untagged_expire_days` prunes the untagged graveyard. But CI tags every
+    build image with its commit SHA, so untagged-only pruning lets TAGGED
+    images accumulate forever (grug-api/webhook hit 200+ images, ~all of the
+    repo's billed unique-layer storage). `keep_last_images`, when set, adds a
+    `tagStatus: any` + `imageCountMoreThan` rule that keeps only the N most
+    recent images (the live Lambda image is always the newest, so N≈20 leaves
+    generous rollback headroom). None preserves the old untagged-only behavior.
 
     `force_delete` is opt-in per stack. Slice 10 #31 `make rebuild`
     needs it for the dev stack so `pulumi destroy` can wipe non-empty
@@ -39,24 +86,7 @@ def create(
         f"{name}-lifecycle",
         repository=repo.name,
         policy=json.dumps(
-            {
-                "rules": [
-                    {
-                        "rulePriority": 1,
-                        "description": (
-                            f"Expire untagged images older than "
-                            f"{untagged_expire_days} days"
-                        ),
-                        "selection": {
-                            "tagStatus": "untagged",
-                            "countType": "sinceImagePushed",
-                            "countUnit": "days",
-                            "countNumber": untagged_expire_days,
-                        },
-                        "action": {"type": "expire"},
-                    },
-                ],
-            },
+            {"rules": lifecycle_rules(untagged_expire_days, keep_last_images)}
         ),
     )
     return repo


### PR DESCRIPTION
## Why

The grug-api / grug-webhook ECR lifecycle policies only expire UNTAGGED images, but CI tags every build with its commit SHA — so tagged images never get pruned and accumulate without bound (grug-api: 200 images, grug-webhook: 215). Each build adds a unique app layer, and that accumulation is the bulk of the repos' billed (deduped) ECR storage. macchina-base already caps its image count correctly; the grug ECR component had no count rule.

## What changed

`ecr_repo.create` gains a `keep_last_images` count. When set, it adds a `tagStatus: any` + `imageCountMoreThan` lifecycle rule at the highest rulePriority (ECR requires any-tag rules to be last). The rule list is extracted into a pure, importable `lifecycle_rules()`. grug-webhook + grug-api now pass `keep_last_images=20` (live deploy + generous rollback headroom). ECR prunes the ~195 excess images per repo within ~24h of apply. The untagged-only default is preserved for repos that don't opt in.

## Test plan

- [ ] `lifecycle_rules(14, None)` returns only the untagged rule (unchanged default)
- [ ] `lifecycle_rules(14, 20)` appends the `tagStatus: any` count rule at rulePriority 2 (verified via the infra env)
- [ ] `pulumi preview` shows the LifecyclePolicy update on grug-webhook + grug-api (no resource replacement)
- [ ] Post-apply: image counts on both repos drop toward 20

## Out of scope

Migrating the Lambda images off ECR — Lambda container images can only be pulled from ECR, so the images must stay; this only prunes accumulation. The macchina-base / tempo / pasto repos already have appropriate policies.

Size: XS

Closes #352