### PR TITLE
feat(store): Postgres port of the single-table adapters

### DIFF
--- a/.github/workflows/check.python.yml
+++ b/.github/workflows/check.python.yml
@@ -36,6 +36,13 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
+    env:
+      # moto-backed suites construct boto3 clients at import; hosted
+      # runners have no ambient AWS config (developer shells do, which
+      # is why this never bit locally).
+      AWS_DEFAULT_REGION: us-east-1
+      AWS_ACCESS_KEY_ID: testing
+      AWS_SECRET_ACCESS_KEY: testing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8

--- a/.github/workflows/check.python.yml
+++ b/.github/workflows/check.python.yml
@@ -36,14 +36,17 @@ jobs:
           --health-interval 5s
           --health-timeout 3s
           --health-retries 10
-    env:
-      GRUG_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/grug_test
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
       - name: webhook tests
-        run: make test-webhook
+        run: make webhook-test
       - name: api tests
-        run: make test-api
+        run: make api-test
       - name: pg store tests (real Postgres)
-        run: make test-pg
+        # DB env is STEP-scoped on purpose: job-scoped would make the plain
+        # api suite (no psycopg dep) try to RUN the pg tests instead of
+        # skipping them.
+        env:
+          GRUG_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/grug_test
+        run: make pg-test

--- a/.github/workflows/check.python.yml
+++ b/.github/workflows/check.python.yml
@@ -1,0 +1,49 @@
+# Python test gate. Until this workflow, the pytest suites only ran via
+# local `make test-*` convention - nothing gated PRs. The postgres
+# service backs the real-Postgres store tests (test_pg_stores.py, #354):
+# their semantics (ON CONFLICT atomicity, jsonb merge, concurrent
+# claims) are exactly what fakes get wrong, so no sqlite stand-in.
+name: check.python
+
+on:
+  pull_request:
+    paths:
+      - 'services/**'
+      - 'Makefile'
+      - '.github/workflows/check.python.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/**'
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: grug_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    env:
+      GRUG_TEST_DATABASE_URL: postgresql://postgres:test@localhost:5432/grug_test
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8
+      - name: webhook tests
+        run: make test-webhook
+      - name: api tests
+        run: make test-api
+      - name: pg store tests (real Postgres)
+        run: make test-pg

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ GRUG_ADMIN_INSTALL_ID ?= 129256114
 test: webhook-test api-test
 
 webhook-test:
-	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi pytest tests/ -q
+	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum pytest tests/ -q
 
 api-test:
-	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi pytest tests/ -q
+	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum pytest tests/ -q
 
 # Real-Postgres store tests (#354). REQUIRE a reachable Postgres via
 # GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GRUG_ADMIN_INSTALL_ID ?= 129256114
 test: webhook-test api-test
 
 webhook-test:
-	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum --with datadog-lambda pytest tests/ -q \
+	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum --with 'ddtrace>=3.5,<4' --with 'datadog-lambda>=6.107,<7' pytest tests/ -q \
 		--deselect tests/test_dispatcher.py::test_installation_created_records_row \
 		--deselect tests/test_dispatcher.py::test_installation_created_org_uses_sender_id \
 		--deselect tests/test_enforcement.py::test_heal_clears_stale_id_and_recreates \

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,14 @@ GRUG_ADMIN_INSTALL_ID ?= 129256114
 test: webhook-test api-test
 
 webhook-test:
-	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum pytest tests/ -q
+	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum --with datadog-lambda pytest tests/ -q \
+		--deselect tests/test_dispatcher.py::test_installation_created_records_row \
+		--deselect tests/test_dispatcher.py::test_installation_created_org_uses_sender_id \
+		--deselect tests/test_enforcement.py::test_heal_clears_stale_id_and_recreates \
+		--deselect tests/test_enforcement.py::test_heal_returns_new_state
+	# ^ deselected: these hit LIVE DynamoDB without a moto fixture and only
+	# ever passed via the developer shell's real AWS creds - #356 restores
+	# them under moto. Do NOT widen this list without an issue.
 
 api-test:
 	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum pytest tests/ -q

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ api-test:
 # GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip
 # loudly otherwise; sqlite stand-ins are banned for these semantics.
 pg-test:
+	@if [ -n "$$CI" ] && [ -z "$$GRUG_TEST_DATABASE_URL" ]; then \
+		echo "FATAL: pg tests would SKIP in CI (GRUG_TEST_DATABASE_URL unset) - a skipped gate is a silent pass (audit H4)"; exit 1; fi
 	cd services/api && uv run --with pytest --with "psycopg[binary,pool]" --with boto3 --with cryptography pytest tests/test_pg_stores.py -q -rs
 
 pulumi-preview:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #   make rebuild            — destroy + up + image-rebuild + workers + reseed + smoke (~12-15min)
 #   make smoke              — quick prod-shape smoke test (read-only)
 
-.PHONY: test webhook-test api-test pulumi-preview pulumi-up \
+.PHONY: test webhook-test api-test pg-test pulumi-preview pulumi-up \
         tear-down rebuild bootstrap-images smoke docker-build-webhook
 
 # Admin seed defaults — the values that get re-installed after a tear-down
@@ -32,7 +32,7 @@ api-test:
 # Real-Postgres store tests (#354). REQUIRE a reachable Postgres via
 # GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip
 # loudly otherwise; sqlite stand-ins are banned for these semantics.
-test-pg:
+pg-test:
 	cd services/api && uv run --with pytest --with "psycopg[binary,pool]" --with boto3 --with cryptography pytest tests/test_pg_stores.py -q -rs
 
 pulumi-preview:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ webhook-test:
 api-test:
 	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi pytest tests/ -q
 
+# Real-Postgres store tests (#354). REQUIRE a reachable Postgres via
+# GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip
+# loudly otherwise; sqlite stand-ins are banned for these semantics.
+test-pg:
+	cd services/api && uv run --with pytest --with "psycopg[binary,pool]" --with boto3 --with cryptography pytest tests/test_pg_stores.py -q -rs
+
 pulumi-preview:
 	cd infra/pulumi && uv sync && pulumi preview --stack dev
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GRUG_ADMIN_INSTALL_ID ?= 129256114
 test: webhook-test api-test
 
 webhook-test:
-	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto pytest tests/ -q
+	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi pytest tests/ -q
 
 api-test:
 	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi pytest tests/ -q

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,12 @@ webhook-test:
 	# them under moto. Do NOT widen this list without an issue.
 
 api-test:
-	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum pytest tests/ -q
+	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum pytest tests/ -q \
+		--deselect tests/test_installations_update_config.py::test_update_repo_config_admin_can_access_any \
+		--deselect tests/test_installations_update_config.py::test_update_repo_config_paginates_until_match
+	# ^ deselected: same live-DynamoDB class as the webhook quartet (#356) -
+	# the long-known 'ordering pollution' local failures were actually real
+	# GetItem calls riding developer AWS creds. #356 restores under moto.
 
 # Real-Postgres store tests (#354). REQUIRE a reachable Postgres via
 # GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip

--- a/infra/scripts/attest_user_with_tokens_decrypt_boundary.py
+++ b/infra/scripts/attest_user_with_tokens_decrypt_boundary.py
@@ -104,28 +104,35 @@ def main() -> int:
         print(f"FAIL: {USER_STORE} missing")
         return 1
 
-    tree = ast.parse(USER_STORE.read_text())
-    cls = _find_class(tree, "UserWithTokens")
-    if cls is None:
-        print(f"FAIL: {USER_STORE}: UserWithTokens class not found")
-        return 1
-
     failures: list[str] = []
 
-    if not _is_frozen_dataclass(cls):
-        failures.append("UserWithTokens is not @dataclass(frozen=True) — spec 0008 attests frozen.")
+    # Shape contract holds for the canonical file AND the staged Postgres
+    # successor (Codex F1 on PR #355: an allowed construction site that
+    # escapes shape validation could violate the very contract the
+    # allowance exists for).
+    for store_path in (USER_STORE, PG_USER_STORE):
+        if not store_path.exists():
+            continue  # PG successor is transitional; absence is fine
+        tree = ast.parse(store_path.read_text())
+        cls = _find_class(tree, "UserWithTokens")
+        if cls is None:
+            failures.append(f"{store_path.name}: UserWithTokens class not found")
+            continue
 
-    fields = _class_fields(cls)
-    extra = set(fields) - EXPECTED_FIELDS
-    missing = EXPECTED_FIELDS - set(fields)
-    if extra:
-        failures.append(f"UserWithTokens has unexpected fields: {sorted(extra)}.")
-    if missing:
-        failures.append(f"UserWithTokens missing expected fields: {sorted(missing)}.")
+        if not _is_frozen_dataclass(cls):
+            failures.append(f"{store_path.name}: UserWithTokens is not @dataclass(frozen=True) — spec 0008 attests frozen.")
 
-    refresh_ann = fields.get("oauth_refresh_token")
-    if refresh_ann is not None and not _refresh_is_optional(refresh_ann):
-        failures.append("UserWithTokens.oauth_refresh_token must be `str | None` (provider may not rotate). Got non-Optional annotation.")
+        fields = _class_fields(cls)
+        extra = set(fields) - EXPECTED_FIELDS
+        missing = EXPECTED_FIELDS - set(fields)
+        if extra:
+            failures.append(f"{store_path.name}: UserWithTokens has unexpected fields: {sorted(extra)}.")
+        if missing:
+            failures.append(f"{store_path.name}: UserWithTokens missing expected fields: {sorted(missing)}.")
+
+        refresh_ann = fields.get("oauth_refresh_token")
+        if refresh_ann is not None and not _refresh_is_optional(refresh_ann):
+            failures.append(f"{store_path.name}: UserWithTokens.oauth_refresh_token must be `str | None` (provider may not rotate). Got non-Optional annotation.")
 
     # Service-scope wall: webhook never references UserWithTokens.
     if WEBHOOK_DIR.exists():
@@ -148,7 +155,11 @@ def main() -> int:
                 continue  # canonical site + staged Postgres successor (#354)
             tree2 = ast.parse(path.read_text())
             for node in ast.walk(tree2):
-                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "UserWithTokens":
+                is_named = isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "UserWithTokens"
+                # Qualified form (module.UserWithTokens(...)) must not
+                # slip the wall (Codex F2 on PR #355).
+                is_attr = isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "UserWithTokens"
+                if is_named or is_attr:
                     construction_sites.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
         if construction_sites:
             failures.append(

--- a/infra/scripts/attest_user_with_tokens_decrypt_boundary.py
+++ b/infra/scripts/attest_user_with_tokens_decrypt_boundary.py
@@ -26,6 +26,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 USER_STORE = REPO_ROOT / "services/api/adapters/user_store.py"
+# Staged Postgres successor (#354): same decrypt-boundary contract, same
+# sole-construction discipline. At cutover the implementation swap
+# collapses construction back to one file and this entry is removed.
+PG_USER_STORE = REPO_ROOT / "services/api/adapters/pg_user_store.py"
 WEBHOOK_DIR = REPO_ROOT / "services/webhook"
 API_DIR = REPO_ROOT / "services/api"
 
@@ -140,15 +144,15 @@ def main() -> int:
         for path in API_DIR.rglob("*.py"):
             if "test" in path.name:
                 continue
-            if path == USER_STORE:
-                continue  # the canonical definition + construction site
+            if path in (USER_STORE, PG_USER_STORE):
+                continue  # canonical site + staged Postgres successor (#354)
             tree2 = ast.parse(path.read_text())
             for node in ast.walk(tree2):
                 if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "UserWithTokens":
                     construction_sites.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
         if construction_sites:
             failures.append(
-                "UserWithTokens constructed outside user_store.py — spec 0008 attests get_user_with_tokens is the sole construction site:\n"
+                "UserWithTokens constructed outside user_store.py / pg_user_store.py (the #354-staged successor) — spec 0008 attests get_user_with_tokens is the sole construction site:\n"
                 + "\n".join(f"    {s}" for s in construction_sites)
             )
 

--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -30,6 +30,8 @@ cd "$(dirname "$0")/.."
 MIRRORED_WITH_HEADER=(
   "activity_log.py"
   "adapters/install_store.py"
+  "adapters/pg_base.py"
+  "adapters/pg_install_store.py"
   "cf_auth.py"
   "code_review_prompt.py"
   "enforcement.py"

--- a/services/api/adapters/pg_base.py
+++ b/services/api/adapters/pg_base.py
@@ -1,0 +1,194 @@
+# MIRRORED — sibling at services/webhook/adapters/pg_base.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Shared Postgres plumbing for the single-table store port (#354).
+
+Replaces DynamoDB's single-table (PK/SK + attrs + GSI1 + ttl) with an
+EXACT-parity Postgres table:
+
+    grug_kv(pk, sk, data jsonb, gsi1pk, gsi1sk, ttl)
+
+Parity rules (the migration's correctness contract):
+- Items round-trip as {"PK": pk, "SK": sk, **attrs}; attrs live in
+  `data` jsonb. GSI1PK/GSI1SK and ttl are LIFTED into columns (indexed)
+  AND kept in `data` when present, mirroring DDB where they are
+  ordinary attributes that the index/TTL machinery reads.
+- Binary attrs (the KMS-encrypted oauth_*_blob values) cannot ride
+  jsonb raw; they are encoded as {"__b64__": "<base64>"} sentinels by
+  the codec below and decoded back to `bytes` on read - callers see
+  bytes exactly as boto3 returned them (modulo DDB's Binary wrapper,
+  which callers already unwrap defensively).
+- DDB TTL deletes rows lazily; Postgres has no reaper, so EVERY read
+  filters `ttl IS NULL OR ttl > now()` (the `_TTL_LIVE` predicate) and
+  writers that must atomically take over an expired row (claim_delivery)
+  encode that in their ON CONFLICT clause. An opportunistic purge runs
+  at most once per process-hour to keep the table bounded.
+
+Connection: GRUG_DATABASE_URL (postgresql://...). Lazy pool init with
+double-checked locking - same rationale as the DDB _LazyTable (env vars
+are monkeypatched after import in tests; eager init would break them).
+Schema bootstrap is idempotent (CREATE TABLE IF NOT EXISTS) and runs on
+first pool acquisition; concurrent bootstrappers are safe (IF NOT EXISTS
++ advisory lock).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+from psycopg_pool import ConnectionPool
+
+log = logging.getLogger("grug.adapters.pg_base")
+
+_pool: ConnectionPool | None = None
+_pool_lock = threading.Lock()
+_last_purge: float = 0.0
+_PURGE_INTERVAL_SECONDS = 3600
+
+# One arbitrary-but-fixed key for the schema-bootstrap advisory lock.
+_BOOTSTRAP_LOCK_KEY = 0x6772_7567  # "grug"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS grug_kv (
+    pk      text NOT NULL,
+    sk      text NOT NULL,
+    data    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    gsi1pk  text,
+    gsi1sk  text,
+    ttl     bigint,
+    PRIMARY KEY (pk, sk)
+);
+CREATE INDEX IF NOT EXISTS grug_kv_gsi1
+    ON grug_kv (gsi1pk, gsi1sk) WHERE gsi1pk IS NOT NULL;
+CREATE INDEX IF NOT EXISTS grug_kv_ttl
+    ON grug_kv (ttl) WHERE ttl IS NOT NULL;
+"""
+
+# SQL fragment: row is live (not TTL-expired). Interpolated as a
+# constant fragment, never with user input.
+TTL_LIVE = "(ttl IS NULL OR ttl > EXTRACT(EPOCH FROM now()))"
+
+
+def _database_url() -> str:
+    url = os.environ.get("GRUG_DATABASE_URL", "")
+    if not url:
+        raise RuntimeError(
+            "GRUG_DATABASE_URL is not set - the Postgres store cannot start. "
+            "(k8s injects it from the deployment secret; tests set it from "
+            "the testcontainer.)"
+        )
+    return url
+
+
+def get_pool() -> ConnectionPool:
+    """Lazy, thread-safe pool. Bootstraps the schema on first creation."""
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                pool = ConnectionPool(
+                    _database_url(),
+                    min_size=1,
+                    max_size=int(os.environ.get("GRUG_PG_POOL_MAX", "5")),
+                    open=True,
+                )
+                with pool.connection() as conn:
+                    # Advisory lock so N replicas bootstrapping at once
+                    # don't race the CREATEs (IF NOT EXISTS is safe but
+                    # noisy under contention).
+                    conn.execute("SELECT pg_advisory_lock(%s)", (_BOOTSTRAP_LOCK_KEY,))
+                    try:
+                        conn.execute(_SCHEMA)
+                    finally:
+                        conn.execute(
+                            "SELECT pg_advisory_unlock(%s)", (_BOOTSTRAP_LOCK_KEY,)
+                        )
+                _pool = pool
+    return _pool
+
+
+def reset_pool_for_tests() -> None:
+    """Close + forget the pool. Tests call this between containers."""
+    global _pool, _last_purge
+    with _pool_lock:
+        if _pool is not None:
+            _pool.close()
+        _pool = None
+        _last_purge = 0.0
+
+
+def _encode_value(v: Any) -> Any:
+    if isinstance(v, bytes):
+        return {"__b64__": base64.b64encode(v).decode("ascii")}
+    if isinstance(v, dict):
+        return {k: _encode_value(x) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_encode_value(x) for x in v]
+    # DDB's Binary wrapper exposes .value; normalize it here so the
+    # migration script can feed boto3 items straight in.
+    if hasattr(v, "value") and isinstance(getattr(v, "value"), bytes):
+        return {"__b64__": base64.b64encode(v.value).decode("ascii")}
+    return v
+
+
+def _decode_value(v: Any) -> Any:
+    if isinstance(v, dict):
+        if set(v.keys()) == {"__b64__"}:
+            return base64.b64decode(v["__b64__"])
+        return {k: _decode_value(x) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_decode_value(x) for x in v]
+    return v
+
+
+def encode_attrs(attrs: dict[str, Any]) -> Jsonb:
+    """Encode an attr dict for the jsonb column (bytes -> b64 sentinel)."""
+    return Jsonb({k: _encode_value(v) for k, v in attrs.items()})
+
+
+def decode_item(pk: str, sk: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Reconstruct the DDB-shaped Item dict from a row."""
+    item = {k: _decode_value(v) for k, v in data.items()}
+    item["PK"] = pk
+    item["SK"] = sk
+    return item
+
+
+def split_special(attrs: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None, int | None]:
+    """Lift GSI1PK/GSI1SK/ttl out of an attr dict into their columns.
+
+    They STAY in `data` too (DDB keeps them as plain attributes); the
+    columns exist for indexing/filtering only.
+    """
+    gsi1pk = attrs.get("GSI1PK")
+    gsi1sk = attrs.get("GSI1SK")
+    ttl = attrs.get("ttl")
+    return attrs, gsi1pk, gsi1sk, int(ttl) if ttl is not None else None
+
+
+def maybe_purge_expired() -> None:
+    """Opportunistic TTL purge, at most once per process-hour.
+
+    Correctness never depends on this (reads filter TTL_LIVE); it only
+    keeps the table from accumulating dead claim/comment rows forever.
+    Failures are logged and swallowed - a purge must never take down a
+    request path.
+    """
+    global _last_purge
+    now = time.monotonic()
+    if _last_purge and now - _last_purge < _PURGE_INTERVAL_SECONDS:
+        return
+    _last_purge = now
+    try:
+        with get_pool().connection() as conn:
+            conn.execute(
+                "DELETE FROM grug_kv WHERE ttl IS NOT NULL "
+                "AND ttl <= EXTRACT(EPOCH FROM now())"
+            )
+    except psycopg.Error:
+        log.warning("pg_ttl_purge_failed", exc_info=True)

--- a/services/api/adapters/pg_base.py
+++ b/services/api/adapters/pg_base.py
@@ -33,10 +33,12 @@ first pool acquisition; concurrent bootstrappers are safe (IF NOT EXISTS
 from __future__ import annotations
 
 import base64
+import binascii
 import logging
 import os
 import threading
 import time
+from decimal import Decimal
 from typing import Any
 
 import psycopg
@@ -96,18 +98,31 @@ def get_pool() -> ConnectionPool:
                     min_size=1,
                     max_size=int(os.environ.get("GRUG_PG_POOL_MAX", "5")),
                     open=True,
+                    # Validate connections at checkout: long-lived pools
+                    # accumulate dead sockets across idle timeouts (and
+                    # Lambda freeze/thaw in the interim deploy shape) -
+                    # without this the FIRST request per stale socket
+                    # 500s (audit M5).
+                    check=ConnectionPool.check_connection,
+                    max_idle=300,
                 )
-                with pool.connection() as conn:
-                    # Advisory lock so N replicas bootstrapping at once
-                    # don't race the CREATEs (IF NOT EXISTS is safe but
-                    # noisy under contention).
-                    conn.execute("SELECT pg_advisory_lock(%s)", (_BOOTSTRAP_LOCK_KEY,))
-                    try:
-                        conn.execute(_SCHEMA)
-                    finally:
+                try:
+                    with pool.connection() as conn:
+                        # TRANSACTION-scoped advisory lock (audit C1): the
+                        # session-scoped variant is NOT released by abort,
+                        # so a failed CREATE would leak the lock into the
+                        # orphaned pool and every retry fleet-wide would
+                        # block forever inside pg_advisory_lock. The xact
+                        # lock auto-releases on commit AND abort, and the
+                        # original error stays the visible one.
                         conn.execute(
-                            "SELECT pg_advisory_unlock(%s)", (_BOOTSTRAP_LOCK_KEY,)
+                            "SELECT pg_advisory_xact_lock(%s)",
+                            (_BOOTSTRAP_LOCK_KEY,),
                         )
+                        conn.execute(_SCHEMA)
+                except BaseException:
+                    pool.close()
+                    raise
                 _pool = pool
     return _pool
 
@@ -125,6 +140,11 @@ def reset_pool_for_tests() -> None:
 def _encode_value(v: Any) -> Any:
     if isinstance(v, bytes):
         return {"__b64__": base64.b64encode(v).decode("ascii")}
+    # boto3 resource-mode returns EVERY DDB number as Decimal; the cutover
+    # migration feeds those items straight in and json.dumps would raise
+    # on the first row otherwise (audit H3).
+    if isinstance(v, Decimal):
+        return int(v) if v == v.to_integral_value() else float(v)
     if isinstance(v, dict):
         return {k: _encode_value(x) for k, x in v.items()}
     if isinstance(v, list):
@@ -138,8 +158,15 @@ def _encode_value(v: Any) -> Any:
 
 def _decode_value(v: Any) -> Any:
     if isinstance(v, dict):
-        if set(v.keys()) == {"__b64__"}:
-            return base64.b64decode(v["__b64__"])
+        if set(v.keys()) == {"__b64__"} and isinstance(v["__b64__"], str):
+            # Guarded decode (audit M6): a colliding/corrupt sentinel in
+            # opaque persisted dicts must degrade to the raw dict, not
+            # throw binascii.Error inside a whole-batch read.
+            try:
+                return base64.b64decode(v["__b64__"], validate=True)
+            except (binascii.Error, ValueError):
+                log.warning("b64_sentinel_decode_failed_returning_raw")
+                return v
         return {k: _decode_value(x) for k, x in v.items()}
     if isinstance(v, list):
         return [_decode_value(x) for x in v]
@@ -158,17 +185,6 @@ def decode_item(pk: str, sk: str, data: dict[str, Any]) -> dict[str, Any]:
     item["SK"] = sk
     return item
 
-
-def split_special(attrs: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None, int | None]:
-    """Lift GSI1PK/GSI1SK/ttl out of an attr dict into their columns.
-
-    They STAY in `data` too (DDB keeps them as plain attributes); the
-    columns exist for indexing/filtering only.
-    """
-    gsi1pk = attrs.get("GSI1PK")
-    gsi1sk = attrs.get("GSI1SK")
-    ttl = attrs.get("ttl")
-    return attrs, gsi1pk, gsi1sk, int(ttl) if ttl is not None else None
 
 
 def maybe_purge_expired() -> None:

--- a/services/api/adapters/pg_install_store.py
+++ b/services/api/adapters/pg_install_store.py
@@ -129,7 +129,17 @@ def is_install_allowlisted(install_id: int) -> bool:
             extra={"install_id": install_id},
         )
         return False
-    user = _get_item(_user_pk(user_id), "META")
+    # PROJECTED read (audit H2): the DDB original used
+    # ProjectionExpression="allowlisted" so the webhook NEVER holds the
+    # OAuth blobs that live on the same row; Postgres has no IAM
+    # projection, so this query is the enforcement now.
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            f"SELECT data->'allowlisted' FROM grug_kv "
+            f"WHERE pk = %s AND sk = 'META' AND {TTL_LIVE}",
+            (_user_pk(user_id),),
+        ).fetchone()
+    user = {"allowlisted": row[0]} if row is not None else None
     if not user:
         log.info(
             "allowlist_miss_no_user",
@@ -154,7 +164,8 @@ def list_allowlisted_installs() -> list[int]:
     """
     with get_pool().connection() as conn:
         rows = conn.execute(
-            f"SELECT pk FROM grug_kv WHERE sk = 'META' AND pk LIKE 'INST#%%' AND {TTL_LIVE}"
+            f"SELECT pk FROM grug_kv WHERE sk = 'META' AND pk LIKE %s AND {TTL_LIVE}",
+            ("INST#%",),
         ).fetchall()
     install_ids: list[int] = []
     for (pk,) in rows:
@@ -232,7 +243,13 @@ def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
 
 def _merge_attrs(pk: str, sk: str, attrs: dict[str, Any]) -> None:
     """Sparse jsonb merge-upsert (DDB update_item SET parity: creates the
-    row when absent, merges fields when present)."""
+    row when absent, merges fields when present).
+
+    Known divergence (audit L8, deliberate): merging into a TTL-EXPIRED
+    row does not clear its ttl - the write lands on a row reads ignore
+    and the purge later removes. DDB would resurrect a sparse live row
+    (its own latent bug: such rows KeyError in the list readers). The
+    PG behavior is the safer of the two."""
     with get_pool().connection() as conn:
         conn.execute(
             """
@@ -462,7 +479,7 @@ def list_check_verdicts(
             f"""
             SELECT pk, sk, data FROM grug_kv
             WHERE pk = %s AND sk LIKE 'ACT#%%' AND {TTL_LIVE}
-            ORDER BY data->>'created_at' DESC
+            ORDER BY data->>'created_at' COLLATE "C" DESC
             """,
             (_inst_pk(install_id),),
         ).fetchall()

--- a/services/api/adapters/pg_install_store.py
+++ b/services/api/adapters/pg_install_store.py
@@ -1,0 +1,570 @@
+# MIRRORED — sibling at services/webhook/adapters/pg_install_store.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Postgres install store - exact-API port of install_store.py (DDB).
+
+Same public surface, same single-table layout (see install_store.py's
+docstring for the PK/SK shapes); storage is the grug_kv table from
+pg_base.py. At cutover install_store.py's implementation is REPLACED by
+this module (no runtime dual-backend seam: DDB retires, the seam is
+git + the image tag - rule-of-three, ADR-0001).
+
+Semantics deliberately preserved from the DDB adapter:
+- record_installation: atomic upsert that PRESERVES the original
+  installed_at under concurrent duplicate deliveries (DDB
+  if_not_exists -> single-statement jsonb upsert here).
+- claim_delivery: win-once atomic claim (DDB conditional put ->
+  INSERT ... ON CONFLICT with expired-row takeover; DDB's TTL machinery
+  would have deleted an expired claim, Postgres must treat it as free).
+- All reads filter TTL-expired rows (pg_base.TTL_LIVE) - DDB expiry is
+  lazy-delete, ours is read-filter + hourly opportunistic purge.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, NotRequired, Optional, TypedDict
+
+from psycopg.types.json import Jsonb
+
+from adapters import pg_base
+from adapters.pg_base import TTL_LIVE, decode_item, encode_attrs, get_pool
+from review_types import verdict as _derive_verdict  # leaf import (no cycle)
+
+log = logging.getLogger("grug.adapters.pg_install_store")
+
+
+def _inst_pk(install_id: int | str) -> str:
+    return f"INST#{install_id}"
+
+
+def _user_pk(github_user_id: int | str) -> str:
+    return f"USER#{github_user_id}"
+
+
+def _get_item(pk: str, sk: str) -> dict[str, Any] | None:
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            f"SELECT pk, sk, data FROM grug_kv WHERE pk = %s AND sk = %s AND {TTL_LIVE}",
+            (pk, sk),
+        ).fetchone()
+    if not row:
+        return None
+    return decode_item(row[0], row[1], row[2])
+
+
+def record_installation(
+    *,
+    install_id: int,
+    account_login: str,
+    account_type: str,
+    installed_by_user_id: int,
+) -> None:
+    """Idempotent upsert of INST#<id> META row on `installation:created`.
+
+    Single-statement upsert: concurrent duplicate webhook deliveries
+    cannot race-overwrite the original install timestamp (the jsonb
+    merge keeps the existing installed_at when present - same guarantee
+    the DDB if_not_exists expression gave).
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    attrs = {
+        "account_login": account_login,
+        "account_type": account_type,
+        "installed_by_user_id": str(installed_by_user_id),
+        "GSI1PK": str(installed_by_user_id),
+        "GSI1SK": _inst_pk(install_id),
+        "installed_at": now,
+    }
+    pg_base.maybe_purge_expired()
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, gsi1pk, gsi1sk)
+            VALUES (%(pk)s, %(sk)s, %(data)s, %(g1pk)s, %(g1sk)s)
+            ON CONFLICT (pk, sk) DO UPDATE SET
+                data = (grug_kv.data || %(data)s)
+                       || jsonb_build_object(
+                              'installed_at',
+                              COALESCE(grug_kv.data->'installed_at',
+                                       %(data)s->'installed_at')),
+                gsi1pk = %(g1pk)s,
+                gsi1sk = %(g1sk)s
+            """,
+            {
+                "pk": _inst_pk(install_id),
+                "sk": "META",
+                "data": encode_attrs(attrs),
+                "g1pk": attrs["GSI1PK"],
+                "g1sk": attrs["GSI1SK"],
+            },
+        )
+
+
+def delete_installation(install_id: int) -> None:
+    with get_pool().connection() as conn:
+        conn.execute(
+            "DELETE FROM grug_kv WHERE pk = %s AND sk = %s",
+            (_inst_pk(install_id), "META"),
+        )
+
+
+def get_installation(install_id: int) -> dict[str, Any] | None:
+    return _get_item(_inst_pk(install_id), "META")
+
+
+def is_install_allowlisted(install_id: int) -> bool:
+    """Return True iff INST#<id> exists AND its installer is allowlisted.
+
+    Two-hop lookup, same shape + logging as the DDB adapter (callers
+    and dashboards grep these event names).
+    """
+    inst = get_installation(install_id)
+    if not inst:
+        log.info("allowlist_miss_no_install", extra={"install_id": install_id})
+        return False
+    user_id = inst.get("installed_by_user_id")
+    if not user_id:
+        log.warning(
+            "allowlist_install_missing_user_id",
+            extra={"install_id": install_id},
+        )
+        return False
+    user = _get_item(_user_pk(user_id), "META")
+    if not user:
+        log.info(
+            "allowlist_miss_no_user",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+        return False
+    allowlisted = bool(user.get("allowlisted", False))
+    if not allowlisted:
+        log.info(
+            "allowlist_miss_user_not_allowlisted",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+    return allowlisted
+
+
+def list_allowlisted_installs() -> list[int]:
+    """Install_ids whose installer is allowlisted (poller batch, #247b).
+
+    The DDB version SCANned; here a single WHERE does it. The per-id
+    re-check via is_install_allowlisted is kept for log parity (the
+    allowlist_miss_* events are how the operator debugs poller gaps).
+    """
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"SELECT pk FROM grug_kv WHERE sk = 'META' AND pk LIKE 'INST#%%' AND {TTL_LIVE}"
+        ).fetchall()
+    install_ids: list[int] = []
+    for (pk,) in rows:
+        _, sep, id_str = pk.partition("#")
+        if not sep:
+            continue
+        try:
+            iid = int(id_str)
+        except (TypeError, ValueError):
+            log.warning("install_pk_unparsable", extra={"pk": pk})
+            continue
+        if is_install_allowlisted(iid):
+            install_ids.append(iid)
+    return install_ids
+
+
+# ---------------------------------------------------------------------------
+# Per-repo persona toggles
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PERSONA_CONFIG = {
+    "tpm_enabled": True,
+    "code_reviewer_enabled": True,
+    "code_reviewer_blocking": False,
+}
+
+
+def _repo_sk(repo_id: int | str) -> str:
+    return f"REPO#{repo_id}"
+
+
+def list_user_installations(github_user_id: str) -> list[dict[str, Any]]:
+    """INST# rows installed by this user - the GSI1 query becomes an
+    indexed column lookup."""
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE gsi1pk = %s AND gsi1sk LIKE 'INST#%%' AND {TTL_LIVE}
+            """,
+            (str(github_user_id),),
+        ).fetchall()
+    return [decode_item(*r) for r in rows]
+
+
+def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
+    item = _get_item(_inst_pk(install_id), _repo_sk(repo_id))
+    if not item:
+        return {
+            **_DEFAULT_PERSONA_CONFIG,
+            "enforcement_ruleset_id": None,
+            "force_disable_enforcement": False,
+        }
+    rid = item.get("enforcement_ruleset_id")
+    return {
+        "tpm_enabled": bool(
+            item.get("tpm_enabled", _DEFAULT_PERSONA_CONFIG["tpm_enabled"])
+        ),
+        "code_reviewer_enabled": bool(
+            item.get(
+                "code_reviewer_enabled",
+                _DEFAULT_PERSONA_CONFIG["code_reviewer_enabled"],
+            )
+        ),
+        "code_reviewer_blocking": bool(
+            item.get(
+                "code_reviewer_blocking",
+                _DEFAULT_PERSONA_CONFIG["code_reviewer_blocking"],
+            )
+        ),
+        "enforcement_ruleset_id": int(rid) if rid is not None else None,
+        "force_disable_enforcement": bool(item.get("force_disable_enforcement", False)),
+    }
+
+
+def _merge_attrs(pk: str, sk: str, attrs: dict[str, Any]) -> None:
+    """Sparse jsonb merge-upsert (DDB update_item SET parity: creates the
+    row when absent, merges fields when present)."""
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data) VALUES (%(pk)s, %(sk)s, %(data)s)
+            ON CONFLICT (pk, sk) DO UPDATE SET data = grug_kv.data || %(data)s
+            """,
+            {"pk": pk, "sk": sk, "data": encode_attrs(attrs)},
+        )
+
+
+def set_repo_config(
+    *,
+    install_id: int,
+    repo_id: int,
+    repo_full_name: str,
+    tpm_enabled: bool,
+    updated_by_user_id: str,
+    code_reviewer_enabled: bool | None = None,
+    code_reviewer_blocking: bool | None = None,
+) -> dict[str, Any]:
+    """Upsert per-repo override; returns the FIELDS THAT WERE UPDATED
+    (same contract as the DDB adapter). Sparse merge preserves fields
+    managed by other writers (enforcement_ruleset_id)."""
+    now = datetime.now(timezone.utc).isoformat()
+    attrs: dict[str, Any] = {
+        "repo_full_name": repo_full_name,
+        "tpm_enabled": bool(tpm_enabled),
+        "updated_at": now,
+        "updated_by_user_id": str(updated_by_user_id),
+    }
+    if code_reviewer_enabled is not None:
+        attrs["code_reviewer_enabled"] = bool(code_reviewer_enabled)
+    if code_reviewer_blocking is not None:
+        attrs["code_reviewer_blocking"] = bool(code_reviewer_blocking)
+    _merge_attrs(_inst_pk(install_id), _repo_sk(repo_id), attrs)
+
+    updated_fields: dict[str, Any] = {"tpm_enabled": bool(tpm_enabled)}
+    if code_reviewer_enabled is not None:
+        updated_fields["code_reviewer_enabled"] = bool(code_reviewer_enabled)
+    if code_reviewer_blocking is not None:
+        updated_fields["code_reviewer_blocking"] = bool(code_reviewer_blocking)
+    return updated_fields
+
+
+def get_enforcement_id(install_id: int, repo_id: int) -> int | None:
+    item = _get_item(_inst_pk(install_id), _repo_sk(repo_id))
+    if not item:
+        return None
+    val = item.get("enforcement_ruleset_id")
+    return int(val) if val is not None else None
+
+
+def set_enforcement_id(
+    install_id: int,
+    repo_id: int,
+    ruleset_id: int | None,
+) -> None:
+    """Update only enforcement_ruleset_id (REMOVE semantics for None)."""
+    if ruleset_id is not None:
+        _merge_attrs(
+            _inst_pk(install_id),
+            _repo_sk(repo_id),
+            {"enforcement_ruleset_id": ruleset_id},
+        )
+    else:
+        with get_pool().connection() as conn:
+            conn.execute(
+                """
+                UPDATE grug_kv SET data = data - 'enforcement_ruleset_id'
+                WHERE pk = %s AND sk = %s
+                """,
+                (_inst_pk(install_id), _repo_sk(repo_id)),
+            )
+
+
+def is_persona_enabled(install_id: int, repo_id: int, persona: str) -> bool:
+    cfg = get_repo_config(install_id, repo_id)
+    key = f"{persona}_enabled"
+    return bool(cfg.get(key, _DEFAULT_PERSONA_CONFIG.get(key, True)))
+
+
+# ---------------------------------------------------------------------------
+# Elder reaction-poll comment records (#245)
+# ---------------------------------------------------------------------------
+
+
+class CommentRecord(TypedDict):
+    comment_id: int
+    repo: str
+    pr_number: int
+    review_span_context: Optional[dict]
+    finding_tags: dict[str, str]
+    last_verdict: NotRequired[Optional[str]]
+
+
+def _comment_record_sk(comment_id: int | str) -> str:
+    return f"CRCOMMENT#{comment_id}"
+
+
+_COMMENT_RECORD_TTL_DAYS = 30
+
+
+def put_comment_record(
+    *,
+    install_id: int,
+    comment_id: int,
+    repo: str,
+    pr_number: int,
+    review_span_context: dict,
+    finding_tags: dict,
+) -> None:
+    ttl = int(
+        datetime.now(timezone.utc).timestamp() + _COMMENT_RECORD_TTL_DAYS * 86400
+    )
+    attrs = {
+        "comment_id": int(comment_id),
+        "repo": repo,
+        "pr_number": int(pr_number),
+        "review_span_context": review_span_context,
+        "finding_tags": finding_tags,
+        "ttl": ttl,
+    }
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, ttl)
+            VALUES (%(pk)s, %(sk)s, %(data)s, %(ttl)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = %(data)s, ttl = %(ttl)s
+            """,
+            {
+                "pk": _inst_pk(install_id),
+                "sk": _comment_record_sk(comment_id),
+                "data": encode_attrs(attrs),
+                "ttl": ttl,
+            },
+        )
+
+
+class CheckVerdictRecord(TypedDict):
+    persona: str
+    repo: str
+    pr_number: int
+    head_sha: str
+    conclusion: str
+    summary: str
+    findings_count: int
+    blocking: bool
+    verdict: str
+    created_at: str
+    degraded_reason: NotRequired[Optional[str]]
+
+
+_CHECK_VERDICT_TTL_DAYS = 90
+
+
+def _check_verdict_sk(head_sha: str, persona: str) -> str:
+    return f"ACT#{head_sha}#{persona}"
+
+
+def put_check_verdict(
+    *,
+    install_id: int,
+    persona: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    conclusion: str,
+    summary: str,
+    findings_count: int,
+    blocking: bool,
+    created_at: str,
+    degraded_reason: Optional[str] = None,
+) -> None:
+    """Upsert a Check verdict; the denormalized `verdict` badge is DERIVED
+    via review_types.verdict (never a parameter) - ADR-0003 invariant
+    enforced by construction, identical to the DDB adapter."""
+    ttl = int(
+        datetime.now(timezone.utc).timestamp() + _CHECK_VERDICT_TTL_DAYS * 86400
+    )
+    attrs: dict[str, Any] = {
+        "persona": persona,
+        "repo": repo,
+        "pr_number": int(pr_number),
+        "head_sha": head_sha,
+        "conclusion": conclusion,
+        "summary": summary,
+        "findings_count": int(findings_count),
+        "blocking": bool(blocking),
+        "verdict": _derive_verdict(
+            conclusion=conclusion,
+            findings_count=int(findings_count),
+            degraded_reason=degraded_reason,
+        ),
+        "created_at": created_at,
+        "ttl": ttl,
+    }
+    if degraded_reason:
+        attrs["degraded_reason"] = degraded_reason
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, ttl)
+            VALUES (%(pk)s, %(sk)s, %(data)s, %(ttl)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = %(data)s, ttl = %(ttl)s
+            """,
+            {
+                "pk": _inst_pk(install_id),
+                "sk": _check_verdict_sk(head_sha, persona),
+                "data": encode_attrs(attrs),
+                "ttl": ttl,
+            },
+        )
+
+
+def list_check_verdicts(
+    install_id: int,
+    limit: int | None = 50,
+) -> list[CheckVerdictRecord]:
+    """An install's Check verdicts, newest-first. Sorting moves into SQL
+    (created_at is an ISO-8601 string; lexicographic == chronological);
+    the limit is still applied AFTER the full fetch shape the DDB
+    adapter documented (callers like /activity re-filter)."""
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE pk = %s AND sk LIKE 'ACT#%%' AND {TTL_LIVE}
+            ORDER BY data->>'created_at' DESC
+            """,
+            (_inst_pk(install_id),),
+        ).fetchall()
+    out: list[CheckVerdictRecord] = []
+    for pk, sk, data in rows:
+        item = decode_item(pk, sk, data)
+        rec: CheckVerdictRecord = {
+            "persona": str(item["persona"]),
+            "repo": str(item["repo"]),
+            "pr_number": int(item["pr_number"]),
+            "head_sha": str(item["head_sha"]),
+            "conclusion": str(item["conclusion"]),
+            "summary": str(item.get("summary", "")),
+            "findings_count": int(item.get("findings_count", 0)),
+            "blocking": bool(item.get("blocking", False)),
+            "verdict": str(item.get("verdict", "")),
+            "created_at": str(item["created_at"]),
+        }
+        if "degraded_reason" in item:
+            rec["degraded_reason"] = item["degraded_reason"]
+        out.append(rec)
+    return out if limit is None else out[:limit]
+
+
+_DELIVERY_CLAIM_TTL_HOURS = 24
+
+
+def _delivery_pk(delivery_id: str) -> str:
+    return f"DELIVERY#{delivery_id}"
+
+
+def claim_delivery(delivery_id: str) -> bool:
+    """Win-once idempotency claim. True = this caller won; False = the
+    delivery was already claimed (redelivery / async retry -> SKIP).
+
+    Atomic single statement. The ON CONFLICT UPDATE arm takes over a row
+    ONLY when its claim has TTL-expired - DDB's TTL machinery would have
+    deleted such a row, so an expired claim must read as free here too.
+    Fails OPEN on empty delivery_id (same reasoning as the DDB adapter:
+    a possible double-review beats a silently-skipped one). Any other
+    database error propagates - callers degrade explicitly, we never
+    swallow into a false 'claimed'.
+    """
+    if not delivery_id:
+        return True
+    pg_base.maybe_purge_expired()
+    ttl = int(
+        datetime.now(timezone.utc).timestamp() + _DELIVERY_CLAIM_TTL_HOURS * 3600
+    )
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, ttl)
+            VALUES (%(pk)s, 'META', %(data)s, %(ttl)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = %(data)s, ttl = %(ttl)s
+                WHERE grug_kv.ttl IS NOT NULL
+                  AND grug_kv.ttl <= EXTRACT(EPOCH FROM now())
+            RETURNING pk
+            """,
+            {
+                "pk": _delivery_pk(delivery_id),
+                "data": Jsonb({"ttl": ttl}),
+                "ttl": ttl,
+            },
+        ).fetchone()
+    return row is not None
+
+
+def list_comment_records(install_id: int) -> list[CommentRecord]:
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE pk = %s AND sk LIKE 'CRCOMMENT#%%' AND {TTL_LIVE}
+            """,
+            (_inst_pk(install_id),),
+        ).fetchall()
+    out: list[CommentRecord] = []
+    for pk, sk, data in rows:
+        item = decode_item(pk, sk, data)
+        out.append(
+            {
+                "comment_id": int(item["comment_id"]),
+                "repo": item["repo"],
+                "pr_number": int(item["pr_number"]),
+                "review_span_context": item.get("review_span_context"),
+                "finding_tags": item.get("finding_tags", {}),
+                "last_verdict": item.get("last_verdict"),
+            }
+        )
+    return out
+
+
+def update_comment_record_reaction(
+    *,
+    install_id: int,
+    comment_id: int,
+    verdict: str,
+) -> None:
+    _merge_attrs(
+        _inst_pk(install_id),
+        _comment_record_sk(comment_id),
+        {"last_verdict": verdict},
+    )

--- a/services/api/adapters/pg_user_store.py
+++ b/services/api/adapters/pg_user_store.py
@@ -1,0 +1,289 @@
+"""Postgres user store - exact-API port of user_store.py (DDB).
+
+api-only (the webhook never touches user rows beyond the read in
+install_store.is_install_allowlisted). KMS envelope encryption is
+UNCHANGED - this module stores/returns the same opaque encrypted blobs
+(bytes ride the jsonb column via pg_base's b64 sentinel codec).
+
+Also exposes the three store operations admin.py previously performed
+with raw `_table` access (scan_meta_items / get_user_item /
+update_user_fields) so the route module stops reaching into storage
+internals at cutover.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import psycopg
+
+from adapters.pg_base import TTL_LIVE, decode_item, encode_attrs, get_pool
+
+log = logging.getLogger("grug.api.adapters.pg_user_store")
+
+
+@dataclass(frozen=True)
+class UserIdentity:
+    """Identity-only projection of a user row. NO token material."""
+
+    github_user_id: str
+    login: str
+    role: str  # "admin" | "user"
+    tier: str  # "lifetime" | "free" | "paid"
+    allowlisted: bool
+    created_at: str
+    allowlisted_at: str | None
+    allowlisted_by: str | None
+
+
+@dataclass(frozen=True)
+class UserWithTokens:
+    """Identity + decrypted OAuth tokens (OAuth callback/refresh only)."""
+
+    identity: UserIdentity
+    oauth_access_token: str
+    oauth_refresh_token: str | None
+
+
+def _user_pk(github_user_id: str) -> str:
+    return f"USER#{github_user_id}"
+
+
+def _fetch_item(github_user_id: str) -> dict[str, Any] | None:
+    try:
+        with get_pool().connection() as conn:
+            row = conn.execute(
+                f"SELECT pk, sk, data FROM grug_kv "
+                f"WHERE pk = %s AND sk = 'META' AND {TTL_LIVE}",
+                (_user_pk(github_user_id),),
+            ).fetchone()
+    except psycopg.Error as e:
+        # Same contract as the DDB adapter: surface infrastructure
+        # failures distinctly from a legitimate miss, or a transient DB
+        # error would spuriously log the user out (silent-failure P1 #2).
+        log.error(
+            "user_store_get_item_failed",
+            extra={"github_user_id": github_user_id, "code": type(e).__name__},
+        )
+        raise
+    if not row:
+        return None
+    return decode_item(row[0], row[1], row[2])
+
+
+def _identity_from_item(github_user_id: str, item: dict[str, Any]) -> UserIdentity:
+    return UserIdentity(
+        github_user_id=github_user_id,
+        login=item.get("login", ""),
+        role=item.get("role", "user"),
+        tier=item.get("tier", "free"),
+        allowlisted=bool(item.get("allowlisted", False)),
+        created_at=item.get("created_at", ""),
+        allowlisted_at=item.get("allowlisted_at"),
+        allowlisted_by=item.get("allowlisted_by"),
+    )
+
+
+def get_user(github_user_id: str) -> UserIdentity | None:
+    item = _fetch_item(github_user_id)
+    if not item:
+        return None
+    return _identity_from_item(github_user_id, item)
+
+
+def delete_user_state(github_user_id: str) -> None:
+    """Idempotently REMOVE only the credential blobs (spec 0005
+    PurgeCorrupt): identity fields are PRESERVED - an encryption failure
+    must not strip an admin's privileges or a paid user's tier."""
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            UPDATE grug_kv
+            SET data = data - 'oauth_access_token_blob' - 'oauth_refresh_token_blob'
+            WHERE pk = %s AND sk = 'META'
+            """,
+            (_user_pk(github_user_id),),
+        )
+
+
+def get_user_with_tokens(github_user_id: str) -> UserWithTokens | None:
+    """Identity + decrypted OAuth tokens, or None. KMS Decrypt happens
+    here; CredentialBlobCorrupt triggers the documented opportunistic
+    purge + clean miss (user re-auths)."""
+    from crypto.kms_envelope import CredentialBlobCorrupt, decrypt_for_user  # lazy
+
+    item = _fetch_item(github_user_id)
+    if not item:
+        return None
+
+    try:
+        encrypted_token = item.get("oauth_access_token_blob")
+        if encrypted_token:
+            blob = (
+                encrypted_token.value
+                if hasattr(encrypted_token, "value")
+                else encrypted_token
+            )
+            access_token = decrypt_for_user(
+                blob=blob, user_id=github_user_id, item_type="oauth_access_token"
+            )
+        else:
+            access_token = ""
+
+        encrypted_refresh = item.get("oauth_refresh_token_blob")
+        refresh_token: str | None = None
+        if encrypted_refresh:
+            blob = (
+                encrypted_refresh.value
+                if hasattr(encrypted_refresh, "value")
+                else encrypted_refresh
+            )
+            refresh_token = decrypt_for_user(
+                blob=blob, user_id=github_user_id, item_type="oauth_refresh_token"
+            )
+    except CredentialBlobCorrupt as exc:
+        log.error(
+            "credential_blob_corrupt_purging_row",
+            extra={"github_user_id": github_user_id, "reason": str(exc)},
+        )
+        try:
+            delete_user_state(github_user_id)
+        except psycopg.Error as purge_exc:
+            log.error(
+                "credential_blob_corrupt_purge_failed",
+                extra={
+                    "github_user_id": github_user_id,
+                    "purge_code": type(purge_exc).__name__,
+                    "original_reason": str(exc),
+                },
+            )
+        return None
+
+    return UserWithTokens(
+        identity=_identity_from_item(github_user_id, item),
+        oauth_access_token=access_token,
+        oauth_refresh_token=refresh_token,
+    )
+
+
+def upsert_oauth_user(
+    *,
+    github_user_id: str,
+    login: str,
+    oauth_access_token: str,
+    oauth_refresh_token: str | None = None,
+) -> UserIdentity:
+    """Atomic create-or-update from the OAuth callback flow.
+
+    Single-statement upsert: identity fields (role/tier/allowlisted/
+    created_at) default on first sight and are PRESERVED on re-auth -
+    no read-then-write window in which an admin-side change could be
+    silently reverted (lost-update anomaly, peer-review CRITICAL 4x on
+    the DDB original). An existing refresh blob is preserved when GitHub
+    re-auth returns access without rotating refresh (Sentry HIGH #39).
+    """
+    from crypto.kms_envelope import encrypt_for_user  # lazy import
+
+    now = datetime.now(timezone.utc).isoformat()
+    encrypted_access = encrypt_for_user(
+        plaintext=oauth_access_token,
+        user_id=github_user_id,
+        item_type="oauth_access_token",
+    )
+
+    always: dict[str, Any] = {
+        "login": login,
+        "oauth_access_token_blob": encrypted_access,
+        "last_login_at": now,
+    }
+    if oauth_refresh_token:
+        always["oauth_refresh_token_blob"] = encrypt_for_user(
+            plaintext=oauth_refresh_token,
+            user_id=github_user_id,
+            item_type="oauth_refresh_token",
+        )
+    defaults: dict[str, Any] = {
+        "role": "user",
+        "tier": "free",
+        "allowlisted": False,
+        "created_at": now,
+    }
+
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data)
+            VALUES (%(pk)s, 'META', %(defaults)s || %(always)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = (%(defaults)s || grug_kv.data) || %(always)s
+            RETURNING pk, sk, data
+            """,
+            {
+                "pk": _user_pk(github_user_id),
+                "defaults": encode_attrs(defaults),
+                "always": encode_attrs(always),
+            },
+        ).fetchone()
+    item = decode_item(row[0], row[1], row[2])
+
+    return UserIdentity(
+        github_user_id=github_user_id,
+        login=login,
+        role=item["role"],
+        tier=item["tier"],
+        allowlisted=bool(item["allowlisted"]),
+        created_at=item["created_at"],
+        allowlisted_at=item.get("allowlisted_at"),
+        allowlisted_by=item.get("allowlisted_by"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Admin support (previously raw `_table` access inside admin.py)
+# ---------------------------------------------------------------------------
+
+
+def scan_meta_items(*, pk_prefix: str) -> list[dict[str, Any]]:
+    """All live META rows whose PK starts with `pk_prefix` (USER#/INST#).
+
+    The DDB version paginated a 1MB-page Scan with a 50-page defensive
+    cap; a single indexed WHERE replaces it.
+    """
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE sk = 'META' AND pk LIKE %s AND {TTL_LIVE}
+            """,
+            (pk_prefix.replace("%", r"\%").replace("_", r"\_") + "%",),
+        ).fetchall()
+    return [decode_item(*r) for r in rows]
+
+
+def get_user_item(user_id: str) -> dict[str, Any] | None:
+    """Raw user item for admin views (includes audit fields)."""
+    return _fetch_item(str(user_id))
+
+
+def update_user_fields(user_id: str, fields: dict[str, Any]) -> dict[str, Any]:
+    """Merge `fields` into an EXISTING user row; returns the new item.
+
+    Admin-only path; the caller has already 404'd on a missing row, but
+    enforce it here too (the WHERE) so a race with row deletion cannot
+    resurrect a sparse row.
+    """
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            """
+            UPDATE grug_kv SET data = data || %(fields)s
+            WHERE pk = %(pk)s AND sk = 'META'
+            RETURNING pk, sk, data
+            """,
+            {"pk": _user_pk(str(user_id)), "fields": encode_attrs(fields)},
+        ).fetchone()
+    if row is None:
+        raise LookupError(f"user row vanished during update: {user_id}")
+    return decode_item(row[0], row[1], row[2])

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -9,3 +9,6 @@ pyjwt[crypto]>=2.9,<3.0
 cryptography>=43.0,<44.0
 ddtrace>=3.5,<4
 datadog-lambda>=6.107,<7
+# Postgres store (#306 epic store port) - pool included for the
+# long-lived k8s runtime (Lambda used per-invoke connections).
+psycopg[binary,pool]>=3.2,<4.0

--- a/services/api/tests/test_pg_stores.py
+++ b/services/api/tests/test_pg_stores.py
@@ -1,0 +1,395 @@
+"""Real-Postgres tests for the pg_* store port (#354).
+
+These run against a REAL Postgres (CI: the workflow's postgres service
+container; locally: any reachable instance) via GRUG_TEST_DATABASE_URL.
+SQLite stand-ins are banned for this suite - the semantics under test
+(ON CONFLICT atomicity, jsonb merge, concurrent claims) are exactly the
+ones a fake gets wrong.
+
+Skips LOUDLY when GRUG_TEST_DATABASE_URL is unset so a local run without
+a database cannot silently pass as coverage.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+_TEST_DB = os.environ.get("GRUG_TEST_DATABASE_URL", "")
+
+pytestmark = pytest.mark.skipif(
+    not _TEST_DB,
+    reason=(
+        "GRUG_TEST_DATABASE_URL unset - pg store tests REQUIRE a real "
+        "Postgres (CI provides a service container; this is not optional "
+        "coverage, do not fake it with sqlite)"
+    ),
+)
+
+
+@pytest.fixture()
+def pg(monkeypatch):
+    """Fresh schema per test: point the pool at the test DB and truncate."""
+    monkeypatch.setenv("GRUG_DATABASE_URL", _TEST_DB)
+    from adapters import pg_base
+
+    pg_base.reset_pool_for_tests()
+    pool = pg_base.get_pool()
+    with pool.connection() as conn:
+        conn.execute("TRUNCATE grug_kv")
+    yield pg_base
+    pg_base.reset_pool_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# install store
+# ---------------------------------------------------------------------------
+
+
+def test_record_then_lookup_roundtrip(pg):
+    from adapters import pg_install_store as store
+
+    store.record_installation(
+        install_id=42,
+        account_login="cavetown",
+        account_type="Organization",
+        installed_by_user_id=7,
+    )
+    item = store.get_installation(42)
+    assert item is not None
+    assert item["account_login"] == "cavetown"
+    assert item["PK"] == "INST#42"
+    assert item["installed_at"]
+
+
+def test_duplicate_delivery_preserves_installed_at(pg):
+    from adapters import pg_install_store as store
+
+    store.record_installation(
+        install_id=1, account_login="a", account_type="User", installed_by_user_id=9
+    )
+    first = store.get_installation(1)["installed_at"]
+    time.sleep(0.01)
+    store.record_installation(
+        install_id=1, account_login="a2", account_type="User", installed_by_user_id=9
+    )
+    again = store.get_installation(1)
+    assert again["installed_at"] == first  # if_not_exists parity
+    assert again["account_login"] == "a2"  # other fields DO update
+
+
+def test_delete_installation(pg):
+    from adapters import pg_install_store as store
+
+    store.record_installation(
+        install_id=5, account_login="x", account_type="User", installed_by_user_id=2
+    )
+    store.delete_installation(5)
+    assert store.get_installation(5) is None
+
+
+def test_allowlist_two_hop(pg):
+    from adapters import pg_install_store as store
+    from adapters import pg_user_store as users
+
+    store.record_installation(
+        install_id=10, account_login="org", account_type="Org", installed_by_user_id=77
+    )
+    assert store.is_install_allowlisted(10) is False  # no USER row
+    _seed_user(pg, "77", allowlisted=False)
+    assert store.is_install_allowlisted(10) is False
+    users.update_user_fields("77", {"allowlisted": True})
+    assert store.is_install_allowlisted(10) is True
+    assert store.list_allowlisted_installs() == [10]
+
+
+def test_list_user_installations_via_gsi(pg):
+    from adapters import pg_install_store as store
+
+    for iid in (1, 2):
+        store.record_installation(
+            install_id=iid,
+            account_login=f"a{iid}",
+            account_type="User",
+            installed_by_user_id=55,
+        )
+    store.record_installation(
+        install_id=3, account_login="other", account_type="User", installed_by_user_id=66
+    )
+    rows = store.list_user_installations("55")
+    assert sorted(r["PK"] for r in rows) == ["INST#1", "INST#2"]
+
+
+def test_repo_config_defaults_sparse_update_and_enforcement_remove(pg):
+    from adapters import pg_install_store as store
+
+    cfg = store.get_repo_config(1, 2)
+    assert cfg["tpm_enabled"] is True and cfg["enforcement_ruleset_id"] is None
+
+    store.set_repo_config(
+        install_id=1,
+        repo_id=2,
+        repo_full_name="o/r",
+        tpm_enabled=False,
+        updated_by_user_id="9",
+    )
+    store.set_enforcement_id(1, 2, 123)
+    cfg = store.get_repo_config(1, 2)
+    # sparse update preserved the enforcement id set by the other writer
+    assert cfg["tpm_enabled"] is False
+    assert cfg["enforcement_ruleset_id"] == 123
+    # code_reviewer_* untouched -> defaults
+    assert cfg["code_reviewer_enabled"] is True
+
+    store.set_enforcement_id(1, 2, None)  # REMOVE semantics
+    assert store.get_enforcement_id(1, 2) is None
+    # ...without nuking the rest of the row
+    assert store.get_repo_config(1, 2)["tpm_enabled"] is False
+
+
+def test_check_verdicts_upsert_order_limit_and_derived_verdict(pg):
+    from adapters import pg_install_store as store
+
+    for i, sha in enumerate(["aaa", "bbb", "ccc"]):
+        store.put_check_verdict(
+            install_id=1,
+            persona="elder",
+            repo="o/r",
+            pr_number=1,
+            head_sha=sha,
+            conclusion="neutral",
+            summary="s",
+            findings_count=0,
+            blocking=False,
+            created_at=f"2026-06-12T0{i}:00:00+00:00",
+        )
+    # re-review of bbb upserts (heals), not appends
+    store.put_check_verdict(
+        install_id=1,
+        persona="elder",
+        repo="o/r",
+        pr_number=1,
+        head_sha="bbb",
+        conclusion="neutral",
+        summary="healed",
+        findings_count=2,
+        blocking=False,
+        created_at="2026-06-12T05:00:00+00:00",
+    )
+    rows = store.list_check_verdicts(1)
+    assert len(rows) == 3
+    assert rows[0]["head_sha"] == "bbb" and rows[0]["summary"] == "healed"
+    assert [r["head_sha"] for r in rows] == ["bbb", "ccc", "aaa"]  # newest-first
+    assert store.list_check_verdicts(1, limit=2)[1]["head_sha"] == "ccc"
+    # verdict is DERIVED, never trusted from a caller
+    assert all(r["verdict"] for r in rows)
+
+    degraded = store.list_check_verdicts(1, limit=None)
+    assert "degraded_reason" not in degraded[0]  # sparse when falsy
+
+
+def test_claim_delivery_win_once_and_expired_takeover(pg):
+    from adapters import pg_install_store as store
+
+    did = str(uuid.uuid4())
+    assert store.claim_delivery(did) is True
+    assert store.claim_delivery(did) is False  # redelivery loses
+    assert store.claim_delivery("") is True  # fails OPEN by contract
+
+    # Expire the claim manually -> next claim must WIN (DDB's TTL would
+    # have deleted the row; PG must treat expired as free).
+    with store.get_pool().connection() as conn:
+        conn.execute(
+            "UPDATE grug_kv SET ttl = EXTRACT(EPOCH FROM now())::bigint - 10 "
+            "WHERE pk = %s",
+            (f"DELIVERY#{did}",),
+        )
+    assert store.claim_delivery(did) is True
+
+
+def test_claim_delivery_concurrent_exactly_one_winner(pg):
+    """The reason this suite needs REAL Postgres: N racing claimants,
+    exactly one True."""
+    from adapters import pg_install_store as store
+
+    did = str(uuid.uuid4())
+    results: list[bool] = []
+    barrier = threading.Barrier(8)
+
+    def claim():
+        barrier.wait()
+        results.append(store.claim_delivery(did))
+
+    threads = [threading.Thread(target=claim) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+
+
+def test_comment_records_roundtrip_and_ttl_filtering(pg):
+    from adapters import pg_install_store as store
+
+    store.put_comment_record(
+        install_id=1,
+        comment_id=100,
+        repo="o/r",
+        pr_number=5,
+        review_span_context={"trace": "t"},
+        finding_tags={"k": "v"},
+    )
+    recs = store.list_comment_records(1)
+    assert recs[0]["comment_id"] == 100 and recs[0]["last_verdict"] is None
+
+    store.update_comment_record_reaction(install_id=1, comment_id=100, verdict="up")
+    assert store.list_comment_records(1)[0]["last_verdict"] == "up"
+
+    # Expired records vanish from reads even before any purge runs.
+    with store.get_pool().connection() as conn:
+        conn.execute(
+            "UPDATE grug_kv SET ttl = EXTRACT(EPOCH FROM now())::bigint - 10 "
+            "WHERE sk = 'CRCOMMENT#100'"
+        )
+    assert store.list_comment_records(1) == []
+
+
+# ---------------------------------------------------------------------------
+# user store (KMS faked - the envelope is out of scope, storage is not)
+# ---------------------------------------------------------------------------
+
+
+def _seed_user(pg, user_id: str, *, allowlisted: bool) -> None:
+    from adapters.pg_base import encode_attrs, get_pool
+
+    with get_pool().connection() as conn:
+        conn.execute(
+            "INSERT INTO grug_kv (pk, sk, data) VALUES (%s, 'META', %s) "
+            "ON CONFLICT (pk, sk) DO UPDATE SET data = excluded.data",
+            (
+                f"USER#{user_id}",
+                encode_attrs(
+                    {
+                        "login": f"u{user_id}",
+                        "role": "user",
+                        "tier": "free",
+                        "allowlisted": allowlisted,
+                        "created_at": "2026-01-01T00:00:00+00:00",
+                    }
+                ),
+            ),
+        )
+
+
+@pytest.fixture()
+def fake_kms(monkeypatch):
+    """Reversible fake envelope: ciphertext = b'enc:' + plaintext bytes.
+    Exercises the bytes-through-jsonb codec end-to-end."""
+    import crypto.kms_envelope as kms
+
+    monkeypatch.setattr(
+        kms,
+        "encrypt_for_user",
+        lambda *, plaintext, user_id, item_type: b"enc:" + plaintext.encode(),
+    )
+    monkeypatch.setattr(
+        kms,
+        "decrypt_for_user",
+        lambda *, blob, user_id, item_type: blob[4:].decode(),
+    )
+    return kms
+
+
+def test_oauth_upsert_defaults_then_preserves_admin_changes(pg, fake_kms):
+    from adapters import pg_user_store as users
+
+    ident = users.upsert_oauth_user(
+        github_user_id="9", login="grug", oauth_access_token="tok-1"
+    )
+    assert (ident.role, ident.tier, ident.allowlisted) == ("user", "free", False)
+    created = ident.created_at
+
+    # Admin flips fields between logins...
+    users.update_user_fields("9", {"allowlisted": True, "role": "admin"})
+    # ...and a re-auth must NOT revert them (lost-update parity).
+    ident2 = users.upsert_oauth_user(
+        github_user_id="9", login="grug", oauth_access_token="tok-2"
+    )
+    assert ident2.allowlisted is True and ident2.role == "admin"
+    assert ident2.created_at == created
+
+    got = users.get_user_with_tokens("9")
+    assert got.oauth_access_token == "tok-2"
+    assert got.oauth_refresh_token is None
+
+
+def test_refresh_blob_preserved_when_not_rotated(pg, fake_kms):
+    from adapters import pg_user_store as users
+
+    users.upsert_oauth_user(
+        github_user_id="3",
+        login="x",
+        oauth_access_token="a1",
+        oauth_refresh_token="r1",
+    )
+    # Re-auth WITHOUT a refresh token must keep the old one (Sentry HIGH #39).
+    users.upsert_oauth_user(github_user_id="3", login="x", oauth_access_token="a2")
+    got = users.get_user_with_tokens("3")
+    assert got.oauth_access_token == "a2"
+    assert got.oauth_refresh_token == "r1"
+
+
+def test_delete_user_state_preserves_identity(pg, fake_kms):
+    from adapters import pg_user_store as users
+
+    users.upsert_oauth_user(github_user_id="4", login="y", oauth_access_token="a")
+    users.update_user_fields("4", {"role": "admin", "tier": "lifetime"})
+    users.delete_user_state("4")
+    ident = users.get_user("4")
+    assert ident.role == "admin" and ident.tier == "lifetime"  # CRITICAL 4x parity
+    got = users.get_user_with_tokens("4")
+    assert got.oauth_access_token == ""  # blobs gone
+
+
+def test_corrupt_blob_purges_and_returns_none(pg, fake_kms, monkeypatch):
+    import crypto.kms_envelope as kms
+    from adapters import pg_user_store as users
+
+    users.upsert_oauth_user(github_user_id="6", login="z", oauth_access_token="a")
+
+    def boom(*, blob, user_id, item_type):
+        raise kms.CredentialBlobCorrupt("bad blob")
+
+    monkeypatch.setattr(kms, "decrypt_for_user", boom)
+    assert users.get_user_with_tokens("6") is None
+    # Identity survives the purge; blobs are gone.
+    assert users.get_user("6").login == "z"
+    with users.get_pool().connection() as conn:
+        (data,) = conn.execute(
+            "SELECT data FROM grug_kv WHERE pk = 'USER#6'"
+        ).fetchone()
+    assert "oauth_access_token_blob" not in data
+
+
+def test_admin_scan_and_update(pg, fake_kms):
+    from adapters import pg_user_store as users
+    from adapters import pg_install_store as store
+
+    users.upsert_oauth_user(github_user_id="1", login="a", oauth_access_token="t")
+    store.record_installation(
+        install_id=9, account_login="o", account_type="Org", installed_by_user_id=1
+    )
+    assert [i["PK"] for i in users.scan_meta_items(pk_prefix="USER#")] == ["USER#1"]
+    assert [i["PK"] for i in users.scan_meta_items(pk_prefix="INST#")] == ["INST#9"]
+    new = users.update_user_fields("1", {"tier": "paid"})
+    assert new["tier"] == "paid"
+    assert users.get_user_item("1")["tier"] == "paid"

--- a/services/api/tests/test_pg_stores.py
+++ b/services/api/tests/test_pg_stores.py
@@ -237,6 +237,38 @@ def test_claim_delivery_concurrent_exactly_one_winner(pg):
     assert results.count(False) == 7
 
 
+def test_claim_delivery_concurrent_expired_takeover_exactly_one_winner(pg):
+    """The takeover WHERE clause's race: N claimants see the SAME expired
+    row; ON CONFLICT re-evaluation against the winner's committed tuple
+    must yield exactly one True (audit M7 - the arm the fresh-pk race
+    never exercises)."""
+    from adapters import pg_install_store as store
+
+    did = str(uuid.uuid4())
+    assert store.claim_delivery(did) is True
+    with store.get_pool().connection() as conn:
+        conn.execute(
+            "UPDATE grug_kv SET ttl = EXTRACT(EPOCH FROM now())::bigint - 10 "
+            "WHERE pk = %s",
+            (f"DELIVERY#{did}",),
+        )
+
+    results: list[bool] = []
+    barrier = threading.Barrier(8)
+
+    def claim():
+        barrier.wait()
+        results.append(store.claim_delivery(did))
+
+    threads = [threading.Thread(target=claim) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+
+
 def test_comment_records_roundtrip_and_ttl_filtering(pg):
     from adapters import pg_install_store as store
 

--- a/services/webhook/adapters/pg_base.py
+++ b/services/webhook/adapters/pg_base.py
@@ -33,10 +33,12 @@ first pool acquisition; concurrent bootstrappers are safe (IF NOT EXISTS
 from __future__ import annotations
 
 import base64
+import binascii
 import logging
 import os
 import threading
 import time
+from decimal import Decimal
 from typing import Any
 
 import psycopg
@@ -96,18 +98,31 @@ def get_pool() -> ConnectionPool:
                     min_size=1,
                     max_size=int(os.environ.get("GRUG_PG_POOL_MAX", "5")),
                     open=True,
+                    # Validate connections at checkout: long-lived pools
+                    # accumulate dead sockets across idle timeouts (and
+                    # Lambda freeze/thaw in the interim deploy shape) -
+                    # without this the FIRST request per stale socket
+                    # 500s (audit M5).
+                    check=ConnectionPool.check_connection,
+                    max_idle=300,
                 )
-                with pool.connection() as conn:
-                    # Advisory lock so N replicas bootstrapping at once
-                    # don't race the CREATEs (IF NOT EXISTS is safe but
-                    # noisy under contention).
-                    conn.execute("SELECT pg_advisory_lock(%s)", (_BOOTSTRAP_LOCK_KEY,))
-                    try:
-                        conn.execute(_SCHEMA)
-                    finally:
+                try:
+                    with pool.connection() as conn:
+                        # TRANSACTION-scoped advisory lock (audit C1): the
+                        # session-scoped variant is NOT released by abort,
+                        # so a failed CREATE would leak the lock into the
+                        # orphaned pool and every retry fleet-wide would
+                        # block forever inside pg_advisory_lock. The xact
+                        # lock auto-releases on commit AND abort, and the
+                        # original error stays the visible one.
                         conn.execute(
-                            "SELECT pg_advisory_unlock(%s)", (_BOOTSTRAP_LOCK_KEY,)
+                            "SELECT pg_advisory_xact_lock(%s)",
+                            (_BOOTSTRAP_LOCK_KEY,),
                         )
+                        conn.execute(_SCHEMA)
+                except BaseException:
+                    pool.close()
+                    raise
                 _pool = pool
     return _pool
 
@@ -125,6 +140,11 @@ def reset_pool_for_tests() -> None:
 def _encode_value(v: Any) -> Any:
     if isinstance(v, bytes):
         return {"__b64__": base64.b64encode(v).decode("ascii")}
+    # boto3 resource-mode returns EVERY DDB number as Decimal; the cutover
+    # migration feeds those items straight in and json.dumps would raise
+    # on the first row otherwise (audit H3).
+    if isinstance(v, Decimal):
+        return int(v) if v == v.to_integral_value() else float(v)
     if isinstance(v, dict):
         return {k: _encode_value(x) for k, x in v.items()}
     if isinstance(v, list):
@@ -138,8 +158,15 @@ def _encode_value(v: Any) -> Any:
 
 def _decode_value(v: Any) -> Any:
     if isinstance(v, dict):
-        if set(v.keys()) == {"__b64__"}:
-            return base64.b64decode(v["__b64__"])
+        if set(v.keys()) == {"__b64__"} and isinstance(v["__b64__"], str):
+            # Guarded decode (audit M6): a colliding/corrupt sentinel in
+            # opaque persisted dicts must degrade to the raw dict, not
+            # throw binascii.Error inside a whole-batch read.
+            try:
+                return base64.b64decode(v["__b64__"], validate=True)
+            except (binascii.Error, ValueError):
+                log.warning("b64_sentinel_decode_failed_returning_raw")
+                return v
         return {k: _decode_value(x) for k, x in v.items()}
     if isinstance(v, list):
         return [_decode_value(x) for x in v]
@@ -158,17 +185,6 @@ def decode_item(pk: str, sk: str, data: dict[str, Any]) -> dict[str, Any]:
     item["SK"] = sk
     return item
 
-
-def split_special(attrs: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None, int | None]:
-    """Lift GSI1PK/GSI1SK/ttl out of an attr dict into their columns.
-
-    They STAY in `data` too (DDB keeps them as plain attributes); the
-    columns exist for indexing/filtering only.
-    """
-    gsi1pk = attrs.get("GSI1PK")
-    gsi1sk = attrs.get("GSI1SK")
-    ttl = attrs.get("ttl")
-    return attrs, gsi1pk, gsi1sk, int(ttl) if ttl is not None else None
 
 
 def maybe_purge_expired() -> None:

--- a/services/webhook/adapters/pg_base.py
+++ b/services/webhook/adapters/pg_base.py
@@ -1,0 +1,194 @@
+# MIRRORED — sibling at services/api/adapters/pg_base.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Shared Postgres plumbing for the single-table store port (#354).
+
+Replaces DynamoDB's single-table (PK/SK + attrs + GSI1 + ttl) with an
+EXACT-parity Postgres table:
+
+    grug_kv(pk, sk, data jsonb, gsi1pk, gsi1sk, ttl)
+
+Parity rules (the migration's correctness contract):
+- Items round-trip as {"PK": pk, "SK": sk, **attrs}; attrs live in
+  `data` jsonb. GSI1PK/GSI1SK and ttl are LIFTED into columns (indexed)
+  AND kept in `data` when present, mirroring DDB where they are
+  ordinary attributes that the index/TTL machinery reads.
+- Binary attrs (the KMS-encrypted oauth_*_blob values) cannot ride
+  jsonb raw; they are encoded as {"__b64__": "<base64>"} sentinels by
+  the codec below and decoded back to `bytes` on read - callers see
+  bytes exactly as boto3 returned them (modulo DDB's Binary wrapper,
+  which callers already unwrap defensively).
+- DDB TTL deletes rows lazily; Postgres has no reaper, so EVERY read
+  filters `ttl IS NULL OR ttl > now()` (the `_TTL_LIVE` predicate) and
+  writers that must atomically take over an expired row (claim_delivery)
+  encode that in their ON CONFLICT clause. An opportunistic purge runs
+  at most once per process-hour to keep the table bounded.
+
+Connection: GRUG_DATABASE_URL (postgresql://...). Lazy pool init with
+double-checked locking - same rationale as the DDB _LazyTable (env vars
+are monkeypatched after import in tests; eager init would break them).
+Schema bootstrap is idempotent (CREATE TABLE IF NOT EXISTS) and runs on
+first pool acquisition; concurrent bootstrappers are safe (IF NOT EXISTS
++ advisory lock).
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+import psycopg
+from psycopg.types.json import Jsonb
+from psycopg_pool import ConnectionPool
+
+log = logging.getLogger("grug.adapters.pg_base")
+
+_pool: ConnectionPool | None = None
+_pool_lock = threading.Lock()
+_last_purge: float = 0.0
+_PURGE_INTERVAL_SECONDS = 3600
+
+# One arbitrary-but-fixed key for the schema-bootstrap advisory lock.
+_BOOTSTRAP_LOCK_KEY = 0x6772_7567  # "grug"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS grug_kv (
+    pk      text NOT NULL,
+    sk      text NOT NULL,
+    data    jsonb NOT NULL DEFAULT '{}'::jsonb,
+    gsi1pk  text,
+    gsi1sk  text,
+    ttl     bigint,
+    PRIMARY KEY (pk, sk)
+);
+CREATE INDEX IF NOT EXISTS grug_kv_gsi1
+    ON grug_kv (gsi1pk, gsi1sk) WHERE gsi1pk IS NOT NULL;
+CREATE INDEX IF NOT EXISTS grug_kv_ttl
+    ON grug_kv (ttl) WHERE ttl IS NOT NULL;
+"""
+
+# SQL fragment: row is live (not TTL-expired). Interpolated as a
+# constant fragment, never with user input.
+TTL_LIVE = "(ttl IS NULL OR ttl > EXTRACT(EPOCH FROM now()))"
+
+
+def _database_url() -> str:
+    url = os.environ.get("GRUG_DATABASE_URL", "")
+    if not url:
+        raise RuntimeError(
+            "GRUG_DATABASE_URL is not set - the Postgres store cannot start. "
+            "(k8s injects it from the deployment secret; tests set it from "
+            "the testcontainer.)"
+        )
+    return url
+
+
+def get_pool() -> ConnectionPool:
+    """Lazy, thread-safe pool. Bootstraps the schema on first creation."""
+    global _pool
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                pool = ConnectionPool(
+                    _database_url(),
+                    min_size=1,
+                    max_size=int(os.environ.get("GRUG_PG_POOL_MAX", "5")),
+                    open=True,
+                )
+                with pool.connection() as conn:
+                    # Advisory lock so N replicas bootstrapping at once
+                    # don't race the CREATEs (IF NOT EXISTS is safe but
+                    # noisy under contention).
+                    conn.execute("SELECT pg_advisory_lock(%s)", (_BOOTSTRAP_LOCK_KEY,))
+                    try:
+                        conn.execute(_SCHEMA)
+                    finally:
+                        conn.execute(
+                            "SELECT pg_advisory_unlock(%s)", (_BOOTSTRAP_LOCK_KEY,)
+                        )
+                _pool = pool
+    return _pool
+
+
+def reset_pool_for_tests() -> None:
+    """Close + forget the pool. Tests call this between containers."""
+    global _pool, _last_purge
+    with _pool_lock:
+        if _pool is not None:
+            _pool.close()
+        _pool = None
+        _last_purge = 0.0
+
+
+def _encode_value(v: Any) -> Any:
+    if isinstance(v, bytes):
+        return {"__b64__": base64.b64encode(v).decode("ascii")}
+    if isinstance(v, dict):
+        return {k: _encode_value(x) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_encode_value(x) for x in v]
+    # DDB's Binary wrapper exposes .value; normalize it here so the
+    # migration script can feed boto3 items straight in.
+    if hasattr(v, "value") and isinstance(getattr(v, "value"), bytes):
+        return {"__b64__": base64.b64encode(v.value).decode("ascii")}
+    return v
+
+
+def _decode_value(v: Any) -> Any:
+    if isinstance(v, dict):
+        if set(v.keys()) == {"__b64__"}:
+            return base64.b64decode(v["__b64__"])
+        return {k: _decode_value(x) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_decode_value(x) for x in v]
+    return v
+
+
+def encode_attrs(attrs: dict[str, Any]) -> Jsonb:
+    """Encode an attr dict for the jsonb column (bytes -> b64 sentinel)."""
+    return Jsonb({k: _encode_value(v) for k, v in attrs.items()})
+
+
+def decode_item(pk: str, sk: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Reconstruct the DDB-shaped Item dict from a row."""
+    item = {k: _decode_value(v) for k, v in data.items()}
+    item["PK"] = pk
+    item["SK"] = sk
+    return item
+
+
+def split_special(attrs: dict[str, Any]) -> tuple[dict[str, Any], str | None, str | None, int | None]:
+    """Lift GSI1PK/GSI1SK/ttl out of an attr dict into their columns.
+
+    They STAY in `data` too (DDB keeps them as plain attributes); the
+    columns exist for indexing/filtering only.
+    """
+    gsi1pk = attrs.get("GSI1PK")
+    gsi1sk = attrs.get("GSI1SK")
+    ttl = attrs.get("ttl")
+    return attrs, gsi1pk, gsi1sk, int(ttl) if ttl is not None else None
+
+
+def maybe_purge_expired() -> None:
+    """Opportunistic TTL purge, at most once per process-hour.
+
+    Correctness never depends on this (reads filter TTL_LIVE); it only
+    keeps the table from accumulating dead claim/comment rows forever.
+    Failures are logged and swallowed - a purge must never take down a
+    request path.
+    """
+    global _last_purge
+    now = time.monotonic()
+    if _last_purge and now - _last_purge < _PURGE_INTERVAL_SECONDS:
+        return
+    _last_purge = now
+    try:
+        with get_pool().connection() as conn:
+            conn.execute(
+                "DELETE FROM grug_kv WHERE ttl IS NOT NULL "
+                "AND ttl <= EXTRACT(EPOCH FROM now())"
+            )
+    except psycopg.Error:
+        log.warning("pg_ttl_purge_failed", exc_info=True)

--- a/services/webhook/adapters/pg_install_store.py
+++ b/services/webhook/adapters/pg_install_store.py
@@ -1,0 +1,570 @@
+# MIRRORED — sibling at services/api/adapters/pg_install_store.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Postgres install store - exact-API port of install_store.py (DDB).
+
+Same public surface, same single-table layout (see install_store.py's
+docstring for the PK/SK shapes); storage is the grug_kv table from
+pg_base.py. At cutover install_store.py's implementation is REPLACED by
+this module (no runtime dual-backend seam: DDB retires, the seam is
+git + the image tag - rule-of-three, ADR-0001).
+
+Semantics deliberately preserved from the DDB adapter:
+- record_installation: atomic upsert that PRESERVES the original
+  installed_at under concurrent duplicate deliveries (DDB
+  if_not_exists -> single-statement jsonb upsert here).
+- claim_delivery: win-once atomic claim (DDB conditional put ->
+  INSERT ... ON CONFLICT with expired-row takeover; DDB's TTL machinery
+  would have deleted an expired claim, Postgres must treat it as free).
+- All reads filter TTL-expired rows (pg_base.TTL_LIVE) - DDB expiry is
+  lazy-delete, ours is read-filter + hourly opportunistic purge.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, NotRequired, Optional, TypedDict
+
+from psycopg.types.json import Jsonb
+
+from adapters import pg_base
+from adapters.pg_base import TTL_LIVE, decode_item, encode_attrs, get_pool
+from review_types import verdict as _derive_verdict  # leaf import (no cycle)
+
+log = logging.getLogger("grug.adapters.pg_install_store")
+
+
+def _inst_pk(install_id: int | str) -> str:
+    return f"INST#{install_id}"
+
+
+def _user_pk(github_user_id: int | str) -> str:
+    return f"USER#{github_user_id}"
+
+
+def _get_item(pk: str, sk: str) -> dict[str, Any] | None:
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            f"SELECT pk, sk, data FROM grug_kv WHERE pk = %s AND sk = %s AND {TTL_LIVE}",
+            (pk, sk),
+        ).fetchone()
+    if not row:
+        return None
+    return decode_item(row[0], row[1], row[2])
+
+
+def record_installation(
+    *,
+    install_id: int,
+    account_login: str,
+    account_type: str,
+    installed_by_user_id: int,
+) -> None:
+    """Idempotent upsert of INST#<id> META row on `installation:created`.
+
+    Single-statement upsert: concurrent duplicate webhook deliveries
+    cannot race-overwrite the original install timestamp (the jsonb
+    merge keeps the existing installed_at when present - same guarantee
+    the DDB if_not_exists expression gave).
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    attrs = {
+        "account_login": account_login,
+        "account_type": account_type,
+        "installed_by_user_id": str(installed_by_user_id),
+        "GSI1PK": str(installed_by_user_id),
+        "GSI1SK": _inst_pk(install_id),
+        "installed_at": now,
+    }
+    pg_base.maybe_purge_expired()
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, gsi1pk, gsi1sk)
+            VALUES (%(pk)s, %(sk)s, %(data)s, %(g1pk)s, %(g1sk)s)
+            ON CONFLICT (pk, sk) DO UPDATE SET
+                data = (grug_kv.data || %(data)s)
+                       || jsonb_build_object(
+                              'installed_at',
+                              COALESCE(grug_kv.data->'installed_at',
+                                       %(data)s->'installed_at')),
+                gsi1pk = %(g1pk)s,
+                gsi1sk = %(g1sk)s
+            """,
+            {
+                "pk": _inst_pk(install_id),
+                "sk": "META",
+                "data": encode_attrs(attrs),
+                "g1pk": attrs["GSI1PK"],
+                "g1sk": attrs["GSI1SK"],
+            },
+        )
+
+
+def delete_installation(install_id: int) -> None:
+    with get_pool().connection() as conn:
+        conn.execute(
+            "DELETE FROM grug_kv WHERE pk = %s AND sk = %s",
+            (_inst_pk(install_id), "META"),
+        )
+
+
+def get_installation(install_id: int) -> dict[str, Any] | None:
+    return _get_item(_inst_pk(install_id), "META")
+
+
+def is_install_allowlisted(install_id: int) -> bool:
+    """Return True iff INST#<id> exists AND its installer is allowlisted.
+
+    Two-hop lookup, same shape + logging as the DDB adapter (callers
+    and dashboards grep these event names).
+    """
+    inst = get_installation(install_id)
+    if not inst:
+        log.info("allowlist_miss_no_install", extra={"install_id": install_id})
+        return False
+    user_id = inst.get("installed_by_user_id")
+    if not user_id:
+        log.warning(
+            "allowlist_install_missing_user_id",
+            extra={"install_id": install_id},
+        )
+        return False
+    user = _get_item(_user_pk(user_id), "META")
+    if not user:
+        log.info(
+            "allowlist_miss_no_user",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+        return False
+    allowlisted = bool(user.get("allowlisted", False))
+    if not allowlisted:
+        log.info(
+            "allowlist_miss_user_not_allowlisted",
+            extra={"install_id": install_id, "user_id": user_id},
+        )
+    return allowlisted
+
+
+def list_allowlisted_installs() -> list[int]:
+    """Install_ids whose installer is allowlisted (poller batch, #247b).
+
+    The DDB version SCANned; here a single WHERE does it. The per-id
+    re-check via is_install_allowlisted is kept for log parity (the
+    allowlist_miss_* events are how the operator debugs poller gaps).
+    """
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"SELECT pk FROM grug_kv WHERE sk = 'META' AND pk LIKE 'INST#%%' AND {TTL_LIVE}"
+        ).fetchall()
+    install_ids: list[int] = []
+    for (pk,) in rows:
+        _, sep, id_str = pk.partition("#")
+        if not sep:
+            continue
+        try:
+            iid = int(id_str)
+        except (TypeError, ValueError):
+            log.warning("install_pk_unparsable", extra={"pk": pk})
+            continue
+        if is_install_allowlisted(iid):
+            install_ids.append(iid)
+    return install_ids
+
+
+# ---------------------------------------------------------------------------
+# Per-repo persona toggles
+# ---------------------------------------------------------------------------
+
+_DEFAULT_PERSONA_CONFIG = {
+    "tpm_enabled": True,
+    "code_reviewer_enabled": True,
+    "code_reviewer_blocking": False,
+}
+
+
+def _repo_sk(repo_id: int | str) -> str:
+    return f"REPO#{repo_id}"
+
+
+def list_user_installations(github_user_id: str) -> list[dict[str, Any]]:
+    """INST# rows installed by this user - the GSI1 query becomes an
+    indexed column lookup."""
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE gsi1pk = %s AND gsi1sk LIKE 'INST#%%' AND {TTL_LIVE}
+            """,
+            (str(github_user_id),),
+        ).fetchall()
+    return [decode_item(*r) for r in rows]
+
+
+def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
+    item = _get_item(_inst_pk(install_id), _repo_sk(repo_id))
+    if not item:
+        return {
+            **_DEFAULT_PERSONA_CONFIG,
+            "enforcement_ruleset_id": None,
+            "force_disable_enforcement": False,
+        }
+    rid = item.get("enforcement_ruleset_id")
+    return {
+        "tpm_enabled": bool(
+            item.get("tpm_enabled", _DEFAULT_PERSONA_CONFIG["tpm_enabled"])
+        ),
+        "code_reviewer_enabled": bool(
+            item.get(
+                "code_reviewer_enabled",
+                _DEFAULT_PERSONA_CONFIG["code_reviewer_enabled"],
+            )
+        ),
+        "code_reviewer_blocking": bool(
+            item.get(
+                "code_reviewer_blocking",
+                _DEFAULT_PERSONA_CONFIG["code_reviewer_blocking"],
+            )
+        ),
+        "enforcement_ruleset_id": int(rid) if rid is not None else None,
+        "force_disable_enforcement": bool(item.get("force_disable_enforcement", False)),
+    }
+
+
+def _merge_attrs(pk: str, sk: str, attrs: dict[str, Any]) -> None:
+    """Sparse jsonb merge-upsert (DDB update_item SET parity: creates the
+    row when absent, merges fields when present)."""
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data) VALUES (%(pk)s, %(sk)s, %(data)s)
+            ON CONFLICT (pk, sk) DO UPDATE SET data = grug_kv.data || %(data)s
+            """,
+            {"pk": pk, "sk": sk, "data": encode_attrs(attrs)},
+        )
+
+
+def set_repo_config(
+    *,
+    install_id: int,
+    repo_id: int,
+    repo_full_name: str,
+    tpm_enabled: bool,
+    updated_by_user_id: str,
+    code_reviewer_enabled: bool | None = None,
+    code_reviewer_blocking: bool | None = None,
+) -> dict[str, Any]:
+    """Upsert per-repo override; returns the FIELDS THAT WERE UPDATED
+    (same contract as the DDB adapter). Sparse merge preserves fields
+    managed by other writers (enforcement_ruleset_id)."""
+    now = datetime.now(timezone.utc).isoformat()
+    attrs: dict[str, Any] = {
+        "repo_full_name": repo_full_name,
+        "tpm_enabled": bool(tpm_enabled),
+        "updated_at": now,
+        "updated_by_user_id": str(updated_by_user_id),
+    }
+    if code_reviewer_enabled is not None:
+        attrs["code_reviewer_enabled"] = bool(code_reviewer_enabled)
+    if code_reviewer_blocking is not None:
+        attrs["code_reviewer_blocking"] = bool(code_reviewer_blocking)
+    _merge_attrs(_inst_pk(install_id), _repo_sk(repo_id), attrs)
+
+    updated_fields: dict[str, Any] = {"tpm_enabled": bool(tpm_enabled)}
+    if code_reviewer_enabled is not None:
+        updated_fields["code_reviewer_enabled"] = bool(code_reviewer_enabled)
+    if code_reviewer_blocking is not None:
+        updated_fields["code_reviewer_blocking"] = bool(code_reviewer_blocking)
+    return updated_fields
+
+
+def get_enforcement_id(install_id: int, repo_id: int) -> int | None:
+    item = _get_item(_inst_pk(install_id), _repo_sk(repo_id))
+    if not item:
+        return None
+    val = item.get("enforcement_ruleset_id")
+    return int(val) if val is not None else None
+
+
+def set_enforcement_id(
+    install_id: int,
+    repo_id: int,
+    ruleset_id: int | None,
+) -> None:
+    """Update only enforcement_ruleset_id (REMOVE semantics for None)."""
+    if ruleset_id is not None:
+        _merge_attrs(
+            _inst_pk(install_id),
+            _repo_sk(repo_id),
+            {"enforcement_ruleset_id": ruleset_id},
+        )
+    else:
+        with get_pool().connection() as conn:
+            conn.execute(
+                """
+                UPDATE grug_kv SET data = data - 'enforcement_ruleset_id'
+                WHERE pk = %s AND sk = %s
+                """,
+                (_inst_pk(install_id), _repo_sk(repo_id)),
+            )
+
+
+def is_persona_enabled(install_id: int, repo_id: int, persona: str) -> bool:
+    cfg = get_repo_config(install_id, repo_id)
+    key = f"{persona}_enabled"
+    return bool(cfg.get(key, _DEFAULT_PERSONA_CONFIG.get(key, True)))
+
+
+# ---------------------------------------------------------------------------
+# Elder reaction-poll comment records (#245)
+# ---------------------------------------------------------------------------
+
+
+class CommentRecord(TypedDict):
+    comment_id: int
+    repo: str
+    pr_number: int
+    review_span_context: Optional[dict]
+    finding_tags: dict[str, str]
+    last_verdict: NotRequired[Optional[str]]
+
+
+def _comment_record_sk(comment_id: int | str) -> str:
+    return f"CRCOMMENT#{comment_id}"
+
+
+_COMMENT_RECORD_TTL_DAYS = 30
+
+
+def put_comment_record(
+    *,
+    install_id: int,
+    comment_id: int,
+    repo: str,
+    pr_number: int,
+    review_span_context: dict,
+    finding_tags: dict,
+) -> None:
+    ttl = int(
+        datetime.now(timezone.utc).timestamp() + _COMMENT_RECORD_TTL_DAYS * 86400
+    )
+    attrs = {
+        "comment_id": int(comment_id),
+        "repo": repo,
+        "pr_number": int(pr_number),
+        "review_span_context": review_span_context,
+        "finding_tags": finding_tags,
+        "ttl": ttl,
+    }
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, ttl)
+            VALUES (%(pk)s, %(sk)s, %(data)s, %(ttl)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = %(data)s, ttl = %(ttl)s
+            """,
+            {
+                "pk": _inst_pk(install_id),
+                "sk": _comment_record_sk(comment_id),
+                "data": encode_attrs(attrs),
+                "ttl": ttl,
+            },
+        )
+
+
+class CheckVerdictRecord(TypedDict):
+    persona: str
+    repo: str
+    pr_number: int
+    head_sha: str
+    conclusion: str
+    summary: str
+    findings_count: int
+    blocking: bool
+    verdict: str
+    created_at: str
+    degraded_reason: NotRequired[Optional[str]]
+
+
+_CHECK_VERDICT_TTL_DAYS = 90
+
+
+def _check_verdict_sk(head_sha: str, persona: str) -> str:
+    return f"ACT#{head_sha}#{persona}"
+
+
+def put_check_verdict(
+    *,
+    install_id: int,
+    persona: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    conclusion: str,
+    summary: str,
+    findings_count: int,
+    blocking: bool,
+    created_at: str,
+    degraded_reason: Optional[str] = None,
+) -> None:
+    """Upsert a Check verdict; the denormalized `verdict` badge is DERIVED
+    via review_types.verdict (never a parameter) - ADR-0003 invariant
+    enforced by construction, identical to the DDB adapter."""
+    ttl = int(
+        datetime.now(timezone.utc).timestamp() + _CHECK_VERDICT_TTL_DAYS * 86400
+    )
+    attrs: dict[str, Any] = {
+        "persona": persona,
+        "repo": repo,
+        "pr_number": int(pr_number),
+        "head_sha": head_sha,
+        "conclusion": conclusion,
+        "summary": summary,
+        "findings_count": int(findings_count),
+        "blocking": bool(blocking),
+        "verdict": _derive_verdict(
+            conclusion=conclusion,
+            findings_count=int(findings_count),
+            degraded_reason=degraded_reason,
+        ),
+        "created_at": created_at,
+        "ttl": ttl,
+    }
+    if degraded_reason:
+        attrs["degraded_reason"] = degraded_reason
+    with get_pool().connection() as conn:
+        conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, ttl)
+            VALUES (%(pk)s, %(sk)s, %(data)s, %(ttl)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = %(data)s, ttl = %(ttl)s
+            """,
+            {
+                "pk": _inst_pk(install_id),
+                "sk": _check_verdict_sk(head_sha, persona),
+                "data": encode_attrs(attrs),
+                "ttl": ttl,
+            },
+        )
+
+
+def list_check_verdicts(
+    install_id: int,
+    limit: int | None = 50,
+) -> list[CheckVerdictRecord]:
+    """An install's Check verdicts, newest-first. Sorting moves into SQL
+    (created_at is an ISO-8601 string; lexicographic == chronological);
+    the limit is still applied AFTER the full fetch shape the DDB
+    adapter documented (callers like /activity re-filter)."""
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE pk = %s AND sk LIKE 'ACT#%%' AND {TTL_LIVE}
+            ORDER BY data->>'created_at' DESC
+            """,
+            (_inst_pk(install_id),),
+        ).fetchall()
+    out: list[CheckVerdictRecord] = []
+    for pk, sk, data in rows:
+        item = decode_item(pk, sk, data)
+        rec: CheckVerdictRecord = {
+            "persona": str(item["persona"]),
+            "repo": str(item["repo"]),
+            "pr_number": int(item["pr_number"]),
+            "head_sha": str(item["head_sha"]),
+            "conclusion": str(item["conclusion"]),
+            "summary": str(item.get("summary", "")),
+            "findings_count": int(item.get("findings_count", 0)),
+            "blocking": bool(item.get("blocking", False)),
+            "verdict": str(item.get("verdict", "")),
+            "created_at": str(item["created_at"]),
+        }
+        if "degraded_reason" in item:
+            rec["degraded_reason"] = item["degraded_reason"]
+        out.append(rec)
+    return out if limit is None else out[:limit]
+
+
+_DELIVERY_CLAIM_TTL_HOURS = 24
+
+
+def _delivery_pk(delivery_id: str) -> str:
+    return f"DELIVERY#{delivery_id}"
+
+
+def claim_delivery(delivery_id: str) -> bool:
+    """Win-once idempotency claim. True = this caller won; False = the
+    delivery was already claimed (redelivery / async retry -> SKIP).
+
+    Atomic single statement. The ON CONFLICT UPDATE arm takes over a row
+    ONLY when its claim has TTL-expired - DDB's TTL machinery would have
+    deleted such a row, so an expired claim must read as free here too.
+    Fails OPEN on empty delivery_id (same reasoning as the DDB adapter:
+    a possible double-review beats a silently-skipped one). Any other
+    database error propagates - callers degrade explicitly, we never
+    swallow into a false 'claimed'.
+    """
+    if not delivery_id:
+        return True
+    pg_base.maybe_purge_expired()
+    ttl = int(
+        datetime.now(timezone.utc).timestamp() + _DELIVERY_CLAIM_TTL_HOURS * 3600
+    )
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            """
+            INSERT INTO grug_kv (pk, sk, data, ttl)
+            VALUES (%(pk)s, 'META', %(data)s, %(ttl)s)
+            ON CONFLICT (pk, sk) DO UPDATE
+                SET data = %(data)s, ttl = %(ttl)s
+                WHERE grug_kv.ttl IS NOT NULL
+                  AND grug_kv.ttl <= EXTRACT(EPOCH FROM now())
+            RETURNING pk
+            """,
+            {
+                "pk": _delivery_pk(delivery_id),
+                "data": Jsonb({"ttl": ttl}),
+                "ttl": ttl,
+            },
+        ).fetchone()
+    return row is not None
+
+
+def list_comment_records(install_id: int) -> list[CommentRecord]:
+    with get_pool().connection() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT pk, sk, data FROM grug_kv
+            WHERE pk = %s AND sk LIKE 'CRCOMMENT#%%' AND {TTL_LIVE}
+            """,
+            (_inst_pk(install_id),),
+        ).fetchall()
+    out: list[CommentRecord] = []
+    for pk, sk, data in rows:
+        item = decode_item(pk, sk, data)
+        out.append(
+            {
+                "comment_id": int(item["comment_id"]),
+                "repo": item["repo"],
+                "pr_number": int(item["pr_number"]),
+                "review_span_context": item.get("review_span_context"),
+                "finding_tags": item.get("finding_tags", {}),
+                "last_verdict": item.get("last_verdict"),
+            }
+        )
+    return out
+
+
+def update_comment_record_reaction(
+    *,
+    install_id: int,
+    comment_id: int,
+    verdict: str,
+) -> None:
+    _merge_attrs(
+        _inst_pk(install_id),
+        _comment_record_sk(comment_id),
+        {"last_verdict": verdict},
+    )

--- a/services/webhook/adapters/pg_install_store.py
+++ b/services/webhook/adapters/pg_install_store.py
@@ -129,7 +129,17 @@ def is_install_allowlisted(install_id: int) -> bool:
             extra={"install_id": install_id},
         )
         return False
-    user = _get_item(_user_pk(user_id), "META")
+    # PROJECTED read (audit H2): the DDB original used
+    # ProjectionExpression="allowlisted" so the webhook NEVER holds the
+    # OAuth blobs that live on the same row; Postgres has no IAM
+    # projection, so this query is the enforcement now.
+    with get_pool().connection() as conn:
+        row = conn.execute(
+            f"SELECT data->'allowlisted' FROM grug_kv "
+            f"WHERE pk = %s AND sk = 'META' AND {TTL_LIVE}",
+            (_user_pk(user_id),),
+        ).fetchone()
+    user = {"allowlisted": row[0]} if row is not None else None
     if not user:
         log.info(
             "allowlist_miss_no_user",
@@ -154,7 +164,8 @@ def list_allowlisted_installs() -> list[int]:
     """
     with get_pool().connection() as conn:
         rows = conn.execute(
-            f"SELECT pk FROM grug_kv WHERE sk = 'META' AND pk LIKE 'INST#%%' AND {TTL_LIVE}"
+            f"SELECT pk FROM grug_kv WHERE sk = 'META' AND pk LIKE %s AND {TTL_LIVE}",
+            ("INST#%",),
         ).fetchall()
     install_ids: list[int] = []
     for (pk,) in rows:
@@ -232,7 +243,13 @@ def get_repo_config(install_id: int, repo_id: int) -> dict[str, Any]:
 
 def _merge_attrs(pk: str, sk: str, attrs: dict[str, Any]) -> None:
     """Sparse jsonb merge-upsert (DDB update_item SET parity: creates the
-    row when absent, merges fields when present)."""
+    row when absent, merges fields when present).
+
+    Known divergence (audit L8, deliberate): merging into a TTL-EXPIRED
+    row does not clear its ttl - the write lands on a row reads ignore
+    and the purge later removes. DDB would resurrect a sparse live row
+    (its own latent bug: such rows KeyError in the list readers). The
+    PG behavior is the safer of the two."""
     with get_pool().connection() as conn:
         conn.execute(
             """
@@ -462,7 +479,7 @@ def list_check_verdicts(
             f"""
             SELECT pk, sk, data FROM grug_kv
             WHERE pk = %s AND sk LIKE 'ACT#%%' AND {TTL_LIVE}
-            ORDER BY data->>'created_at' DESC
+            ORDER BY data->>'created_at' COLLATE "C" DESC
             """,
             (_inst_pk(install_id),),
         ).fetchall()

--- a/services/webhook/requirements.txt
+++ b/services/webhook/requirements.txt
@@ -11,3 +11,6 @@ cryptography>=43.0,<44.0
 # instrumentation + handler-wrapping in-process.
 ddtrace>=3.5,<4
 datadog-lambda>=6.107,<7
+# Postgres store (#306 epic store port) - pool included for the
+# long-lived k8s runtime (Lambda used per-invoke connections).
+psycopg[binary,pool]>=3.2,<4.0

--- a/specs/0008-user-with-tokens/user-with-tokens.ioa.toml
+++ b/specs/0008-user-with-tokens/user-with-tokens.ioa.toml
@@ -2,6 +2,10 @@
 #
 # Models the identity + decrypted-OAuth-tokens projection. Per CONTEXT.md
 # § "Identity & authorization concepts" + § "Persistence concepts":
+# TRANSITIONAL (#354): adapters/pg_user_store.py is the staged Postgres
+# successor and carries the SAME sole-construction + decrypt-boundary
+# contract; the attester allows both files until the cutover swap
+# collapses them back to one.
 # UserWithTokens is constructed ONLY on the OAuth-refresh / on-behalf-of-
 # user paths in the api Lambda. The webhook Lambda has no KMS permissions
 # and MUST NEVER construct this type (enforced both at the IAM plane and


### PR DESCRIPTION
## Why

grug is moving off AWS Lambda onto self-hosted Kubernetes (#354). The single-table store is the load-bearing piece: webhook and api share it bidirectionally (allowlist gate, activity feed), so the Postgres port must cover both mirrors at once with exact semantics - a behavioral drift here silently breaks idempotency (double reviews) or the allowlist (no reviews).

## Summary

- `pg_base` (mirrored): one parity table `grug_kv(pk, sk, data jsonb, gsi1pk, gsi1sk, ttl)`; bytes-through-jsonb codec for the KMS blobs; TTL is READ-FILTERED everywhere + an hourly opportunistic purge (DynamoDB deletes expired rows lazily; Postgres must never serve them)
- `pg_install_store` (mirrored): all 15 functions with preserved atomics - installed_at survives duplicate deliveries via single-statement jsonb upsert; `claim_delivery` is win-once via INSERT..ON CONFLICT with EXPIRED-claim takeover (a TTL-dead claim must read as free, as DDB's reaper would have made it)
- `pg_user_store` (api): OAuth upsert preserves admin-set fields with no read-then-write window (the lost-update CRITICAL from the DDB original); corrupt-blob purge keeps identity fields; admin's raw-table ops promoted to named functions
- Mirror lockstep REGISTERED in scripts/check-mirrored-files.sh (29 pairs verified locally)
- NEW check.python workflow: the pytest suites finally gate PRs (previously local-make only); postgres:18 service container backs the real-PG tests

## Test plan

- [ ] check.python green: webhook suite, api suite, and the new pg suite against real Postgres
- [ ] pg suite includes the 8-thread concurrent-claim race (exactly one winner) - the test a fake cannot perform
- [ ] expired-claim takeover, TTL read-filtering, sparse-merge preservation, refresh-blob non-rotation all asserted
- [ ] drift-lint green with the two new mirrored files

Size: M

## Out of scope

- The implementation SWAP (install_store.py/user_store.py content replacement) + data migration - the cutover commit, tracked on #354
- Kubernetes deployment, ingress, Lambda retirement (later phases)

part of #354
