### PR TITLE
fix(cf): bound deploy.sh CF API curl calls with --max-time

### DIFF
--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -114,7 +114,7 @@ deploy_one() {
       "$worker_src" > /tmp/worker.js
 
     local upload
-    upload=$(curl -sS -X PUT \
+    upload=$(curl -sS --connect-timeout 10 --max-time 60 -X PUT \
         -H "Authorization: Bearer $CF_TOKEN" \
         -F 'metadata={"main_module":"worker.js","compatibility_date":"2024-09-01"};type=application/json' \
         -F "worker.js=@/tmp/worker.js;type=application/javascript+module" \
@@ -134,7 +134,7 @@ deploy_one() {
     # header. The endpoint is upsert semantics so re-runs are safe.
     if [ -n "$CF_SHARED_SECRET" ]; then
         local secret_response
-        secret_response=$(curl -sS -X PUT \
+        secret_response=$(curl -sS --connect-timeout 10 --max-time 60 -X PUT \
             -H "Authorization: Bearer $CF_TOKEN" \
             -H "Content-Type: application/json" \
             -d "{\"name\":\"$BINDING_NAME\",\"type\":\"secret_text\",\"text\":\"$CF_SHARED_SECRET\"}" \
@@ -150,7 +150,7 @@ deploy_one() {
     fi
 
     local route_response
-    route_response=$(curl -sS -X POST \
+    route_response=$(curl -sS --connect-timeout 10 --max-time 60 -X POST \
         "https://api.cloudflare.com/client/v4/zones/$CF_ZONE/workers/routes" \
         -H "Authorization: Bearer $CF_TOKEN" -H "Content-Type: application/json" \
         -d "{\"pattern\":\"$route_pattern\",\"script\":\"$worker_name\"}")


### PR DESCRIPTION
## Why

`infra/cloudflare/deploy.sh` makes three `curl` calls to the Cloudflare API with **no `--max-time`**. A stalled or slow CF API response has no per-call escape valve, so the step blocks until the parent `pulumi-up` job's 20-minute wall-clock limit reaps the whole deploy — at which point the Worker upload state is unknown (partial script, binding unset, route half-created) with no timeout signal. The same deploy stack already uses `--max-time` on its cache-purge and smoke-probe curls; the sibling `pages-bootstrap.sh` `api()` helper was hardened identically in #340/#342. This file was the last unguarded one.

## What

Add `--connect-timeout 10 --max-time 60` (matching the merged #342 values) to all three executed CF API calls:

- `infra/cloudflare/deploy.sh:117` — Worker script PUT upload
- `infra/cloudflare/deploy.sh:137` — `GRUG_CF_SECRET` binding PUT
- `infra/cloudflare/deploy.sh:153` — route POST

On timeout `curl` exits 28 and the existing `set -euo pipefail` aborts the step fast with a clear signal instead of hanging.

Size: XS

## Acceptance criteria

- [x] All three executed `curl` calls pass `--max-time` (and `--connect-timeout`).
- [x] A curl exceeding the limit exits 28 → `set -euo pipefail` aborts cleanly rather than hanging.
- [x] Happy-path behavior unchanged (only curl flags added); `bash -n` passes.
- [x] Single-file change; the only remaining `curl` mentions are inside `echo`'d smoke-test instructions (not executed), per the issue's out-of-scope.

## Out of scope

- Retries / circuit-breakers beyond `--max-time` (issue #330 out-of-scope).
- The CF Worker deployment logic itself.

Closes #330