### PR TITLE
fix(api): CORSMiddleware for grug.lol SPA credentialed fetches (dashboard OAuth loop)

### DIFF
--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -124,6 +124,14 @@ jobs:
             echo "AWS_SECRET_ACCESS_KEY=$(get /grug/k8s-pod-aws-secret-access-key)"
             echo "AWS_DEFAULT_REGION=us-east-1"
             echo "GRUG_DATABASE_URL=$(get /grug/database-url)"
+            # GRUG_KMS_CMK_ARN: envelope-encryption CMK for OAuth/credential
+            # blobs (crypto/kms_envelope.encrypt_for_user hard-requires it at
+            # call time). The Lambda env had it; the k8s secret-seed missed
+            # it, so the dashboard OAuth callback 500'd on first sign-in.
+            # Sourced from SSM (the ARN carries the account id - keep it out
+            # of the repo). The grug k8s-pod IAM user already holds the KMS
+            # grant on this CMK (#354).
+            echo "GRUG_KMS_CMK_ARN=$(get /grug/kms-cmk-arn)"
             echo "GRUG_CAVE_JOBS_QUEUE_URL=$(aws sqs get-queue-url --queue-name grug-cave-jobs.fifo --query QueueUrl --output text)"
             echo "GRUG_RERUN_QUEUE_URL=$(aws sqs get-queue-url --queue-name grug-rerun-jobs.fifo --query QueueUrl --output text)"
             echo "GRUG_CAVE_RESULTS_QUEUE_URL=$(aws sqs get-queue-url --queue-name grug-cave-results.fifo --query QueueUrl --output text)"

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -17,6 +17,7 @@ import os
 from datetime import datetime, timezone
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from admin import router as admin_router
 from auth.github_oauth import router as github_oauth_router
@@ -43,6 +44,26 @@ app = FastAPI(
 # yet so deploy ordering across Pulumi + Workers + service can race
 # without breaking production traffic.
 app.add_middleware(CfAuthMiddleware)
+
+# CORS for the grug.lol SPA -> api.grug.lol cross-origin (different
+# subdomain = different origin). The SPA fetches /api/v1/me etc. with
+# `credentials: "include"`; without these headers the browser blocks the
+# credentialed response, the SPA reads it as logged-out, and the dashboard
+# loops back into OAuth (which trips GitHub's secondary rate limit).
+# The Lambda Function URL carried this CORS config (FunctionUrlCorsArgs);
+# the Lambda->k8s migration dropped it since FastAPI never added the
+# middleware. allow_origins MUST be explicit (not "*") when
+# allow_credentials=True — the browser rejects "*" with credentials.
+# Added last so CORS is the OUTERMOST layer: it answers the OPTIONS
+# preflight and stamps headers even on CfAuth short-circuits.
+_SPA_DOMAIN = os.environ.get("GRUG_DOMAIN", "grug.lol")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[f"https://{_SPA_DOMAIN}", f"https://www.{_SPA_DOMAIN}"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/livez")


### PR DESCRIPTION
## Why

After the `GRUG_KMS_CMK_ARN` fix (#382) un-broke the OAuth callback, the dashboard still looped into OAuth and tripped GitHub's "Too many requests." Root cause: api.grug.lol returns no CORS headers. The SPA (CF Pages at grug.lol) fetches `/api/v1/me` with `credentials: "include"` cross-origin; with no `Access-Control-Allow-Origin`/`Allow-Credentials` the browser blocks the credentialed response -> SPA reads logged-out -> `/signin` auto-bounces to GitHub -> callback -> `/dashboard` -> blocked again -> loop. The Lambda Function URL carried CORS via `FunctionUrlCorsArgs`; the k8s FastAPI app never added the equivalent.

closes #383

## Test plan

- Live evidence pre-fix: `GET /api/v1/me` (Origin `https://grug.lol`) -> 200 with no `access-control-*` headers; `OPTIONS /api/v1/me` -> 405.
- After deploy: `curl -H 'Origin: https://grug.lol' https://api.grug.lol/api/v1/me` returns `access-control-allow-origin: https://grug.lol` + `access-control-allow-credentials: true`; OPTIONS preflight -> 200.
- Chrome: one GitHub sign-in reaches the dashboard and stays (no redirect loop, no GitHub rate-limit).

Size: XS

## Out of scope

- Cookie domain/SameSite (host-only `api.grug.lol` + Lax is correct for same-site credentialed XHR; CORS was the gap).
- The KMS callback fix (already shipped in #382).