### PR TITLE
fix(iac): trust the k8s-prod environment sub on the deploy role

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -131,6 +131,8 @@ _deploy_role_bundle = oidc_role.create(
     # AND silently narrowed back whenever main re-deployed without the
     # wider list.
     branches=["main", "feat/*", "fix/*", "hotfix/*"],
+    # deploy.k8s runs inside the k8s-prod environment (#354).
+    environments=["k8s-prod"],
     tags_pattern="v*",
 )
 gha_deploy_role = _deploy_role_bundle.role

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -60,12 +60,20 @@ def create(
     repo: str,
     branches: list[str],
     tags_pattern: str | None = None,
+    environments: list[str] | None = None,
 ) -> DeployRole:
     provider_arn = _ensure_oidc_provider()
 
     sub_patterns = [f"repo:{repo}:ref:refs/heads/{b}" for b in branches]
     if tags_pattern:
         sub_patterns.append(f"repo:{repo}:ref:refs/tags/{tags_pattern}")
+    # Jobs that declare a GitHub `environment:` present a DIFFERENT OIDC
+    # sub shape (`repo:<repo>:environment:<name>`), NOT the ref-based one.
+    # Without an explicit entry STS rejects with "Not authorized to
+    # perform sts:AssumeRoleWithWebIdentity" - hit live on the first
+    # deploy.k8s dispatch (#354), same trap the infra repo documented.
+    for env in environments or []:
+        sub_patterns.append(f"repo:{repo}:environment:{env}")
 
     assume = json.dumps(
         {


### PR DESCRIPTION
## Why

First deploy.k8s dispatch (#354) failed at AWS credential configuration: jobs that declare a GitHub `environment:` present `repo:<repo>:environment:<name>` as the OIDC sub claim instead of the ref-based shape, and the deploy role's trust policy only listed branch/tag refs. Known trap class, now hit live here.

## Summary

- oidc_role component gains an `environments` parameter appending the environment-shaped subs to the trust policy
- deploy role trusts `k8s-prod` (the only environment-scoped workflow)

## Test plan

- [ ] check.python green (no service code)
- [ ] post-merge pulumi up updates the trust policy
- [ ] re-dispatched deploy.k8s passes the credential step

Size: XS

## Out of scope

- Any permission (policy) changes - trust shape only

part of #354