### PR TITLE
fix(k8s): final secret seed + runtime env contract

### DIFF
--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -111,21 +111,28 @@ jobs:
           # ephemeral runner; review F3). Multiline values (the App
           # private key) ride base64 in the env-file; the app reads the
           # _B64 form (decode at startup) for exactly this reason.
+          # The app self-loads its secrets from the parameter store at
+          # runtime (secrets_loader + the *_SSM path envs in the
+          # manifests) - the pod secret carries ONLY the AWS credential
+          # authorizing those reads, the database URL, and two
+          # deploy-resolved values that must not be committed as
+          # literals (the queue URL embeds the account id).
           ENVF="$RUNNER_TEMP/grug-secrets.env"
           install -m 600 /dev/null "$ENVF"
           {
+            echo "AWS_ACCESS_KEY_ID=$(get /grug/k8s-pod-aws-access-key-id)"
+            echo "AWS_SECRET_ACCESS_KEY=$(get /grug/k8s-pod-aws-secret-access-key)"
+            echo "AWS_DEFAULT_REGION=us-east-1"
             echo "GRUG_DATABASE_URL=$(get /grug/database-url)"
-            echo "GRUG_GITHUB_APP_ID=$(get /grug/github-app-id)"
-            echo "GRUG_GITHUB_APP_PRIVATE_KEY_B64=$(get /grug/github-app-private-key | base64 -w0)"
-            echo "GRUG_GITHUB_WEBHOOK_SECRET=$(get /grug/github-app-webhook-secret)"
-            echo "GRUG_GITHUB_APP_CLIENT_ID=$(get /grug/github-app-client-id)"
-            echo "GRUG_GITHUB_APP_CLIENT_SECRET=$(get /grug/github-app-client-secret)"
-            echo "CF_SHARED_SECRET=$(get /grug/cf-shared-secret)"
-            echo "DD_API_KEY=$(get /grug/dd-api-key)"
+            echo "GRUG_CAVE_JOBS_QUEUE_URL=$(aws sqs get-queue-url --queue-name grug-cave-jobs.fifo --query QueueUrl --output text)"
+            echo "GRUG_CAVE_DIFF_BUCKET=$(aws s3api list-buckets --query 'Buckets[?starts_with(Name, `grug-cave-diffs`)].Name | [0]' --output text)"
           } > "$ENVF"
+          # DELETE-then-create: kubectl apply MERGES secret data, so a
+          # shape change would leave stale keys behind (bit us on the
+          # first deploys - the interim seed's keys lingered).
+          kubectl -n grug delete secret grug-secrets --ignore-not-found
           kubectl -n grug create secret generic grug-secrets \
-            --from-env-file="$ENVF" \
-            --dry-run=client -o yaml | kubectl apply -f -
+            --from-env-file="$ENVF"
           rm -f "$ENVF"
           kubectl -n grug create secret docker-registry registry-pull \
             --docker-server="$REGISTRY_HOST" \

--- a/infra/pulumi/components/k8s_pod_user.py
+++ b/infra/pulumi/components/k8s_pod_user.py
@@ -56,7 +56,13 @@ def create(
                             "ssm:GetParameters",
                             "ssm:GetParametersByPath",
                         ],
-                        "Resource": "arn:aws:ssm:us-east-1:*:parameter/grug/*",
+                        "Resource": [
+                            "arn:aws:ssm:us-east-1:*:parameter/grug/*",
+                            # Shared LLM keys the Elder backends read at
+                            # runtime (paths already public in this repo).
+                            "arn:aws:ssm:us-east-1:*:parameter/infra/llm/openrouter_api_key",
+                            "arn:aws:ssm:us-east-1:*:parameter/infra/llm/poolside_api_key",
+                        ],
                     },
                     {
                         "Sid": "DecryptSsmSecureStrings",

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -50,6 +50,21 @@ spec:
             - name: DD_AGENT_HOST
               valueFrom: {fieldRef: {fieldPath: status.hostIP}}
             - {name: DD_LOGS_INJECTION, value: "true"}
+            - {name: GRUG_ENV, value: prod}
+            - {name: GRUG_DDB_TABLE, value: grug-main}
+            - {name: GITHUB_APP_ID_SSM, value: /grug/github-app-id}
+            - {name: GITHUB_APP_PRIVATE_KEY_SSM, value: /grug/github-app-private-key}
+            - {name: GITHUB_APP_WEBHOOK_SECRET_SSM, value: /grug/github-app-webhook-secret}
+            - {name: GITHUB_APP_CLIENT_ID_SSM, value: /grug/github-app-client-id}
+            - {name: GITHUB_APP_CLIENT_SECRET_SSM, value: /grug/github-app-client-secret}
+            - {name: GRUG_CF_SHARED_SECRET_SSM, value: /grug/cf-shared-secret}
+            - {name: GRUG_OPENROUTER_API_KEY_SSM, value: /infra/llm/openrouter_api_key}
+            - {name: GRUG_POOLSIDE_API_KEY_SSM, value: /infra/llm/poolside_api_key}
+            - {name: GRUG_PROMPT_EXPERIMENT_SSM, value: /grug/elder-prompt-experiment}
+            - {name: GRUG_FALLBACK_ENABLED_SSM, value: /grug/elder-fallback-enabled}
+            - {name: DD_SITE, value: datadoghq.com}
+            - {name: DD_LLMOBS_ENABLED, value: "true"}
+            - {name: DD_LLMOBS_ML_APP, value: grug-elder}
           readinessProbe:
             httpGet: {path: /readyz, port: http}
             periodSeconds: 10

--- a/k8s/poller-cronjob.yaml
+++ b/k8s/poller-cronjob.yaml
@@ -47,6 +47,21 @@ spec:
                   value: TAG_PLACEHOLDER
                 - name: DD_AGENT_HOST
                   valueFrom: {fieldRef: {fieldPath: status.hostIP}}
+                - {name: GRUG_ENV, value: prod}
+                - {name: GRUG_DDB_TABLE, value: grug-main}
+                - {name: GITHUB_APP_ID_SSM, value: /grug/github-app-id}
+                - {name: GITHUB_APP_PRIVATE_KEY_SSM, value: /grug/github-app-private-key}
+                - {name: GITHUB_APP_WEBHOOK_SECRET_SSM, value: /grug/github-app-webhook-secret}
+                - {name: GITHUB_APP_CLIENT_ID_SSM, value: /grug/github-app-client-id}
+                - {name: GITHUB_APP_CLIENT_SECRET_SSM, value: /grug/github-app-client-secret}
+                - {name: GRUG_CF_SHARED_SECRET_SSM, value: /grug/cf-shared-secret}
+                - {name: GRUG_OPENROUTER_API_KEY_SSM, value: /infra/llm/openrouter_api_key}
+                - {name: GRUG_POOLSIDE_API_KEY_SSM, value: /infra/llm/poolside_api_key}
+                - {name: GRUG_PROMPT_EXPERIMENT_SSM, value: /grug/elder-prompt-experiment}
+                - {name: GRUG_FALLBACK_ENABLED_SSM, value: /grug/elder-fallback-enabled}
+                - {name: DD_SITE, value: datadoghq.com}
+                - {name: DD_LLMOBS_ENABLED, value: "true"}
+                - {name: DD_LLMOBS_ML_APP, value: grug-elder}
               resources:
                 requests: {cpu: 50m, memory: 192Mi}
                 limits: {memory: 512Mi}

--- a/k8s/webhook-deployment.yaml
+++ b/k8s/webhook-deployment.yaml
@@ -50,6 +50,21 @@ spec:
             - name: DD_AGENT_HOST
               valueFrom: {fieldRef: {fieldPath: status.hostIP}}
             - {name: DD_LOGS_INJECTION, value: "true"}
+            - {name: GRUG_ENV, value: prod}
+            - {name: GRUG_DDB_TABLE, value: grug-main}
+            - {name: GITHUB_APP_ID_SSM, value: /grug/github-app-id}
+            - {name: GITHUB_APP_PRIVATE_KEY_SSM, value: /grug/github-app-private-key}
+            - {name: GITHUB_APP_WEBHOOK_SECRET_SSM, value: /grug/github-app-webhook-secret}
+            - {name: GITHUB_APP_CLIENT_ID_SSM, value: /grug/github-app-client-id}
+            - {name: GITHUB_APP_CLIENT_SECRET_SSM, value: /grug/github-app-client-secret}
+            - {name: GRUG_CF_SHARED_SECRET_SSM, value: /grug/cf-shared-secret}
+            - {name: GRUG_OPENROUTER_API_KEY_SSM, value: /infra/llm/openrouter_api_key}
+            - {name: GRUG_POOLSIDE_API_KEY_SSM, value: /infra/llm/poolside_api_key}
+            - {name: GRUG_PROMPT_EXPERIMENT_SSM, value: /grug/elder-prompt-experiment}
+            - {name: GRUG_FALLBACK_ENABLED_SSM, value: /grug/elder-fallback-enabled}
+            - {name: DD_SITE, value: datadoghq.com}
+            - {name: DD_LLMOBS_ENABLED, value: "true"}
+            - {name: DD_LLMOBS_ML_APP, value: grug-elder}
           readinessProbe:
             httpGet: {path: /readyz, port: http}
             periodSeconds: 10


### PR DESCRIPTION
## Why

First live deploy reached apply but pods crash-looped at boot with NoRegionError: the merged tree carried an interim secret seed (app-credential literals and a key-name contract the app never implemented) rather than the final self-load design, the manifests lacked the *_SSM path env vars the runtime secret loader reads, and kubectl apply's merge semantics left the interim secret's stale keys behind.

## Summary

- seed (final): pod AWS credential + region + database URL + two deploy-resolved values that must not be committed as literals (the queue URL embeds the account id; resolved via the CLI at deploy time); DELETE-then-create for deterministic shape
- manifests: the runtime env contract mirrored from the LIVE Lambda configuration (SSM path vars, GRUG_ENV, the table name until the store swap, LLM-observability flags) - no account-bearing literals
- pod IAM policy: + the two shared LLM parameter reads (paths already public in this repo's Pulumi)

## Test plan

- [ ] check.python green (no service code)
- [ ] post-merge pulumi up applies the policy widening
- [ ] re-dispatched deploy: pods reach Ready (probes green), zero CrashLoopBackOff
- [ ] DD shows webhook/api spans+logs from the cluster with the build-sha version

Size: S

## Out of scope

- The store swap, data migration, DNS flip, Lambda retirement (cutover)

part of #354