### PR TITLE
fix(iac): transitional DynamoDB grant + suspend the k8s poller

### DIFF
--- a/infra/pulumi/components/k8s_pod_user.py
+++ b/infra/pulumi/components/k8s_pod_user.py
@@ -59,6 +59,27 @@ def create(
                         "Resource": "arn:aws:ssm:us-east-1:*:parameter/grug/*",
                     },
                     {
+                        # TRANSITIONAL (#354): until the store swap, all
+                        # three services still read/write the DynamoDB
+                        # table - the Postgres-only end-state policy made
+                        # the first deploy's poller die on Scan. REMOVE
+                        # this statement in the store-swap PR.
+                        "Sid": "TransitionalDdbAccess",
+                        "Effect": "Allow",
+                        "Action": [
+                            "dynamodb:GetItem",
+                            "dynamodb:PutItem",
+                            "dynamodb:UpdateItem",
+                            "dynamodb:DeleteItem",
+                            "dynamodb:Query",
+                            "dynamodb:Scan",
+                        ],
+                        "Resource": [
+                            "arn:aws:dynamodb:us-east-1:*:table/grug-main",
+                            "arn:aws:dynamodb:us-east-1:*:table/grug-main/index/*",
+                        ],
+                    },
+                    {
                         "Sid": "DecryptSsmSecureStrings",
                         "Effect": "Allow",
                         "Action": ["kms:Decrypt"],

--- a/k8s/poller-cronjob.yaml
+++ b/k8s/poller-cronjob.yaml
@@ -8,6 +8,12 @@ metadata:
   namespace: grug
   labels: {app: grug-poller}
 spec:
+  # SUSPENDED until the cutover (#354): the Lambda poller still runs on
+  # its schedule - a second poller against the same stores double-submits
+  # reaction annotations. The deploy smoke still validates this CronJob
+  # via `create job --from` (suspend only stops SCHEDULING). The cutover
+  # PR flips this to false when the Lambdas retire.
+  suspend: true
   schedule: "*/15 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 2


### PR DESCRIPTION
## Why

First k8s deploy verdict: webhook + api reached 1/1 Ready (boot, env contract, probes all good), and the deploy's own smoke gate correctly failed the run on the poller - the pod IAM user was scoped to the Postgres END-STATE while all three services still use the DynamoDB table until the store swap (dynamodb:Scan AccessDenied, confirmed in logs). The scheduled k8s poller also double-runs alongside the Lambda poller during the overlap, which would double-submit reaction annotations.

## Summary

- pod policy: TRANSITIONAL DynamoDB statement (table + indexes, CRUD+Query+Scan) with a remove-in-the-swap-PR marker
- poller CronJob: suspend: true until cutover (suspend stops scheduling only; the deploy smoke still validates via create --from)

## Test plan

- [ ] check.python green
- [ ] post-merge pulumi up applies the policy
- [ ] auto-deploy: webhook+api Ready AND the poller smoke completes (DDB scan authorized)
- [ ] scheduled poller pods stop appearing in the namespace

Size: XS

## Out of scope

- The store swap (removes the transitional grant), data migration, cutover

part of #354