### PR TITLE
fix(auth): exempt /readyz from CF auth like /livez

### DIFF
--- a/services/api/cf_auth.py
+++ b/services/api/cf_auth.py
@@ -41,6 +41,11 @@ _ssm = boto3.client("ssm")
 
 SECRET_HEADER = "X-Grug-CF-Secret"
 LIVEZ_PATH = "/livez"
+# Readiness must be probeable by the ORCHESTRATOR (kubelet sends no CF
+# header); a 403 here reads as not-ready while the process is healthy -
+# exactly what blocked the first Kubernetes rollout (#354). Same
+# no-sensitive-data rationale as /livez.
+READYZ_PATH = "/readyz"
 
 # Narrow set of exceptions that put the middleware into fail-open mode.
 # Anything outside this set propagates as a 500 — a programmer bug or
@@ -123,7 +128,7 @@ class CfAuthMiddleware(BaseHTTPMiddleware):
         # + case so `/livez/` and `/LIVEZ` also bypass — FastAPI's
         # auto-redirect on trailing slash issues 307 from the route
         # layer, but the middleware sees the raw path first.
-        if request.url.path.rstrip("/").lower() == LIVEZ_PATH:
+        if request.url.path.rstrip("/").lower() in (LIVEZ_PATH, READYZ_PATH):
             return await call_next(request)
 
         try:

--- a/services/api/tests/test_cf_auth.py
+++ b/services/api/tests/test_cf_auth.py
@@ -47,6 +47,10 @@ def _build_app(*, secret_loader=None):
     else:
         app.add_middleware(CfAuthMiddleware, secret_loader=secret_loader)
 
+    @app.get("/readyz")
+    def readyz():
+        return {"status": "ready"}
+
     @app.get("/livez")
     def livez():
         return {"status": "ok"}
@@ -63,6 +67,14 @@ def test_livez_always_bypasses_check_when_strict() -> None:
     app = _build_app(secret_loader=lambda: "real-secret")
     client = TestClient(app)
     r = client.get("/livez")
+    assert r.status_code == 200
+
+
+def test_readyz_always_bypasses_check_when_strict() -> None:
+    """DD synthetic uptime + smoke tests must reach /readyz without the header."""
+    app = _build_app(secret_loader=lambda: "real-secret")
+    client = TestClient(app)
+    r = client.get("/readyz")
     assert r.status_code == 200
 
 

--- a/services/webhook/cf_auth.py
+++ b/services/webhook/cf_auth.py
@@ -41,6 +41,11 @@ _ssm = boto3.client("ssm")
 
 SECRET_HEADER = "X-Grug-CF-Secret"
 LIVEZ_PATH = "/livez"
+# Readiness must be probeable by the ORCHESTRATOR (kubelet sends no CF
+# header); a 403 here reads as not-ready while the process is healthy -
+# exactly what blocked the first Kubernetes rollout (#354). Same
+# no-sensitive-data rationale as /livez.
+READYZ_PATH = "/readyz"
 
 # Narrow set of exceptions that put the middleware into fail-open mode.
 # Anything outside this set propagates as a 500 — a programmer bug or
@@ -123,7 +128,7 @@ class CfAuthMiddleware(BaseHTTPMiddleware):
         # + case so `/livez/` and `/LIVEZ` also bypass — FastAPI's
         # auto-redirect on trailing slash issues 307 from the route
         # layer, but the middleware sees the raw path first.
-        if request.url.path.rstrip("/").lower() == LIVEZ_PATH:
+        if request.url.path.rstrip("/").lower() in (LIVEZ_PATH, READYZ_PATH):
             return await call_next(request)
 
         try:

--- a/services/webhook/tests/test_cf_auth.py
+++ b/services/webhook/tests/test_cf_auth.py
@@ -47,6 +47,10 @@ def _build_app(*, secret_loader=None):
     else:
         app.add_middleware(CfAuthMiddleware, secret_loader=secret_loader)
 
+    @app.get("/readyz")
+    def readyz():
+        return {"status": "ready"}
+
     @app.get("/livez")
     def livez():
         return {"status": "ok"}
@@ -63,6 +67,14 @@ def test_livez_always_bypasses_check_when_strict() -> None:
     app = _build_app(secret_loader=lambda: "real-secret")
     client = TestClient(app)
     r = client.get("/livez")
+    assert r.status_code == 200
+
+
+def test_readyz_always_bypasses_check_when_strict() -> None:
+    """DD synthetic uptime + smoke tests must reach /readyz without the header."""
+    app = _build_app(secret_loader=lambda: "real-secret")
+    client = TestClient(app)
+    r = client.get("/readyz")
     assert r.status_code == 200
 
 


### PR DESCRIPTION
## Why

The first healthy Kubernetes rollout sat 0/1 Ready forever: pods alive with zero restarts, but the kubelet readiness probe carries no CF secret header, and now that pods CAN load the shared secret the middleware enforces - returning 403 to the orchestrator. Liveness already had the exemption; readiness needs the identical one (a readiness endpoint serves no sensitive data, and an unprobeable readiness check is indistinguishable from an outage to the orchestrator).

## Summary

- READYZ_PATH exempted alongside LIVEZ_PATH in the CF auth middleware (same trailing-slash/case normalization), mirrored in both services
- bypass tests cloned from the livez pair incl. strict mode; the shared test app now registers both probe routes

## Test plan

- [ ] cf_auth module suites green in both twins (19 webhook locally)
- [ ] check.python green
- [ ] auto-deploy on merge: pods reach 1/1 Ready, rollout gate passes
- [ ] DD shows webhook/api spans from the cluster

Size: XS

## Out of scope

- Readiness gaining downstream-dependency checks (documented future slice in the endpoint docstring)

part of #354