### PR TITLE
fix(cf): ignore webhook record content - unblocks the retirement up

### DIFF
--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -355,6 +355,14 @@ _k8s_pod = k8s_pod_user.create(
 # target only matters if the Worker route is ever removed: traffic
 # still lands on the tunnel origin (and 401s without the Worker's
 # auth header — cf_auth holds the boundary).
+# CONTENT IS HAND-OWNED until the #239 zone migration: the stack's CF
+# token verifies active but gets 10000 Authentication error on every
+# grug.lol DNS-records call (it kept Workers perms, lost zone DNS) -
+# the retirement up failed exactly here. The record's content was
+# PATCHed to the tunnel origin out-of-band with the infra-zone token;
+# ignore_changes below keeps this stack from ever calling the DNS API
+# it cannot use. The infra stack adopts both grug.lol records at the
+# zone migration (infra#239).
 _webhook_upstream_host = aws.ssm.get_parameter(name="/grug/webhook-upstream-host")
 cloudflare_dns.create_proxied_cname(
     zone_id=_cf_zone_id.value,
@@ -364,6 +372,7 @@ cloudflare_dns.create_proxied_cname(
     provider=cf_provider,
     # Proxied=True so the Worker route intercepts and rewrites Host.
     proxied=True,
+    ignore_content=True,
 )
 
 # API Lambda — separate ECR + Function URL from webhook (per Q10

--- a/infra/pulumi/components/cloudflare_dns.py
+++ b/infra/pulumi/components/cloudflare_dns.py
@@ -31,6 +31,7 @@ def create_proxied_cname(
     target_url: pulumi.Output[str],
     provider: cloudflare.Provider | None = None,
     proxied: bool = True,
+    ignore_content: bool = False,
 ) -> cloudflare.Record:
     """Create a CNAME `<name>.<domain>` → host of target_url.
 
@@ -51,5 +52,11 @@ def create_proxied_cname(
         proxied=proxied,
         ttl=1 if proxied else 300,  # 1 = "Auto" when proxied; 300 = 5min DNS-only
         comment=f"grug — managed by Pulumi (slice 1) — {name}.{domain}",
-        opts=pulumi.ResourceOptions(provider=provider) if provider else None,
+        # ignore_content: the record exists but its VALUE is owned
+        # out-of-band (e.g. the webhook record post-#354 - this stack's
+        # CF token lost zone-DNS access; see the call site + infra#239).
+        opts=pulumi.ResourceOptions(
+            provider=provider,
+            ignore_changes=["content"] if ignore_content else None,
+        ),
     )


### PR DESCRIPTION
## Why

- The retirement apply (#376) failed at cf-webhook: the stack's CF token gets 10000 Authentication error on ALL grug.lol DNS-records calls (verified empirically: token verify = active, Workers deploys work, zone DNS list/edit = 10000) - it kept Workers perms and lost zone DNS somewhere along the line
- The record's content is already correct: PATCHed out-of-band to the tunnel origin with the infra-zone token (traffic verified 200 after)
- ignore_changes=[content] makes the stack stop calling the API it cannot use, which unblocks the queued Lambda/ESM/ECR deletions; infra#239 (zone migration) adopts both grug.lol records properly

## Test plan

- [x] AST + ruff clean (E402s pre-existing)
- [x] webhook.grug.lol /livez 200 after the out-of-band record PATCH
- [ ] Post-merge iac.deploy up completes: webhook Lambda + both ESMs + poller + webhook ECR actually deleted (verified via AWS API, evidence on infra#1170)

Size: XS

## Out of scope

- api.grug.lol record (same trap awaits the api cutover; flagged for infra#239)
- Re-scoping/re-minting the grug CF token (operator decision; may be moot after #239)