### PR TITLE
fix(webhook): response annotation 500s every dispatched PR delivery on the k8s image

### DIFF
--- a/services/webhook/main.py
+++ b/services/webhook/main.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import logging
 import os
 
+from typing import Any
+
 from fastapi import FastAPI, Header, HTTPException, Request, status
 
 from cf_auth import CfAuthMiddleware
@@ -64,7 +66,13 @@ async def receive_github_webhook(
     x_github_event: str = Header(default=""),
     x_github_delivery: str = Header(default=""),
     x_hub_signature_256: str = Header(default=""),
-) -> dict[str, str]:
+) -> dict[str, Any]:
+    # dict[str, Any], NOT dict[str, str]: dispatch() returns an aggregated
+    # {status, personas: [...]} for pull_request events (list-shaped - see
+    # dispatcher.py's own contract comment). The narrower annotation made
+    # FastAPI's response validation 500 every dispatched PR delivery on the
+    # k8s image (caught by the #368 live proof; the Lambda image's older
+    # dependency set never enforced it).
     # Handler is async because reading raw body via Starlette's Request
     # requires `await request.body()`. Earlier sync version used
     # `body: bytes = Body(...)` but FastAPI 0.115 / Pydantic-v2

--- a/services/webhook/tests/test_main_webhook_receiver.py
+++ b/services/webhook/tests/test_main_webhook_receiver.py
@@ -33,12 +33,18 @@ def _client(monkeypatch):
     monkeypatch.setenv("GRUG_DDB_TABLE", "grug-main-test")
     monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
     import main as webhook_main
+
     monkeypatch.setattr(webhook_main, "get_webhook_secret", lambda: _WEBHOOK_SECRET)
     # Stub dispatcher so we don't need DDB/KMS for the webhook-receiver tests
     import dispatcher
+
     monkeypatch.setattr(
-        dispatcher, "dispatch",
-        lambda event, payload, *, delivery_id="": {"status": "no_op", "reason": "stubbed"},
+        dispatcher,
+        "dispatch",
+        lambda event, payload, *, delivery_id="": {
+            "status": "no_op",
+            "reason": "stubbed",
+        },
     )
     return TestClient(webhook_main.app)
 
@@ -71,6 +77,7 @@ def test_unsigned_probe_logs_distinct_event_not_signature_invalid(_client, caplo
     `webhook_unsigned_probe`, never `webhook_signature_invalid` (the monitored
     alert). Keeps the sig-verify monitor precise to real rotated-secret events."""
     import logging
+
     caplog.set_level(logging.INFO)
     _client.post(
         "/webhook/github",
@@ -87,6 +94,7 @@ def test_signed_but_invalid_logs_signature_invalid(_client, caplog):
     rejection (rotated secret / forged delivery) — it must log the monitored
     `webhook_signature_invalid`, not the quiet probe event."""
     import logging
+
     caplog.set_level(logging.WARNING)
     _client.post(
         "/webhook/github",
@@ -114,6 +122,41 @@ def test_signed_non_json_body_returns_400(_client):
     )
     assert r.status_code == 400
     assert r.json()["detail"] == "body_not_json"
+
+
+def test_dispatched_personas_list_response_returns_200(_client, monkeypatch):
+    """#368 live-proof regression: dispatch() returns {status, personas: [...]}
+    (LIST-shaped) for pull_request events. The route annotation must accept
+    it - a dict[str, str] annotation made FastAPI's response validation 500
+    every dispatched PR delivery on the k8s image (the Lambda image's older
+    dependency set never enforced it, which hid the bug)."""
+    import dispatcher
+
+    monkeypatch.setattr(
+        dispatcher,
+        "dispatch",
+        lambda event, payload, *, delivery_id="": {
+            "status": "dispatched",
+            "personas": [
+                {"persona": "tpm", "result": "pass"},
+                {"persona": "code_reviewer", "result": "queued"},
+            ],
+        },
+    )
+    body = b'{"action":"synchronize","number":373}'
+    r = _client.post(
+        "/webhook/github",
+        content=body,
+        headers={
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "k8sproof-regression",
+            "X-Hub-Signature-256": _sign(_WEBHOOK_SECRET, body),
+        },
+    )
+    assert r.status_code == 200
+    out = r.json()
+    assert out["status"] == "dispatched"
+    assert out["personas"][1] == {"persona": "code_reviewer", "result": "queued"}
 
 
 def test_signed_valid_json_dispatches(_client):


### PR DESCRIPTION
## Why

- The grug#368 live proof against the in-cluster pod surfaced a flip blocker: every dispatched pull_request delivery 500s on the k8s image because the route's `-> dict[str, str]` annotation rejects dispatch()'s documented `{status, personas: [...]}` list shape via FastAPI response validation
- The Lambda image's older dependency set never enforced the annotation, which is why prod has returned 200s daily on the identical shape - the bug only manifests on the runtime we are flipping TO
- After the flip, GitHub would mark every PR delivery failed (reviews would still post - the Elder thread detaches before serialization - but the delivery surface would be red and eventually noisy)

## Acceptance criteria

- [x] Route annotation matches the dispatcher's actual return contract (dict[str, Any], with the why documented inline)
- [x] Regression test: signed pull_request delivery with the real personas-list shape returns 200 (this exact test 500s on main)
- [x] Full webhook suite green: 587 passed locally

Size: XS

## Out of scope

- The dispatcher's return shape itself (its contract comment is explicit and correct)
- The DNS flip (next step after this lands; live proof evidence on grug#368)
