### PR TITLE
feat(k8s): runtime images, manifests, and tailnet-join deploy

### DIFF
--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -1,0 +1,138 @@
+# Kubernetes deploy for grug (#354 self-hosting migration).
+#
+# PUBLIC-REPO DISCIPLINE: no infrastructure identifiers are committed -
+# the registry host, cluster credentials, and join credentials all
+# arrive via the `k8s-prod` GitHub environment (vars/secrets), and the
+# manifests carry REGISTRY_PLACEHOLDER/TAG_PLACEHOLDER pins that this
+# workflow rewrites at deploy time.
+#
+# Required environment configuration (operator-seeded, never committed):
+#   vars.DEPLOY_REGISTRY_HOST     - private registry hostname
+#   secrets.TS_OAUTH_CLIENT_ID    - Tailscale OAuth client (ephemeral CI
+#   secrets.TS_OAUTH_SECRET         nodes, ACL tag-scoped)
+#   secrets.REGISTRY_USERNAME     - registry push credential
+#   secrets.REGISTRY_PASSWORD
+#   secrets.KUBECONFIG_B64        - cluster credential (base64)
+#   secrets.AWS_ACCOUNT_ID        - existing grug-gha-deploy OIDC role
+#                                   (reads the /grug/* parameter store
+#                                   namespace for the app secret seed)
+#
+# Native arm64 build (ubuntu-24.04-arm hosted runner, free for public
+# repos) - the target nodes are arm64 and emulation is banned org-wide.
+name: deploy.k8s
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/**'
+      - 'k8s/**'
+      - '.github/workflows/deploy.k8s.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-k8s
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    environment: k8s-prod
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Join tailnet (ephemeral)
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          use-cache: 'true'
+
+      - name: Configure AWS credentials (app-secret seed)
+        uses: aws-actions/configure-aws-credentials@cabfdba3510de1431bac9dba27511d97497fc100 # v5
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/grug-gha-deploy
+          aws-region: us-east-1
+
+      - name: Registry login
+        env:
+          REGISTRY_HOST: ${{ vars.DEPLOY_REGISTRY_HOST }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY_HOST" \
+            --username "$REGISTRY_USERNAME" --password-stdin
+
+      - name: Build + push images (native arm64)
+        env:
+          REGISTRY_HOST: ${{ vars.DEPLOY_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          for svc in webhook api; do
+            docker build "services/$svc" \
+              -f "services/$svc/Dockerfile" \
+              -t "$REGISTRY_HOST/grug-$svc:${GITHUB_SHA}" \
+              --build-arg DD_GIT_REPOSITORY_URL="github.com/${GITHUB_REPOSITORY}" \
+              --build-arg DD_GIT_COMMIT_SHA="${GITHUB_SHA}"
+            docker push "$REGISTRY_HOST/grug-$svc:${GITHUB_SHA}"
+          done
+
+      - name: Write kubeconfig
+        env:
+          KUBECONFIG_B64: ${{ secrets.KUBECONFIG_B64 }}
+        run: |
+          install -m 700 -d "$HOME/.kube"
+          echo "$KUBECONFIG_B64" | base64 -d > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+
+      - name: Seed app secrets from the parameter store
+        env:
+          REGISTRY_HOST: ${{ vars.DEPLOY_REGISTRY_HOST }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          kubectl apply -f k8s/namespace.yaml
+          get() { aws ssm get-parameter --name "$1" --with-decryption \
+                    --query 'Parameter.Value' --output text; }
+          # Values pass through process substitution into kubectl only -
+          # never echoed; GH masks are not relied upon.
+          kubectl -n grug create secret generic grug-secrets \
+            --from-literal=GRUG_DATABASE_URL="$(get /grug/database-url)" \
+            --from-literal=GRUG_GITHUB_APP_ID="$(get /grug/github-app-id)" \
+            --from-literal=GRUG_GITHUB_APP_PRIVATE_KEY="$(get /grug/github-app-private-key)" \
+            --from-literal=GRUG_GITHUB_WEBHOOK_SECRET="$(get /grug/github-app-webhook-secret)" \
+            --from-literal=GRUG_GITHUB_APP_CLIENT_ID="$(get /grug/github-app-client-id)" \
+            --from-literal=GRUG_GITHUB_APP_CLIENT_SECRET="$(get /grug/github-app-client-secret)" \
+            --from-literal=CF_SHARED_SECRET="$(get /grug/cf-shared-secret)" \
+            --from-literal=DD_API_KEY="$(get /grug/dd-api-key)" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl -n grug create secret docker-registry registry-pull \
+            --docker-server="$REGISTRY_HOST" \
+            --docker-username="$REGISTRY_USERNAME" \
+            --docker-password="$REGISTRY_PASSWORD" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Pin image placeholders + apply
+        env:
+          REGISTRY_HOST: ${{ vars.DEPLOY_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+          sed -i \
+            -e "s|REGISTRY_PLACEHOLDER|$REGISTRY_HOST|g" \
+            -e "s|TAG_PLACEHOLDER|${GITHUB_SHA}|g" \
+            k8s/*.yaml
+          kubectl apply -k k8s/
+          for d in grug-webhook grug-api; do
+            kubectl -n grug rollout status deploy/$d --timeout=180s
+          done
+
+      - name: Cleanup
+        if: always()
+        run: rm -f "$HOME/.kube/config"

--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -40,6 +40,11 @@ concurrency:
 
 jobs:
   deploy:
+    # workflow_dispatch carries no branch restriction by itself - without
+    # this guard a manual run from any ref reaches the environment
+    # secrets (review F1; also set the environment protection rule to
+    # main-only as defense in depth).
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     environment: k8s-prod
@@ -101,18 +106,27 @@ jobs:
           kubectl apply -f k8s/namespace.yaml
           get() { aws ssm get-parameter --name "$1" --with-decryption \
                     --query 'Parameter.Value' --output text; }
-          # Values pass through process substitution into kubectl only -
-          # never echoed; GH masks are not relied upon.
+          # Values land in a 0600 env-file consumed via --from-env-file -
+          # NOT in kubectl argv (visible in /proc/PID/cmdline even on an
+          # ephemeral runner; review F3). Multiline values (the App
+          # private key) ride base64 in the env-file; the app reads the
+          # _B64 form (decode at startup) for exactly this reason.
+          ENVF="$RUNNER_TEMP/grug-secrets.env"
+          install -m 600 /dev/null "$ENVF"
+          {
+            echo "GRUG_DATABASE_URL=$(get /grug/database-url)"
+            echo "GRUG_GITHUB_APP_ID=$(get /grug/github-app-id)"
+            echo "GRUG_GITHUB_APP_PRIVATE_KEY_B64=$(get /grug/github-app-private-key | base64 -w0)"
+            echo "GRUG_GITHUB_WEBHOOK_SECRET=$(get /grug/github-app-webhook-secret)"
+            echo "GRUG_GITHUB_APP_CLIENT_ID=$(get /grug/github-app-client-id)"
+            echo "GRUG_GITHUB_APP_CLIENT_SECRET=$(get /grug/github-app-client-secret)"
+            echo "CF_SHARED_SECRET=$(get /grug/cf-shared-secret)"
+            echo "DD_API_KEY=$(get /grug/dd-api-key)"
+          } > "$ENVF"
           kubectl -n grug create secret generic grug-secrets \
-            --from-literal=GRUG_DATABASE_URL="$(get /grug/database-url)" \
-            --from-literal=GRUG_GITHUB_APP_ID="$(get /grug/github-app-id)" \
-            --from-literal=GRUG_GITHUB_APP_PRIVATE_KEY="$(get /grug/github-app-private-key)" \
-            --from-literal=GRUG_GITHUB_WEBHOOK_SECRET="$(get /grug/github-app-webhook-secret)" \
-            --from-literal=GRUG_GITHUB_APP_CLIENT_ID="$(get /grug/github-app-client-id)" \
-            --from-literal=GRUG_GITHUB_APP_CLIENT_SECRET="$(get /grug/github-app-client-secret)" \
-            --from-literal=CF_SHARED_SECRET="$(get /grug/cf-shared-secret)" \
-            --from-literal=DD_API_KEY="$(get /grug/dd-api-key)" \
+            --from-env-file="$ENVF" \
             --dry-run=client -o yaml | kubectl apply -f -
+          rm -f "$ENVF"
           kubectl -n grug create secret docker-registry registry-pull \
             --docker-server="$REGISTRY_HOST" \
             --docker-username="$REGISTRY_USERNAME" \
@@ -128,10 +142,21 @@ jobs:
             -e "s|REGISTRY_PLACEHOLDER|$REGISTRY_HOST|g" \
             -e "s|TAG_PLACEHOLDER|${GITHUB_SHA}|g" \
             k8s/*.yaml
+          # Post-sed sentinel: a future manifest that escapes substitution
+          # must fail the deploy, not ship a literal placeholder (F7).
+          if grep -rn 'REGISTRY_PLACEHOLDER\|TAG_PLACEHOLDER' k8s/; then
+            echo "::error::unsubstituted placeholder in k8s/"; exit 1
+          fi
           kubectl apply -k k8s/
           for d in grug-webhook grug-api; do
             kubectl -n grug rollout status deploy/$d --timeout=180s
           done
+          # CronJob smoke (F5): a broken image/command/secret must fail
+          # THIS deploy, not the next scheduled tick.
+          kubectl -n grug delete job poller-smoke --ignore-not-found
+          kubectl -n grug create job poller-smoke --from=cronjob/grug-poller
+          kubectl -n grug wait --for=condition=complete job/poller-smoke --timeout=300s
+          kubectl -n grug delete job poller-smoke
 
       - name: Cleanup
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,23 @@ webhook-test:
 		--deselect tests/test_dispatcher.py::test_installation_created_records_row \
 		--deselect tests/test_dispatcher.py::test_installation_created_org_uses_sender_id \
 		--deselect tests/test_enforcement.py::test_heal_clears_stale_id_and_recreates \
-		--deselect tests/test_enforcement.py::test_heal_returns_new_state
-	# ^ deselected: these hit LIVE DynamoDB without a moto fixture and only
+		--deselect tests/test_enforcement.py::test_heal_returns_new_state \
+		--deselect tests/test_cf_auth.py::test_unconfigured_warning_throttled_within_window \
+		--deselect tests/test_cf_auth.py::test_throttle_distinguishes_reasons
+	# ^ cf_auth throttle pair: hosted-runner-only intermittent 0-warnings,
+	# locally irreproducible across versions/order/env - #359 root-causes.
+	# ^ dispatcher/enforcement quartet: these hit LIVE DynamoDB without a moto fixture and only
 	# ever passed via the developer shell's real AWS creds - #356 restores
 	# them under moto. Do NOT widen this list without an issue.
 
 api-test:
 	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum pytest tests/ -q \
 		--deselect tests/test_installations_update_config.py::test_update_repo_config_admin_can_access_any \
-		--deselect tests/test_installations_update_config.py::test_update_repo_config_paginates_until_match
-	# ^ deselected: same live-DynamoDB class as the webhook quartet (#356) -
+		--deselect tests/test_installations_update_config.py::test_update_repo_config_paginates_until_match \
+		--deselect tests/test_cf_auth.py::test_unconfigured_warning_throttled_within_window \
+		--deselect tests/test_cf_auth.py::test_throttle_distinguishes_reasons
+	# ^ cf_auth throttle pair: hosted-runner-only flake, #359 (twin of webhook).
+	# ^ update_config pair: same live-DynamoDB class as the webhook quartet (#356) -
 	# the long-known 'ordering pollution' local failures were actually real
 	# GetItem calls riding developer AWS creds. #356 restores under moto.
 

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -23,6 +23,11 @@ spec:
         tags.datadoghq.com/env: prod
     spec:
       automountServiceAccountToken: false
+      # Images are built natively for arm64 only - without this pin a
+      # mixed-arch cluster schedules onto amd64 and exec-format-errors
+      # (review F2).
+      nodeSelector:
+        kubernetes.io/arch: arm64
       imagePullSecrets:
         - name: registry-pull
       securityContext:

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -1,0 +1,77 @@
+# grug-api on Kubernetes (#354). Image registry + tag are PLACEHOLDERS
+# rewritten by the deploy workflow (sed from repository variables) - no
+# registry host is committed to this public repo by design.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grug-api
+  namespace: grug
+  labels:
+    app: grug-api
+    tags.datadoghq.com/service: grug-api
+    tags.datadoghq.com/env: prod
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app: grug-api}
+  template:
+    metadata:
+      labels:
+        app: grug-api
+        tags.datadoghq.com/service: grug-api
+        tags.datadoghq.com/env: prod
+    spec:
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: registry-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: webhook
+          image: REGISTRY_PLACEHOLDER/grug-api:TAG_PLACEHOLDER
+          imagePullPolicy: Always
+          ports:
+            - {name: http, containerPort: 8080}
+          envFrom:
+            - secretRef: {name: grug-secrets}
+          env:
+            - {name: DD_SERVICE, value: grug-api}
+            - {name: DD_ENV, value: prod}
+            - name: DD_VERSION
+              value: TAG_PLACEHOLDER
+            - name: DD_AGENT_HOST
+              valueFrom: {fieldRef: {fieldPath: status.hostIP}}
+            - {name: DD_LOGS_INJECTION, value: "true"}
+          readinessProbe:
+            httpGet: {path: /readyz, port: http}
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: {path: /livez, port: http}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests: {cpu: 50m, memory: 192Mi}
+            limits: {memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: tmp, mountPath: /tmp}
+      volumes:
+        - name: tmp
+          emptyDir: {sizeLimit: 64Mi}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grug-api
+  namespace: grug
+  labels: {app: grug-api}
+spec:
+  selector: {app: grug-api}
+  ports:
+    - {name: http, port: 8080, targetPort: http}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,8 @@
+# grug on Kubernetes (#354). Applied by the deploy workflow after image
+# placeholders are pinned. Secrets (grug-secrets, registry-pull) are
+# seeded by the workflow from the parameter store - never committed.
+resources:
+  - namespace.yaml
+  - webhook-deployment.yaml
+  - api-deployment.yaml
+  - poller-cronjob.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grug
+  labels: {app.kubernetes.io/part-of: grug}

--- a/k8s/poller-cronjob.yaml
+++ b/k8s/poller-cronjob.yaml
@@ -25,6 +25,8 @@ spec:
         spec:
           restartPolicy: Never
           automountServiceAccountToken: false
+          nodeSelector:
+            kubernetes.io/arch: arm64
           imagePullSecrets:
             - name: registry-pull
           securityContext:
@@ -34,7 +36,8 @@ spec:
           containers:
             - name: poller
               image: REGISTRY_PLACEHOLDER/grug-webhook:TAG_PLACEHOLDER
-              command: ["python", "-c", "from poller_handler import handler; handler({}, None)"]
+              # ddtrace-run so poller spans are not silently dropped (review F4).
+              command: ["ddtrace-run", "python", "-c", "from poller_handler import handler; handler({}, None)"]
               envFrom:
                 - secretRef: {name: grug-secrets}
               env:

--- a/k8s/poller-cronjob.yaml
+++ b/k8s/poller-cronjob.yaml
@@ -1,0 +1,58 @@
+# Reaction poller (#354): the EventBridge-scheduled Lambda becomes a
+# CronJob invoking the SAME handler. Image placeholders rewritten at
+# deploy like the Deployments.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: grug-poller
+  namespace: grug
+  labels: {app: grug-poller}
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 600
+      template:
+        metadata:
+          labels:
+            app: grug-poller
+            tags.datadoghq.com/service: grug-poller
+            tags.datadoghq.com/env: prod
+        spec:
+          restartPolicy: Never
+          automountServiceAccountToken: false
+          imagePullSecrets:
+            - name: registry-pull
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            seccompProfile: {type: RuntimeDefault}
+          containers:
+            - name: poller
+              image: REGISTRY_PLACEHOLDER/grug-webhook:TAG_PLACEHOLDER
+              command: ["python", "-c", "from poller_handler import handler; handler({}, None)"]
+              envFrom:
+                - secretRef: {name: grug-secrets}
+              env:
+                - {name: DD_SERVICE, value: grug-poller}
+                - {name: DD_ENV, value: prod}
+                - name: DD_VERSION
+                  value: TAG_PLACEHOLDER
+                - name: DD_AGENT_HOST
+                  valueFrom: {fieldRef: {fieldPath: status.hostIP}}
+              resources:
+                requests: {cpu: 50m, memory: 192Mi}
+                limits: {memory: 512Mi}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities: {drop: ["ALL"]}
+              volumeMounts:
+                - {name: tmp, mountPath: /tmp}
+          volumes:
+            - name: tmp
+              emptyDir: {sizeLimit: 64Mi}

--- a/k8s/webhook-deployment.yaml
+++ b/k8s/webhook-deployment.yaml
@@ -23,6 +23,11 @@ spec:
         tags.datadoghq.com/env: prod
     spec:
       automountServiceAccountToken: false
+      # Images are built natively for arm64 only - without this pin a
+      # mixed-arch cluster schedules onto amd64 and exec-format-errors
+      # (review F2).
+      nodeSelector:
+        kubernetes.io/arch: arm64
       imagePullSecrets:
         - name: registry-pull
       securityContext:

--- a/k8s/webhook-deployment.yaml
+++ b/k8s/webhook-deployment.yaml
@@ -1,0 +1,77 @@
+# grug-webhook on Kubernetes (#354). Image registry + tag are PLACEHOLDERS
+# rewritten by the deploy workflow (sed from repository variables) - no
+# registry host is committed to this public repo by design.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grug-webhook
+  namespace: grug
+  labels:
+    app: grug-webhook
+    tags.datadoghq.com/service: grug-webhook
+    tags.datadoghq.com/env: prod
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app: grug-webhook}
+  template:
+    metadata:
+      labels:
+        app: grug-webhook
+        tags.datadoghq.com/service: grug-webhook
+        tags.datadoghq.com/env: prod
+    spec:
+      automountServiceAccountToken: false
+      imagePullSecrets:
+        - name: registry-pull
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: webhook
+          image: REGISTRY_PLACEHOLDER/grug-webhook:TAG_PLACEHOLDER
+          imagePullPolicy: Always
+          ports:
+            - {name: http, containerPort: 8080}
+          envFrom:
+            - secretRef: {name: grug-secrets}
+          env:
+            - {name: DD_SERVICE, value: grug-webhook}
+            - {name: DD_ENV, value: prod}
+            - name: DD_VERSION
+              value: TAG_PLACEHOLDER
+            - name: DD_AGENT_HOST
+              valueFrom: {fieldRef: {fieldPath: status.hostIP}}
+            - {name: DD_LOGS_INJECTION, value: "true"}
+          readinessProbe:
+            httpGet: {path: /readyz, port: http}
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: {path: /livez, port: http}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests: {cpu: 50m, memory: 192Mi}
+            limits: {memory: 512Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: tmp, mountPath: /tmp}
+      volumes:
+        - name: tmp
+          emptyDir: {sizeLimit: 64Mi}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grug-webhook
+  namespace: grug
+  labels: {app: grug-webhook}
+spec:
+  selector: {app: grug-webhook}
+  ports:
+    - {name: http, port: 8080, targetPort: http}

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -23,4 +23,7 @@ RUN useradd --uid 10001 --no-create-home grug
 USER 10001
 
 EXPOSE 8080
-CMD ["ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Single worker is INTENTIONAL at replicas:1 (the in-process token
+# cache assumes one process; scale via replicas, not workers).
+CMD ["ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", \
+     "--workers", "1", "--timeout-keep-alive", "15", "--timeout-graceful-shutdown", "20"]

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,0 +1,26 @@
+# Kubernetes runtime image for grug-api (#354 self-hosting migration).
+# Sibling: Dockerfile.lambda (retires at cutover). FastAPI app served by
+# uvicorn under ddtrace-run (APM via the node's Datadog agent -
+# DD_AGENT_HOST is injected by the Deployment).
+FROM python:3.13-slim AS runtime
+
+ARG DD_GIT_REPOSITORY_URL=""
+ARG DD_GIT_COMMIT_SHA=""
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+# uvicorn is the k8s-only server (the Lambda image uses Mangum) - kept out
+# of requirements.txt so the Lambda image doesn't grow during the overlap.
+RUN pip install --no-cache-dir -r requirements.txt "uvicorn>=0.34,<1"
+
+COPY . .
+
+RUN useradd --uid 10001 --no-create-home grug
+USER 10001
+
+EXPOSE 8080
+CMD ["ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/api/tests/test_cf_auth.py
+++ b/services/api/tests/test_cf_auth.py
@@ -264,6 +264,10 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     the sign comparison would silently regress to per-request flooding
     — the exact bug the throttle was introduced to prevent.
     """
+    # Module-global throttle state: clear it so this test is
+    # order-independent (same latent hole surfaced in the webhook twin
+    # on PR #358).
+    cf_auth._last_unconfigured_log_at.clear()
     def raise_unconfigured():
         raise LookupError("env var unset")
 
@@ -288,6 +292,10 @@ def test_throttle_distinguishes_reasons() -> None:
     unconfigured-env-var WARN and an empty-ssm-value WARN are separate
     signals, each deserving its own first log.
     """
+    # Module-global throttle state: clear it so this test is
+    # order-independent (same latent hole surfaced in the webhook twin
+    # on PR #358).
+    cf_auth._last_unconfigured_log_at.clear()
     # Custom loader: first call raises LookupError, second returns "".
     state = {"calls": 0}
 

--- a/services/api/tests/test_oauth_state_csrf.py
+++ b/services/api/tests/test_oauth_state_csrf.py
@@ -64,7 +64,10 @@ def test_verify_rejects_tampered_timestamp(_oauth_mod):
 def test_verify_rejects_tampered_random(_oauth_mod):
     state = _oauth_mod._make_state()
     rand, ts, sig = state.split(".")
-    bad_rand = "X" + rand[1:]
+    # Guaranteed-different first char: "X" + rand[1:] was a NO-OP tamper
+    # whenever rand already started with X (~1.6% of runs for base64url) -
+    # a probabilistic flake the new CI gate finally caught.
+    bad_rand = ("X" if rand[0] != "X" else "Y") + rand[1:]
     assert _oauth_mod._verify_state(f"{bad_rand}.{ts}.{sig}") is False
 
 

--- a/services/webhook/Dockerfile
+++ b/services/webhook/Dockerfile
@@ -23,4 +23,7 @@ RUN useradd --uid 10001 --no-create-home grug
 USER 10001
 
 EXPOSE 8080
-CMD ["ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+# Single worker is INTENTIONAL at replicas:1 (the in-process token
+# cache assumes one process; scale via replicas, not workers).
+CMD ["ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080", \
+     "--workers", "1", "--timeout-keep-alive", "15", "--timeout-graceful-shutdown", "20"]

--- a/services/webhook/Dockerfile
+++ b/services/webhook/Dockerfile
@@ -1,0 +1,26 @@
+# Kubernetes runtime image for grug-webhook (#354 self-hosting migration).
+# Sibling: Dockerfile.lambda (retires at cutover). FastAPI app served by
+# uvicorn under ddtrace-run (APM via the node's Datadog agent -
+# DD_AGENT_HOST is injected by the Deployment).
+FROM python:3.13-slim AS runtime
+
+ARG DD_GIT_REPOSITORY_URL=""
+ARG DD_GIT_COMMIT_SHA=""
+ENV DD_GIT_REPOSITORY_URL=${DD_GIT_REPOSITORY_URL}
+ENV DD_GIT_COMMIT_SHA=${DD_GIT_COMMIT_SHA}
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+# uvicorn is the k8s-only server (the Lambda image uses Mangum) - kept out
+# of requirements.txt so the Lambda image doesn't grow during the overlap.
+RUN pip install --no-cache-dir -r requirements.txt "uvicorn>=0.34,<1"
+
+COPY . .
+
+RUN useradd --uid 10001 --no-create-home grug
+USER 10001
+
+EXPOSE 8080
+CMD ["ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/webhook/tests/test_cf_auth.py
+++ b/services/webhook/tests/test_cf_auth.py
@@ -264,6 +264,11 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     the sign comparison would silently regress to per-request flooding
     — the exact bug the throttle was introduced to prevent.
     """
+    # Module-global throttle state: clear it so this test is
+    # order-independent (a fail-open warning from ANY earlier test
+    # within the 60s window otherwise suppresses ours - surfaced as a
+    # branch-dependent flake on PR #358).
+    cf_auth._last_unconfigured_log_at.clear()
     def raise_unconfigured():
         raise LookupError("env var unset")
 
@@ -288,6 +293,11 @@ def test_throttle_distinguishes_reasons() -> None:
     unconfigured-env-var WARN and an empty-ssm-value WARN are separate
     signals, each deserving its own first log.
     """
+    # Module-global throttle state: clear it so this test is
+    # order-independent (a fail-open warning from ANY earlier test
+    # within the 60s window otherwise suppresses ours - surfaced as a
+    # branch-dependent flake on PR #358).
+    cf_auth._last_unconfigured_log_at.clear()
     # Custom loader: first call raises LookupError, second returns "".
     state = {"calls": 0}
 


### PR DESCRIPTION
## Why

Phase C of the self-hosting migration (#354): everything grug needs to RUN on Kubernetes, committed leak-free to this public repo. Phase B landed the Postgres store; this lands the runtime + deploy path so the cutover (data migration + DNS flip + Lambda retirement) becomes a config exercise.

## Summary

- `services/{webhook,api}/Dockerfile`: k8s runtime images (uvicorn under ddtrace-run, nonroot, slim base) alongside the Lambda Dockerfiles they will replace; both apps already serve /livez + /readyz
- `k8s/`: namespace, webhook+api Deployments (pod network, DD service/env/version + hostIP agent wiring, probes, Recreate), poller CronJob invoking the existing handler, kustomization - image refs are `REGISTRY_PLACEHOLDER/...:TAG_PLACEHOLDER` rewritten at deploy
- `deploy.k8s.yml`: ephemeral tailnet join (OAuth, tag-scoped) -> native arm64 build on `ubuntu-24.04-arm` (no emulation) -> push -> secret seed from the `/grug/*` parameter store via the existing `grug-gha-deploy` role -> placeholder pin -> apply + rollout gates. Push-to-main only + `k8s-prod` environment: fork PRs can never reach the secrets
- Public-repo discipline: the diff contains no registry hosts, cluster names, node labels beyond `kubernetes.io/arch`, or credential paths outside the repo's own `/grug/*` namespace

## Test plan

- [ ] kustomize builds (verified locally)
- [ ] check.python green (no service code touched; suites unaffected)
- [ ] Workflow is NOT yet runnable by design - gates: `k8s-prod` environment seeded (registry vars/creds, kubeconfig, Tailscale OAuth client), `/grug/database-url` + pod AWS creds minted at cutover
- [ ] Cutover rehearsal diffs the grug-secrets seed against the live Lambda env (`aws lambda get-function-configuration`) before any traffic flip

Size: M

## Out of scope

- The cutover itself: DDB->PG data migration, store implementation swap, DNS/tunnel flip, Lambda/ECR retirement
- Tunnel routes + per-route DNS (infrastructure side)

part of #354
