### PR TITLE
test: restore the 6 store-deselected tests by patching the real boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,32 +27,23 @@ webhook-test:
 	@if [ -n "$$CI" ] && [ -z "$$GRUG_TEST_DATABASE_URL" ]; then \
 		echo "FATAL: store-backed tests would SKIP in CI (GRUG_TEST_DATABASE_URL unset) - a skipped gate is a silent pass (audit H4)"; exit 1; fi
 	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum --with 'psycopg[binary,pool]' --with 'ddtrace>=3.5,<4' --with 'datadog-lambda>=6.107,<7' pytest tests/ -q \
-		--deselect tests/test_dispatcher.py::test_installation_created_records_row \
-		--deselect tests/test_dispatcher.py::test_installation_created_org_uses_sender_id \
-		--deselect tests/test_enforcement.py::test_heal_clears_stale_id_and_recreates \
-		--deselect tests/test_enforcement.py::test_heal_returns_new_state \
 		--deselect tests/test_cf_auth.py::test_unconfigured_warning_throttled_within_window \
 		--deselect tests/test_cf_auth.py::test_throttle_distinguishes_reasons
 	# ^ cf_auth throttle pair: hosted-runner-only intermittent 0-warnings,
 	# locally irreproducible across versions/order/env - #359 root-causes.
-	# ^ dispatcher/enforcement quartet: written against live DDB (pre-swap,
-	# only ever passed via developer-shell AWS creds); post-#354 the right
-	# fix is converting them to the pg_store fixture - #356 tracks. Do NOT
-	# widen this list without an issue.
+	# (#356 dispatcher/enforcement quartet restored: the unmocked store
+	# boundary is now patched like every sibling test.) Do NOT widen this
+	# list without an issue.
 
 api-test:
 	@if [ -n "$$CI" ] && [ -z "$$GRUG_TEST_DATABASE_URL" ]; then \
 		echo "FATAL: store-backed tests would SKIP in CI (GRUG_TEST_DATABASE_URL unset) - a skipped gate is a silent pass (audit H4)"; exit 1; fi
 	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum --with 'psycopg[binary,pool]' pytest tests/ -q \
-		--deselect tests/test_installations_update_config.py::test_update_repo_config_admin_can_access_any \
-		--deselect tests/test_installations_update_config.py::test_update_repo_config_paginates_until_match \
 		--deselect tests/test_cf_auth.py::test_unconfigured_warning_throttled_within_window \
 		--deselect tests/test_cf_auth.py::test_throttle_distinguishes_reasons
 	# ^ cf_auth throttle pair: hosted-runner-only flake, #359 (twin of webhook).
-	# ^ update_config pair: same live-store class as the webhook quartet -
-	# the long-known 'ordering pollution' local failures were actually real
-	# GetItem calls riding developer AWS creds (pre-swap). #356 converts
-	# them to the pg_store fixture.
+	# (#356 update_config pair restored: the unmocked previous_cfg store
+	# read is now patched.)
 
 # Real-Postgres store tests (#354). REQUIRE a reachable Postgres via
 # GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip

--- a/services/api/tests/test_installations_update_config.py
+++ b/services/api/tests/test_installations_update_config.py
@@ -77,7 +77,8 @@ def test_update_repo_config_admin_can_access_any():
             with patch("httpx.Client") as client_cls:
                 client = client_cls.return_value.__enter__.return_value
                 client.get.return_value = fake_pages[0]
-                with patch("installations.set_repo_config", return_value={"tpm_enabled": False}):
+                with patch("installations.get_repo_config", return_value={}), \
+                     patch("installations.set_repo_config", return_value={"tpm_enabled": False}):
                     out = inst.update_repo_config(
                         install_id=1, repo_id=42,
                         body=payload, user=_user(user_id="100", role="admin"),
@@ -170,7 +171,8 @@ def test_update_repo_config_paginates_until_match():
             with patch("httpx.Client") as client_cls:
                 client = client_cls.return_value.__enter__.return_value
                 client.get.side_effect = _client_get
-                with patch("installations.set_repo_config", return_value={"tpm_enabled": False}):
+                with patch("installations.get_repo_config", return_value={}), \
+                     patch("installations.set_repo_config", return_value={"tpm_enabled": False}):
                     out = inst.update_repo_config(
                         install_id=1, repo_id=200,
                         body=payload, user=_user(user_id="100"),

--- a/services/webhook/tests/test_dispatcher.py
+++ b/services/webhook/tests/test_dispatcher.py
@@ -297,7 +297,8 @@ def test_installation_created_records_row():
         },
         "sender": {"id": 100, "login": "githumps"},
     }
-    with patch("dispatcher.record_installation") as mock_rec:
+    with patch("dispatcher.record_installation") as mock_rec, \
+         patch("dispatcher.is_install_allowlisted", return_value=False):
         out = dispatch("installation", payload)
     assert out["status"] == "recorded" and out["action"] == "created"
     mock_rec.assert_called_once_with(
@@ -316,7 +317,8 @@ def test_installation_created_org_uses_sender_id():
         },
         "sender": {"id": 100, "login": "evan"},
     }
-    with patch("dispatcher.record_installation") as mock_rec:
+    with patch("dispatcher.record_installation") as mock_rec, \
+         patch("dispatcher.is_install_allowlisted", return_value=False):
         dispatch("installation", payload)
     assert mock_rec.call_args.kwargs["installed_by_user_id"] == 100
 

--- a/services/webhook/tests/test_enforcement.py
+++ b/services/webhook/tests/test_enforcement.py
@@ -148,9 +148,9 @@ def test_check_name():
 
 def test_heal_clears_stale_id_and_recreates():
     """Deleted Grug ruleset → clear old ID → ensure creates a new one."""
-    with patch("adapters.install_store.set_enforcement_id") as mock_set, \
-         patch("enforcement.detect_enforcement", return_value="none"), \
+    with patch("enforcement.detect_enforcement", return_value="none"), \
          patch("enforcement.create_ruleset", return_value={"id": 99}), \
+         patch("adapters.install_store.get_enforcement_id", return_value=99), \
          patch("adapters.install_store.set_enforcement_id") as mock_set:
         result = heal_enforcement("tok", "o", "r", "main", 1, 2, old_ruleset_id=42)
 
@@ -164,7 +164,8 @@ def test_heal_returns_new_state():
     """heal_enforcement returns the EnforcementState from ensure."""
     with patch("adapters.install_store.set_enforcement_id"), \
          patch("enforcement.detect_enforcement", return_value="none"), \
-         patch("enforcement.create_ruleset", return_value={"id": 50}):
+         patch("enforcement.create_ruleset", return_value={"id": 50}), \
+         patch("adapters.install_store.get_enforcement_id", return_value=50):
         result = heal_enforcement("tok", "o", "r", "main", 1, 2, old_ruleset_id=10)
 
     assert result == "grug_managed"


### PR DESCRIPTION
## Summary

Restores the six tests deselected for hitting live storage (the #356 quartet + the api update_config pair). The issue's premise held — unit tests were integration-testing prod storage via ambient developer credentials — but the prescription (moto fixtures) aged out with the #354 Postgres swap. Post-swap each test failed loud on an unconfigured store, which pinpointed the real gap: exactly one unmocked store call past the mocked happy path in each test (`is_install_allowlisted` in the dispatcher pair, the post-ensure `get_enforcement_id` log read in the heal pair, the `previous_cfg` read in the update_config pair). Each is now patched at the same boundary its sibling tests already mock. All deselects except the #359 cf_auth throttle pairs are gone from the Makefile.

## Test plan

- [x] All 6 restored tests pass with NO ambient AWS creds and NO database (`env -u GRUG_TEST_DATABASE_URL` + empty key env) — the issue's acceptance criterion
- [x] `make webhook-test` — 577 passed (was 573 + 4 restored), 2 deselected (#359 only)
- [x] `make api-test` — 315 passed (was 313 + 2 restored), 2 deselected (#359 only)
- [x] Makefile deselect comments updated to reflect what remains and why

## Out of scope

- The #359 cf_auth throttle pairs (hosted-runner-only flake, separate root-cause)
- Converting these to real-PG integration tests (they are unit tests of dispatch/route logic; the store behavior they'd exercise is covered by test_pg_stores.py)

Size: S

closes #356