### PR TITLE
fix(tests): add moto DDB fixture to webhook conftest — stop hitting prod DynamoDB

### DIFF
--- a/services/webhook/tests/conftest.py
+++ b/services/webhook/tests/conftest.py
@@ -20,10 +20,49 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
+import boto3
 import httpx
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+@pytest.fixture(autouse=True)
+def _ddb_table(monkeypatch):
+    """moto DDB for all webhook tests — prevents accidental prod DDB hits.
+    
+    install_store uses lazy DDB init (boto3.resource on first _table access),
+    so moto's mock_aws is picked up naturally — no module reload needed.
+    """
+    moto = pytest.importorskip("moto")
+    from moto import mock_aws  # type: ignore
+
+    with mock_aws():
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+        ddb = boto3.client("dynamodb", region_name="us-east-1")
+        ddb.create_table(
+            TableName="grug-main",  # matches install_store's _TABLE_NAME default
+            KeySchema=[
+                {"AttributeName": "PK", "KeyType": "HASH"},
+                {"AttributeName": "SK", "KeyType": "RANGE"},
+            ],
+            AttributeDefinitions=[
+                {"AttributeName": "PK", "AttributeType": "S"},
+                {"AttributeName": "SK", "AttributeType": "S"},
+                {"AttributeName": "GSI1PK", "AttributeType": "S"},
+                {"AttributeName": "GSI1SK", "AttributeType": "S"},
+            ],
+            GlobalSecondaryIndexes=[{
+                "IndexName": "GSI1",
+                "KeySchema": [
+                    {"AttributeName": "GSI1PK", "KeyType": "HASH"},
+                    {"AttributeName": "GSI1SK", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            }],
+            BillingMode="PAY_PER_REQUEST",
+        )
+        yield
 
 
 def _build_handler(


### PR DESCRIPTION
Closes #356

## Problem

4 tests in test_dispatcher.py and test_enforcement.py were calling `is_install_allowlisted` and `get_enforcement_id` against the production DDB table when run with ambient AWS credentials. On CI runners (dummy creds) they fail with `UnrecognizedClientException`.

- test_installation_created_records_row
- test_installation_created_org_uses_sender_id
- test_heal_clears_stale_id_and_recreates
- test_heal_returns_new_state

## Fix

Added an autouse `_ddb_table` fixture to `services/webhook/tests/conftest.py` that spins a moto-backed DynamoDB table with the same schema as production. The fixture runs for every test in the webhook test suite, preventing accidental prod DDB hits across all tests.

The fixture uses the default table name "grug-main" which matches install_store's `_TABLE_NAME` default, so the lazy DDB init (`boto3.resource` on first table access) picks up the moto endpoint naturally — no module reloading needed.

## Verification

82 webhook tests pass (including all 4 previously hitting prod DDB) with NO ambient AWS credentials:

```
tests/test_dispatcher.py::test_installation_created_records_row PASSED
tests/test_dispatcher.py::test_installation_created_org_uses_sender_id PASSED
tests/test_enforcement.py::test_heal_clears_stale_id_and_recreates PASSED
tests/test_enforcement.py::test_heal_returns_new_state PASSED
```
