### PR TITLE
feat(iac): scoped k8s pod IAM user + authkey tailnet join

### DIFF
--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -8,8 +8,7 @@
 #
 # Required environment configuration (operator-seeded, never committed):
 #   vars.DEPLOY_REGISTRY_HOST     - private registry hostname
-#   secrets.TS_OAUTH_CLIENT_ID    - Tailscale OAuth client (ephemeral CI
-#   secrets.TS_OAUTH_SECRET         nodes, ACL tag-scoped)
+#   secrets.TS_AUTHKEY            - tag-scoped ephemeral join key
 #   secrets.REGISTRY_USERNAME     - registry push credential
 #   secrets.REGISTRY_PASSWORD
 #   secrets.KUBECONFIG_B64        - cluster credential (base64)
@@ -54,8 +53,9 @@ jobs:
       - name: Join tailnet (ephemeral)
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          # Pre-minted tag:ci authkey (ephemeral+reusable, 90-day expiry
+          # tracked in the parameter store) - no OAuth client needed.
+          authkey: ${{ secrets.TS_AUTHKEY }}
           tags: tag:ci
           use-cache: 'true'
 

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -25,6 +25,7 @@ import pulumi_datadog as _datadog
 
 from components import (
     cf_shared_secret,
+    k8s_pod_user,
     cloudflare_dns,
     dd_dashboard,
     dd_monitors,
@@ -353,6 +354,15 @@ _rerun_jobs_queue = aws.sqs.Queue(
         lambda arn: json.dumps({"deadLetterTargetArn": arn, "maxReceiveCount": 3})
     ),
     tags={"app": "grug", "service": "grug-rerun"},
+)
+
+# Scoped IAM user for the Kubernetes pods (#354): queue + envelope-KMS +
+# /grug/* parameter access, key pair landed in /grug/k8s-pod-aws-* for
+# the deploy workflow's secret seed. Retires with nothing - the same
+# user serves webhook/api/poller pods.
+_k8s_pod = k8s_pod_user.create(
+    queue_arns=[_cave_jobs_queue.arn, _cave_results_queue.arn, _rerun_jobs_queue.arn],
+    kms_key_arn=grug_tokens_cmk.arn,
 )
 
 webhook = lambda_service.create(

--- a/infra/pulumi/components/k8s_pod_user.py
+++ b/infra/pulumi/components/k8s_pod_user.py
@@ -1,0 +1,117 @@
+"""Scoped IAM user for the Kubernetes pods (#354 self-hosting migration).
+
+The k8s pods keep using AWS services after the move (queue dispatch,
+credential-envelope crypto, runtime secret loads from the parameter
+store) but have no OIDC identity off-Lambda - they authenticate with a
+long-lived access key delivered via the deploy workflow's secret seed.
+
+Least privilege: read /grug/* parameters (+ the SSM decrypt path), use
+the grug queues, and use the envelope KMS key. Nothing else - the pods
+must not be able to widen their own access.
+
+Rotation: taint/replace the AccessKey resource (`pulumi up` re-mints),
+then re-run the deploy workflow so the k8s secret re-seeds.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_aws as aws
+
+
+@dataclass(frozen=True, slots=True)
+class K8sPodUserBundle:
+    user: aws.iam.User
+    access_key: aws.iam.AccessKey
+
+
+def create(
+    *,
+    queue_arns: list[pulumi.Input[str]],
+    kms_key_arn: pulumi.Input[str],
+    name: str = "grug-k8s-pod",
+) -> K8sPodUserBundle:
+    """Provision the pod user + scoped policy + access key, landing the
+    key pair in /grug/k8s-pod-aws-* SecureStrings for the deploy seed."""
+    user = aws.iam.User(
+        name,
+        name=name,
+        tags={"managed_by": "pulumi", "project": "grug", "purpose": "k8s-pod-runtime"},
+    )
+
+    policy_doc = pulumi.Output.all(
+        queues=pulumi.Output.all(*queue_arns), kms=kms_key_arn
+    ).apply(
+        lambda args: json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Sid": "ReadGrugParams",
+                        "Effect": "Allow",
+                        "Action": [
+                            "ssm:GetParameter",
+                            "ssm:GetParameters",
+                            "ssm:GetParametersByPath",
+                        ],
+                        "Resource": "arn:aws:ssm:us-east-1:*:parameter/grug/*",
+                    },
+                    {
+                        "Sid": "DecryptSsmSecureStrings",
+                        "Effect": "Allow",
+                        "Action": ["kms:Decrypt"],
+                        "Resource": "*",
+                        "Condition": {
+                            "StringEquals": {
+                                "kms:ViaService": "ssm.us-east-1.amazonaws.com"
+                            }
+                        },
+                    },
+                    {
+                        "Sid": "UseGrugQueues",
+                        "Effect": "Allow",
+                        "Action": [
+                            "sqs:SendMessage",
+                            "sqs:ReceiveMessage",
+                            "sqs:DeleteMessage",
+                            "sqs:GetQueueAttributes",
+                        ],
+                        "Resource": args["queues"],
+                    },
+                    {
+                        "Sid": "EnvelopeCrypto",
+                        "Effect": "Allow",
+                        "Action": ["kms:Encrypt", "kms:Decrypt", "kms:GenerateDataKey"],
+                        "Resource": args["kms"],
+                    },
+                ],
+            }
+        )
+    )
+    aws.iam.UserPolicy(
+        f"{name}-policy",
+        name=f"{name}-runtime",
+        user=user.name,
+        policy=policy_doc,
+    )
+
+    access_key = aws.iam.AccessKey(f"{name}-key", user=user.name)
+
+    aws.ssm.Parameter(
+        f"{name}-akid-ssm",
+        name="/grug/k8s-pod-aws-access-key-id",
+        type="SecureString",
+        value=access_key.id,
+        description="k8s pod runtime AWS access key id (#354). Rotation: replace the AccessKey resource.",
+    )
+    aws.ssm.Parameter(
+        f"{name}-secret-ssm",
+        name="/grug/k8s-pod-aws-secret-access-key",
+        type="SecureString",
+        value=pulumi.Output.secret(access_key.secret),
+        description="k8s pod runtime AWS secret access key (#354).",
+    )
+
+    return K8sPodUserBundle(user=user, access_key=access_key)


### PR DESCRIPTION
## Why

Final credential plumbing before the cutover (#354): the Kubernetes pods still consume the queues, the envelope KMS key, and runtime parameter loads, but have no OIDC identity off-Lambda. They authenticate with a least-privilege IAM user whose key pair the deploy workflow seeds into the pod secret. The tailnet join also drops its OAuth-client requirement - a pre-minted tag-scoped ephemeral authkey (already in the parameter store, expiry tracked) does the same with one less console-only credential.

## Summary

- components/k8s_pod_user.py: IAM user + scoped inline policy (grug queue ops, envelope-KMS crypto, /grug/* parameter reads + the SSM-scoped kms:Decrypt) + AccessKey, landing /grug/k8s-pod-aws-* SecureStrings - same mint-into-SSM idiom as cf_shared_secret
- wired in __main__ off the existing queue/CMK resources
- deploy.k8s.yml: tailscale join via `authkey:` (TS_AUTHKEY environment secret) instead of OAuth client inputs; docs updated

## Test plan

- [ ] check.python green (no service code)
- [ ] post-merge `pulumi up` provisions user/policy/key/params (watch for a scoped-role IAM deny - the deploy role has managed OIDC/IAM before, but iam:CreateUser is new ground)
- [ ] first workflow_dispatch of deploy.k8s: tailnet join succeeds with the authkey, registry push succeeds, pods Ready

Size: S

## Out of scope

- The cutover itself (data migration, store swap, DNS flip, Lambda retirement)

part of #354
