### PR TITLE
feat(grug): security audit hardening batch (red/blue team pass)

### DIFF
--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -86,6 +86,16 @@ jobs:
               --build-arg DD_GIT_REPOSITORY_URL="github.com/${GITHUB_REPOSITORY}" \
               --build-arg DD_GIT_COMMIT_SHA="${GITHUB_SHA}"
             docker push "$REGISTRY_HOST/grug-$svc:${GITHUB_SHA}"
+            # Capture the IMMUTABLE digest the registry assigned and deploy
+            # by @sha256, not the mutable tag (audit #7: a tag can be
+            # overwritten in the registry to serve a different image; a
+            # digest pins exactly what we just built + pushed).
+            digest="$(docker inspect --format='{{index .RepoDigests 0}}' \
+              "$REGISTRY_HOST/grug-$svc:${GITHUB_SHA}")"
+            if [ -z "$digest" ]; then
+              echo "::error::no RepoDigest for grug-$svc after push"; exit 1
+            fi
+            echo "IMAGE_${svc^^}=${digest}" >> "$GITHUB_ENV"
           done
 
       - name: Write kubeconfig
@@ -155,9 +165,14 @@ jobs:
           REGISTRY_HOST: ${{ vars.DEPLOY_REGISTRY_HOST }}
         run: |
           set -euo pipefail
+          # Substitute each service's full image ref with the digest-pinned
+          # form captured at push time (audit #7). REGISTRY_PLACEHOLDER only
+          # ever appears inside image lines, so replacing the whole
+          # registry/name:tag token is sufficient — there's no longer a
+          # separate mutable tag substitution.
           sed -i \
-            -e "s|REGISTRY_PLACEHOLDER|$REGISTRY_HOST|g" \
-            -e "s|TAG_PLACEHOLDER|${GITHUB_SHA}|g" \
+            -e "s|REGISTRY_PLACEHOLDER/grug-api:TAG_PLACEHOLDER|${IMAGE_API}|g" \
+            -e "s|REGISTRY_PLACEHOLDER/grug-webhook:TAG_PLACEHOLDER|${IMAGE_WEBHOOK}|g" \
             k8s/*.yaml
           # Post-sed sentinel: a future manifest that escapes substitution
           # must fail the deploy, not ship a literal placeholder (F7).

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,15 @@
 .PHONY: test webhook-test api-test pg-test pulumi-preview pulumi-up \
         tear-down rebuild bootstrap-images smoke docker-build-webhook
 
-# Admin seed defaults — the values that get re-installed after a tear-down
-# so allowlist gate works on first PR after rebuild. Override via env.
-GRUG_ADMIN_USER_ID ?= 59060157
-GRUG_ADMIN_LOGIN   ?= githumps
-GRUG_ADMIN_INSTALL_ID ?= 129256114
+# Admin seed values — the row (re)installed after a tear-down so the
+# allowlist gate works on the first PR after rebuild. NO DEFAULTS on
+# purpose: a fork that ran this with the maintainer's hardcoded GitHub id
+# would seed the upstream owner as the lifetime admin of the fork's own
+# database (an accidental backdoor). You MUST supply your own via env:
+#   GRUG_ADMIN_USER_ID=12345 GRUG_ADMIN_LOGIN=you GRUG_ADMIN_INSTALL_ID=678 make rebuild
+GRUG_ADMIN_USER_ID ?=
+GRUG_ADMIN_LOGIN   ?=
+GRUG_ADMIN_INSTALL_ID ?=
 
 test: webhook-test api-test
 
@@ -102,6 +106,7 @@ rebuild: tear-down
 	  gh run watch $$RUN_ID --exit-status --repo githumps/grug
 	@echo ">> step 6/7: CF Workers re-deploy + admin re-seed"
 	bash infra/cloudflare/deploy.sh
+	@test -n "$(GRUG_ADMIN_USER_ID)" || { echo "FATAL: set GRUG_ADMIN_USER_ID (and GRUG_ADMIN_LOGIN/GRUG_ADMIN_INSTALL_ID) to YOUR own GitHub identity before seeding admin"; exit 1; }
 	uv run --with 'psycopg[binary]' python infra/scripts/seed-admin.py \
 	  --github-user-id $(GRUG_ADMIN_USER_ID) \
 	  --login $(GRUG_ADMIN_LOGIN) \

--- a/docs/HITL_PREREQUISITES.md
+++ b/docs/HITL_PREREQUISITES.md
@@ -60,6 +60,17 @@ aws ssm put-parameter --region us-east-1 \
   --type SecureString \
   --value "<the openssl rand -hex 32 output>"
 
+# Session-signing secret — dedicated HMAC key for the dashboard's session
+# cookie + OAuth CSRF state, kept SEPARATE from the webhook secret so the
+# two trust domains can be rotated independently (audit #5). api falls back
+# to the webhook secret if this is absent, but provisioning it is what
+# closes the finding. Use a fresh random value (do NOT reuse the webhook
+# secret).
+aws ssm put-parameter --region us-east-1 \
+  --name /grug/session-signing-secret \
+  --type SecureString \
+  --value "$(openssl rand -hex 32)"
+
 # LLM backend keys live at the SHARED cross-project path
 # `/infra/llm/<provider>_api_key` (NOT a grug-specific copy) so each key is
 # minted/rotated once across all projects. If they already exist (other
@@ -84,7 +95,7 @@ Verify:
 
 ```bash
 aws ssm get-parameters-by-path --region us-east-1 --path /grug --recursive --query 'Parameters[].Name'
-# Expected: ["/grug/github-app-id", "/grug/github-app-private-key", "/grug/github-app-webhook-secret"]
+# Expected: ["/grug/github-app-id", "/grug/github-app-private-key", "/grug/github-app-webhook-secret", "/grug/session-signing-secret"]
 aws ssm get-parameters-by-path --region us-east-1 --path /infra/llm --recursive --query 'Parameters[].Name'
 # Expected (shared): ["/infra/llm/openrouter_api_key", "/infra/llm/poolside_api_key"]
 ```

--- a/docs/NETWORK-TOPOLOGY.md
+++ b/docs/NETWORK-TOPOLOGY.md
@@ -8,7 +8,7 @@ External SaaS the stack depends on (flat dependencies, not topology):
 
 - **Cloudflare Pages** — `grug-web` project at apex `grug.lol` (static + SPA)
 - **Cloudflare DNS + Workers** — proxied A records for `api.grug.lol` + `webhook.grug.lol`; two Host-rewrite Workers
-- **AWS us-east-1** account `317164914846` — Lambda, DDB, KMS, SSM, ECR, CloudWatch Logs
+- **AWS us-east-1** account `<aws-account-id>` — Lambda, DDB, KMS, SSM, ECR, CloudWatch Logs
 - **Datadog US1** — APM + Logs + RUM + Monitors + Synthetics
 - **GitHub** — App registration `grug-tribe` (webhook source + OAuth identity provider) + Actions OIDC (deploys)
 - **Pulumi Cloud** — `<pulumi-org>/grug/{dev,prod}` stacks (no passphrase)
@@ -31,8 +31,8 @@ Stacks: `dev` (live), `prod` (locked, not yet cut over).
 
 | Component | Resource | Notes |
 |---|---|---|
-| `grug-api` Lambda | `arn:aws:lambda:us-east-1:317164914846:function:grug-api` | arm64, 512MB, 15s timeout, container image from ECR. FastAPI via Mangum. DD Extension 96-next baked in |
-| `grug-webhook` Lambda | `arn:aws:lambda:us-east-1:317164914846:function:grug-webhook` | Same shape; tighter DDB IAM scope (no token reads) |
+| `grug-api` Lambda | `arn:aws:lambda:us-east-1:<aws-account-id>:function:grug-api` | arm64, 512MB, 15s timeout, container image from ECR. FastAPI via Mangum. DD Extension 96-next baked in |
+| `grug-webhook` Lambda | `arn:aws:lambda:us-east-1:<aws-account-id>:function:grug-webhook` | Same shape; tighter DDB IAM scope (no token reads) |
 | Function URLs | `:url:grug-api`, `:url:grug-webhook` | AuthType=NONE; CF is the trust boundary. api Lambda has CORS allow `https://grug.lol` |
 | ECR repos | `grug-api`, `grug-webhook` | Private; 14d untagged GC |
 | DynamoDB | `grug-main` | Single-table, PAY_PER_REQUEST |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -176,7 +176,7 @@ Slice 10 (#31) acceptance proof. The "ready to tear down + build" requirement is
 | Webhook URL setting | github.com (matches DNS recreated by Pulumi) |
 | App webhook secret + private key | SSM SecureString `/grug/github-app-{webhook-secret,private-key}` |
 | OAuth client secret | SSM `/grug/github-app-client-secret` |
-| Existing installations | github.com (install_id 129256114 etc.) |
+| Existing installations | github.com (install_id <your-install-id> etc.) |
 | Branch protection on installed repos | github.com (referencing check-run name `Grug — Definition of Ready`) |
 | Datadog API + App keys | SSM `/shared/datadog-{api,app}-key` |
 | Cloudflare API token | SSM `/grug/cloudflare-api-token` |
@@ -232,9 +232,9 @@ Note: KMS CMK enters 7-day pending-deletion. Within that window, `pulumi up` aga
 
 | Var | Default | Use |
 |---|---|---|
-| `GRUG_ADMIN_USER_ID` | 59060157 | Numeric GitHub user ID for admin USER# row |
-| `GRUG_ADMIN_LOGIN` | githumps | login for the row |
-| `GRUG_ADMIN_INSTALL_ID` | 129256114 | INST# row to backfill (skip on org-account migrations where install_id changed) |
+| `GRUG_ADMIN_USER_ID` | _(none — set to YOUR id)_ | Numeric GitHub user ID for admin USER# row |
+| `GRUG_ADMIN_LOGIN` | _(none — set to YOUR login)_ | login for the row |
+| `GRUG_ADMIN_INSTALL_ID` | _(none — set to YOUR install)_ | INST# row to backfill (skip on org-account migrations where install_id changed) |
 
 Override per-recovery: `GRUG_ADMIN_USER_ID=123 make rebuild`
 
@@ -436,7 +436,7 @@ default is a future code slice (bake the winner into `build_system_prompt`'s
 default), not a toggle flip.
 
 **Arm-up record (2026-06-10, #276).** The cell-balance check found the live
-population is **one install** (`129256114` → the `poolside × v2` cell; the
+population is **one install** (the maintainer install -> the `poolside x v2` cell; the
 other three cells empty). `split` would therefore be a misleading rename of
 all-v2 — there is no within-population A/B at n=1. Decision: the toggle is set
 to **`all_v2`** and the experiment is a **temporal comparison** — v2 spans

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -103,14 +103,15 @@ _dd_extension_version = config.get("dd_extension_version") or "65"
 _deploy_role_bundle = oidc_role.create(
     name="grug-gha-deploy",
     repo="githumps/grug",
-    # `main` and SaaS-conversion feature branches (epic-grug-saas).
-    # Tighten back to `main` only once Slice 13 (#34) ships.
-    # Permissive `feat/*` + `fix/*` during the SaaS conversion (closes #64).
-    # Tighten back to `main` only at Slice 13 cutover (#34). Earlier
-    # per-slice patterns required local pulumi up after every new branch
-    # AND silently narrowed back whenever main re-deployed without the
-    # wider list.
-    branches=["main", "feat/*", "fix/*", "hotfix/*"],
+    # Trust ONLY `main` (+ `v*` tags below). The SaaS conversion is past
+    # cutover, so the permissive `feat/*` / `fix/*` / `hotfix/*` patterns
+    # (closes #64) are retired: they let anyone who could push such a
+    # branch to githumps/grug assume the deploy role and act in the AWS
+    # account. `pulumi up` only runs from `main` anyway (the deploy job is
+    # gated on it), so a feature branch never legitimately needs the role.
+    # (Audit #2.) Forks are already excluded — the trust is repo-scoped to
+    # githumps/grug, so this only ever governed first-party branches.
+    branches=["main"],
     # deploy.k8s runs inside the k8s-prod environment (#354).
     environments=["k8s-prod"],
     tags_pattern="v*",

--- a/infra/pulumi/components/dd_monitors.py
+++ b/infra/pulumi/components/dd_monitors.py
@@ -183,7 +183,7 @@ def create_all(
             "or a large diff couldn't spill to S3. (Clouds-down alone is "
             "expected — the SaaS backends are unfunded by design; do NOT top up "
             "OpenRouter/Poolside.) Check the grug-cave-connector pod on the LAN "
-            "worker, proxy-egress-sparkles, the Cave itself, and the cave DLQs. "
+            "worker, the cave egress proxy, the Cave itself, and the cave DLQs. "
             "The errored Activity row can be re-run from the dashboard once "
             "the Cave recovers.\n"
             "Runbook: docs/RUNBOOK.md#elder-async-offload"

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -21,7 +21,6 @@ import hashlib
 import json
 from dataclasses import dataclass
 
-import pulumi
 import pulumi_aws as aws
 import pulumiverse_time as ptime
 
@@ -108,66 +107,80 @@ def create(
         tags={"app": "grug", "purpose": "gha-deploy"},
     )
 
-    # Permissions: PowerUser-equivalent for the resources Pulumi creates,
-    # scoped down later. For Slice 1 — Lambda + ECR + IAM (for role
-    # creation) + SSM read + CloudWatch + Cloudflare-via-API.
-    #
-    # SSM read explicitly includes `/shared/*` so CI can fetch the
-    # cross-repo Pulumi access token (per the operator's private infra
-    # SSM convention — `/shared/<token>` is the cross-cutting namespace).
+    # Least-privilege deploy permissions, scoped to what the prod stack
+    # ACTUALLY manages (audit #2). Verified against the live stack
+    # (`pulumi stack export`): IAM principals are grug-gha-deploy (role) +
+    # grug-cave-connector / grug-k8s-pod (users) — all `grug-*` prefixed;
+    # and NO Lambda / ECR / EventBridge / CloudWatch-Logs resources are
+    # deployed (retired at the #354 k8s cutover; the container registry is
+    # self-hosted, not ECR). Those service grants were therefore dead and
+    # are removed. SSM reads include `/shared/*` so CI can fetch the
+    # cross-repo Pulumi access token (`/shared/<token>` is the operator's
+    # cross-cutting namespace); writes stay scoped to `/grug/*` below.
     deploy_policy_doc = json.dumps(
             {
                 "Version": "2012-10-17",
                 "Statement": [
                     {
+                        # IAM lifecycle for the stack's OWN principals only.
+                        # Replaces the former `iam:*` on `*`, which was
+                        # privilege-escalation-complete (CreateAccessKey /
+                        # AttachUserPolicy / CreateRole on ANY principal ->
+                        # self-grant admin). Scoped to role/grug-* + user/grug-*.
                         "Effect": "Allow",
                         "Action": [
-                            "lambda:*",
-                            "ecr:*",
-                            "iam:*",
-                            "logs:*",
-                            "ssm:GetParameter*",
-                            "ssm:DescribeParameters",
-                            "cloudwatch:*",
-                            # EventBridge (events:*) is a DISTINCT namespace
-                            # from cloudwatch:* (metrics/alarms). The reaction-
-                            # poll scheduled Lambda (#261) is the first
-                            # EventBridge resource; creating a TAGGED rule needs
-                            # events:TagResource + PutRule/PutTargets/etc. Broad
-                            # like the lambda:*/cloudwatch:* grants above
-                            # (Slice-1 "deploy works"; ARN-scoping is the
-                            # deferred follow-up).
-                            "events:*",
-                            "sts:GetCallerIdentity",
-                            "kms:Decrypt",
-                            # Lambda eagerly encrypts env vars on the
-                            # CALLING principal's behalf when kms_key_arn
-                            # is set on the function. Without kms:Encrypt
-                            # on the deployer role, UpdateFunctionConfig
-                            # 403s. Closes #60.
-                            #
-                            # kms:CreateGrant — required by AWS docs
-                            # for "configuring a customer managed key on
-                            # a Lambda function". Lambda needs the grant
-                            # to encrypt/decrypt during invocations.
-                            # Greptile P1 PR #79 (defensive: pulumi up
-                            # works without it, but AWS docs are
-                            # explicit it should be present).
-                            "kms:Encrypt",
-                            "kms:CreateGrant",
-                            "kms:DescribeKey",
-                            # Lambda's UpdateFunctionConfiguration on a
-                            # CMK-protected function performs an upfront
-                            # GenerateDataKey check using the calling
-                            # principal's perms. Verified mid-loop on
-                            # run 25310220972 (failed step 10, succeeded
-                            # step 10c after IAM-retry sleep). Adding
-                            # defensively so cold-account first deploys
-                            # don't repeat the chicken-egg.
-                            "kms:GenerateDataKey",
+                            "iam:CreateRole", "iam:GetRole", "iam:DeleteRole",
+                            "iam:UpdateRole", "iam:UpdateAssumeRolePolicy",
+                            "iam:TagRole", "iam:UntagRole",
+                            "iam:ListRolePolicies", "iam:ListAttachedRolePolicies",
+                            "iam:ListRoleTags",
+                            "iam:PutRolePolicy", "iam:GetRolePolicy",
+                            "iam:DeleteRolePolicy",
+                            "iam:CreateUser", "iam:GetUser", "iam:DeleteUser",
+                            "iam:TagUser", "iam:UntagUser",
+                            "iam:ListUserPolicies", "iam:ListAttachedUserPolicies",
+                            "iam:ListUserTags",
+                            "iam:PutUserPolicy", "iam:GetUserPolicy",
+                            "iam:DeleteUserPolicy",
+                            "iam:CreateAccessKey", "iam:DeleteAccessKey",
+                            "iam:ListAccessKeys", "iam:GetAccessKeyLastUsed",
                         ],
-                        # NOTE: tightening to specific resource ARNs is a
-                        # follow-up. Slice 1 prioritizes "deploy works".
+                        "Resource": [
+                            "arn:aws:iam::*:role/grug-*",
+                            "arn:aws:iam::*:user/grug-*",
+                        ],
+                    },
+                    {
+                        # SSM reads: the stack's own `/grug/*` params + the
+                        # cross-repo Pulumi token at `/shared/*`.
+                        "Effect": "Allow",
+                        "Action": ["ssm:GetParameter*"],
+                        "Resource": [
+                            "arn:aws:ssm:*:*:parameter/grug/*",
+                            "arn:aws:ssm:*:*:parameter/shared/*",
+                        ],
+                    },
+                    {
+                        # Account-global actions that have no resource-level
+                        # scoping.
+                        "Effect": "Allow",
+                        "Action": [
+                            "sts:GetCallerIdentity",
+                            "ssm:DescribeParameters",
+                        ],
+                        "Resource": "*",
+                    },
+                    {
+                        # KMS for the Pulumi awskms secrets provider (decrypts
+                        # the stack's encrypted config on every op) + drift
+                        # reads on the grug-tokens CMK. Real key access is
+                        # gated by each key's KEY POLICY, so `*` here is the
+                        # key-policy-gated minimum, not an escalation vector.
+                        # The former Encrypt / CreateGrant / GenerateDataKey
+                        # grants existed only for Lambda env-var encryption
+                        # (retired) and are removed.
+                        "Effect": "Allow",
+                        "Action": ["kms:Decrypt", "kms:DescribeKey"],
                         "Resource": "*",
                     },
                     {

--- a/infra/scripts/seed-admin.py
+++ b/infra/scripts/seed-admin.py
@@ -3,12 +3,15 @@
 
 Usage:
     GRUG_DATABASE_URL=postgresql://... python3 infra/scripts/seed-admin.py \\
-        --github-user-id 59060157 --login githumps
+        --github-user-id <YOUR_GITHUB_USER_ID> --login <YOUR_LOGIN>
+
+Supply your OWN GitHub identity — there is no default, by design. A fork
+that seeded the upstream maintainer's id would hand that account lifetime
+admin of the fork's database.
 
 Idempotent: re-running on an existing row preserves OAuth blobs and
 created_at; it (re)writes login, role, tier, allowlisted (always True)
-and backfills the allowlisted_at/by audit pair if absent. Defaults
-match locked PRD: admin = Evan + GF; tier = lifetime.
+and backfills the allowlisted_at/by audit pair if absent.
 
 Slice 5 #26 — required to unblock the webhook allowlist gate. Without
 this, the webhook will no_op every PR until at least one admin row

--- a/k8s/api-deployment.yaml
+++ b/k8s/api-deployment.yaml
@@ -54,6 +54,11 @@ spec:
             - {name: GITHUB_APP_ID_SSM, value: /grug/github-app-id}
             - {name: GITHUB_APP_PRIVATE_KEY_SSM, value: /grug/github-app-private-key}
             - {name: GITHUB_APP_WEBHOOK_SECRET_SSM, value: /grug/github-app-webhook-secret}
+            # Dedicated key for session-cookie + CSRF-state HMAC, decoupled
+            # from the webhook secret (audit #5). github_oauth falls back to
+            # the webhook secret until this param exists, so it's safe to
+            # wire before the SecureString is created (HITL prereq).
+            - {name: GRUG_SESSION_SIGNING_SECRET_SSM, value: /grug/session-signing-secret}
             - {name: GITHUB_APP_CLIENT_ID_SSM, value: /grug/github-app-client-id}
             - {name: GITHUB_APP_CLIENT_SECRET_SSM, value: /grug/github-app-client-secret}
             - {name: GRUG_CF_SHARED_SECRET_SSM, value: /grug/cf-shared-secret}

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,6 +3,7 @@
 # seeded by the workflow from the parameter store - never committed.
 resources:
   - namespace.yaml
+  - networkpolicy.yaml
   - webhook-deployment.yaml
   - api-deployment.yaml
   - poller-cronjob.yaml

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -1,0 +1,79 @@
+# Network segmentation for the grug namespace (audit #3).
+#
+# The OKE cluster is shared (CNPG, digital-ledger, pasto, tempo, ... all
+# live alongside grug). Without a NetworkPolicy the namespace is flat /
+# default-allow: any compromised pod anywhere on the cluster can reach the
+# grug pods on any port, and a compromised grug pod has unrestricted
+# egress. These policies close the lateral-movement path and add port-level
+# egress hygiene.
+#
+# ENFORCEMENT NOTE: NetworkPolicy is only enforced by a policy-capable CNI.
+# OKE's default VCN-native / flannel CNI does NOT enforce it unless Calico
+# (or an equivalent) is installed. This manifest is harmless when
+# unenforced and protective when enforced -- confirm the cluster CNI
+# enforces NetworkPolicy for it to actually bite.
+#
+# Egress is intentionally restricted to PORTS, not CIDRs: grug talks to
+# AWS (SSM/SQS/KMS/S3, 443), GitHub + the LLM backends (443), CNPG
+# Postgres (5432), and the node-local Datadog agent (DogStatsD 8125 / APM
+# 8126), plus DNS. Pinning destination CIDRs is the follow-up hardening;
+# port-scoping already blocks exfil over non-standard channels without
+# risking an outage from a wrong CIDR.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: grug
+spec:
+  # Empty podSelector = every pod in the namespace.
+  podSelector: {}
+  policyTypes: [Ingress]
+  # No ingress rules => deny ALL inbound to every grug pod by default.
+  # The allow-rule below re-opens only what must be reachable.
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-http-ingress
+  namespace: grug
+spec:
+  # Only the two HTTP services accept inbound; consumer + poller stay
+  # fully sealed (they pull work from SQS / run on a cron, never serve).
+  podSelector:
+    matchExpressions:
+      - {key: app, operator: In, values: [grug-api, grug-webhook]}
+  policyTypes: [Ingress]
+  ingress:
+    # Port 8080 only. `from` is omitted so the Cloudflare tunnel
+    # (cloudflared) can reach it regardless of which namespace it runs in;
+    # the real request auth is the CF shared-secret + HMAC/session layers.
+    # Tightening `from` to the tunnel pod is a follow-up once its labels
+    # are pinned.
+    - ports:
+        - {protocol: TCP, port: 8080}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-scoped
+  namespace: grug
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    # DNS resolution.
+    - ports:
+        - {protocol: UDP, port: 53}
+        - {protocol: TCP, port: 53}
+    # HTTPS: AWS APIs, GitHub, LLM backends.
+    - ports:
+        - {protocol: TCP, port: 443}
+    # CNPG Postgres.
+    - ports:
+        - {protocol: TCP, port: 5432}
+    # Node-local Datadog agent: DogStatsD (UDP 8125) + APM trace intake
+    # (TCP 8126). Restricting these would silently kill observability.
+    - ports:
+        - {protocol: UDP, port: 8125}
+        - {protocol: TCP, port: 8126}

--- a/services/api/auth/github_oauth.py
+++ b/services/api/auth/github_oauth.py
@@ -79,11 +79,9 @@ def _state_secret() -> str:
             # such param is GRUG_SESSION_SIGNING_SECRET_SSM, so the message
             # already identifies it, and logging a value sourced from a
             # `*_SECRET_SSM` env var trips clear-text-secret scanners.
-            log.warning(
-                "session_signing_secret_unavailable_falling_back_to_webhook_secret"
-            )
+            log.warning("session_signing_secret_unavailable_using_fallback")
     else:
-        log.warning("session_signing_secret_unconfigured_using_webhook_secret")
+        log.warning("session_signing_secret_unconfigured_using_fallback")
     return _get_ssm_secure_string(
         os.environ.get("GITHUB_APP_WEBHOOK_SECRET_SSM", "")
     )

--- a/services/api/auth/github_oauth.py
+++ b/services/api/auth/github_oauth.py
@@ -75,9 +75,12 @@ def _state_secret() -> str:
         try:
             return _get_ssm_secure_string(dedicated)
         except Exception:
+            # NB: do NOT log `dedicated` (the SSM param name) - the only
+            # such param is GRUG_SESSION_SIGNING_SECRET_SSM, so the message
+            # already identifies it, and logging a value sourced from a
+            # `*_SECRET_SSM` env var trips clear-text-secret scanners.
             log.warning(
-                "session_signing_secret_unavailable_falling_back_to_webhook_secret",
-                extra={"param": dedicated},
+                "session_signing_secret_unavailable_falling_back_to_webhook_secret"
             )
     else:
         log.warning("session_signing_secret_unconfigured_using_webhook_secret")

--- a/services/api/auth/github_oauth.py
+++ b/services/api/auth/github_oauth.py
@@ -19,11 +19,11 @@ from __future__ import annotations
 
 import hashlib
 import hmac
-import json
 import logging
 import os
 import secrets
 import time
+from functools import lru_cache
 from urllib.parse import urlencode
 
 import httpx
@@ -48,12 +48,42 @@ _DASHBOARD_URL = f"https://{_DOMAIN}/dashboard"
 _STATE_TTL_SECONDS = 600  # 10 min
 
 
+@lru_cache(maxsize=1)
 def _state_secret() -> str:
-    """Reuse the GitHub App webhook secret for CSRF state HMAC.
-    Same secret already in SSM; same secret-rotation cadence."""
+    """HMAC key for CSRF state + session-cookie signing.
+
+    Prefers a DEDICATED secret (GRUG_SESSION_SIGNING_SECRET_SSM) so that
+    session/CSRF signing does NOT share a key with GitHub webhook
+    verification (audit #5). Sharing was a latent account-takeover lever:
+    one leaked secret -> forge a session cookie for any gh_id (incl. admin),
+    and you could not rotate the webhook secret to respond without breaking
+    inbound webhook verification + logging every user out at once.
+
+    Falls back to the webhook secret when the dedicated param isn't
+    provisioned yet, so this is a ZERO-DOWNTIME migration: create the
+    SecureString `/grug/session-signing-secret` (HITL, see
+    docs/HITL_PREREQUISITES.md), wire GRUG_SESSION_SIGNING_SECRET_SSM in
+    k8s/api-deployment.yaml, and the next deploy switches over (live
+    sessions invalidate once — users simply re-login).
+
+    lru_cache(maxsize=1): resolve once per process (pods restart on deploy
+    / rotation), so the fallback warning logs once, not per request.
+    """
     from secrets_loader import _get_ssm_secure_string  # type: ignore
-    name = os.environ.get("GITHUB_APP_WEBHOOK_SECRET_SSM", "")
-    return _get_ssm_secure_string(name)
+    dedicated = os.environ.get("GRUG_SESSION_SIGNING_SECRET_SSM", "")
+    if dedicated:
+        try:
+            return _get_ssm_secure_string(dedicated)
+        except Exception:
+            log.warning(
+                "session_signing_secret_unavailable_falling_back_to_webhook_secret",
+                extra={"param": dedicated},
+            )
+    else:
+        log.warning("session_signing_secret_unconfigured_using_webhook_secret")
+    return _get_ssm_secure_string(
+        os.environ.get("GITHUB_APP_WEBHOOK_SECRET_SSM", "")
+    )
 
 
 def _make_state() -> str:

--- a/services/api/cf_auth.py
+++ b/services/api/cf_auth.py
@@ -7,12 +7,14 @@ the same value sourced from SSM `/grug/cf-shared-secret`. Direct hits
 on the Lambda Function URL that bypass CF arrive without the header
 and get 401.
 
-Fail-open is the safe default during deploy churn — if the env var is
-unset OR the SSM lookup fails (ParameterNotFound, empty value), the
-middleware logs the misconfiguration and lets requests through. The
-Worker side mirrors this: when its `GRUG_CF_SECRET` binding is absent,
-no header is injected, so a strict-mode middleware would 401 every
-legitimate request. Pulumi-first rollout depends on this symmetry.
+Fail-CLOSED by default (audit #4): if the env var is unset OR the SSM
+lookup fails (ParameterNotFound, empty value), the middleware logs the
+misconfiguration and returns 503 rather than silently disabling the
+origin-auth boundary. During the very first Pulumi->Worker->service
+rollout the Worker's `GRUG_CF_SECRET` binding may not exist yet (no
+header injected), which a fail-closed boundary would 503; set
+`GRUG_CF_AUTH_FAIL_OPEN=1` for that bring-up window ONLY, then remove it
+once the secret is live so prod runs fail-closed.
 
 `/livez` is always exempt so DD synthetics and post-deploy smoke tests
 can reach the Lambda without a header.
@@ -89,6 +91,32 @@ def _ssm_cache_clear() -> None:
     _default_secret_loader.cache_clear()
 
 
+def _fail_open_enabled() -> bool:
+    """Fail-OPEN only when explicitly opted in for initial bring-up.
+
+    Default is fail-CLOSED (audit #4): a misconfigured / empty / unreachable
+    CF secret denies (503) rather than silently disabling the origin-auth
+    boundary. Set `GRUG_CF_AUTH_FAIL_OPEN=1` ONLY during the first
+    Pulumi->Worker->service rollout, when the Worker secret binding may not
+    exist yet; remove it once the secret is live.
+    """
+    return os.getenv("GRUG_CF_AUTH_FAIL_OPEN", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+
+
+def _fail_response() -> Response:
+    """503 returned when the boundary can't verify and fail-open is off.
+
+    503 (not 401): the cause is a server-side misconfig, not a bad client
+    credential. /livez + /readyz are exempt earlier in dispatch, so the pod
+    stays schedulable even while app traffic is denied."""
+    return JSONResponse(
+        {"detail": "auth boundary unavailable"},
+        status_code=503,
+    )
+
+
 class CfAuthMiddleware(BaseHTTPMiddleware):
     """Starlette/FastAPI middleware that enforces the auth boundary.
 
@@ -106,14 +134,17 @@ class CfAuthMiddleware(BaseHTTPMiddleware):
         """
         Args:
           secret_loader: zero-arg callable returning the SSM secret value.
-            - returns a non-empty `str` → strict mode for this request
-            - returns `""` → fail-open + `cf_shared_secret_unconfigured`
-              log with `reason="empty_ssm_value"` (throttled per reason)
+            - returns a non-empty `str` -> strict mode for this request
+            - returns `""` -> log `cf_shared_secret_unconfigured`
+              (reason="empty_ssm_value") then deny 503, UNLESS
+              `GRUG_CF_AUTH_FAIL_OPEN=1` (bring-up only), in which case
+              fail-open
             - raises any exception in `_FAIL_OPEN_ERRORS` (LookupError,
-              ClientError, BotoCoreError) → fail-open + same log with
-              `reason=<type name>` (throttled per reason)
+              ClientError, BotoCoreError) -> same log with
+              `reason=<type name>` then deny 503 (or fail-open under the
+              bring-up flag)
             Anything else (`AttributeError`, `NameError`, `TypeError`,
-            …) propagates as 500. Programmer bugs MUST NOT silently
+            ...) propagates as 500. Programmer bugs MUST NOT silently
             disable the auth boundary — see `_FAIL_OPEN_ERRORS` for the
             whitelist rationale.
         """
@@ -140,18 +171,22 @@ class CfAuthMiddleware(BaseHTTPMiddleware):
             # or background-task coroutines that would otherwise stall.
             expected = await asyncio.to_thread(self._secret_loader)
         except _FAIL_OPEN_ERRORS as e:
-            # Known misconfig classes — fail-open with throttled log.
-            # Programmer bugs (AttributeError, NameError, TypeError, etc.)
-            # are NOT in _FAIL_OPEN_ERRORS and propagate as 500 so the
-            # boundary doesn't silently disable on unexpected failures.
+            # Known misconfig classes. Programmer bugs (AttributeError,
+            # NameError, TypeError, etc.) are NOT in _FAIL_OPEN_ERRORS and
+            # propagate as 500. Default: fail CLOSED (503). Only the
+            # explicit bring-up flag lets the request through.
             _log_unconfigured_throttled(type(e).__name__, request.url.path)
-            return await call_next(request)
+            if _fail_open_enabled():
+                return await call_next(request)
+            return _fail_response()
 
         if not expected:
-            # Same fail-open behavior for empty-string. Distinguishing
-            # from "unconfigured" only matters for the log signal.
+            # Empty-string secret — same handling. Distinguishing from
+            # "unconfigured" only matters for the log signal.
             _log_unconfigured_throttled("empty_ssm_value", request.url.path)
-            return await call_next(request)
+            if _fail_open_enabled():
+                return await call_next(request)
+            return _fail_response()
 
         # Strict mode from here on.
         received = request.headers.get(SECRET_HEADER, "")

--- a/services/api/conftest.py
+++ b/services/api/conftest.py
@@ -10,4 +10,21 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
+
+
+@pytest.fixture(autouse=True)
+def _cf_auth_bringup_mode(monkeypatch):
+    """Default app-level tests to CF-auth bring-up mode (fail-open).
+
+    CfAuthMiddleware now fail-CLOSES by default (audit #4) when the CF
+    shared secret is unconfigured, so any test that drives the full app via
+    TestClient without configuring the secret would 503 at the boundary even
+    though it is not testing the boundary. This conftest autouse fixture
+    runs BEFORE module-level autouse fixtures, so the cf_auth suites - which
+    delete this flag in their own autouse fixture - still exercise the real
+    fail-closed default.
+    """
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "1")

--- a/services/api/github_checks_client.py
+++ b/services/api/github_checks_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Literal
+from urllib.parse import quote
 
 import httpx
 
@@ -68,7 +69,7 @@ def post_check_run(
         body["external_id"] = external_id
 
     resp = httpx.post(
-        f"{_GH_API}/repos/{owner}/{repo}/check-runs",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/check-runs",
         json=body,
         headers={
             "Authorization": f"Bearer {install_token}",

--- a/services/api/github_reviews_client.py
+++ b/services/api/github_reviews_client.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict, dataclass
 from typing import Literal, get_args
+from urllib.parse import quote
 
 import httpx
 
@@ -138,7 +139,7 @@ def post_review(
     # stay in lockstep with field renames; this stays correct by
     # construction.
     resp = httpx.post(
-        f"{_GH_API}/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}/reviews",
         json=asdict(result),
         headers={
             "Authorization": f"Bearer {install_token}",
@@ -175,7 +176,7 @@ def get_review_comments(
     out: list[dict] = []
     for page in range(1, _MAX_REVIEW_COMMENT_PAGES + 1):
         resp = httpx.get(
-            f"{_GH_API}/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
+            f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}/reviews/{review_id}/comments",
             params={"per_page": 100, "page": page},
             headers={
                 "Authorization": f"Bearer {install_token}",

--- a/services/api/github_rulesets_client.py
+++ b/services/api/github_rulesets_client.py
@@ -190,7 +190,7 @@ def create_ruleset(
         ],
     }
     resp = httpx.post(
-        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/rulesets",
         json=body,
         headers=_auth_headers(install_token),
         timeout=10,
@@ -220,7 +220,7 @@ def delete_ruleset(
 ) -> None:
     """Delete a ruleset by ID."""
     resp = httpx.delete(
-        f"{_GH_API}/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/rulesets/{ruleset_id}",
         headers=_auth_headers(install_token),
         timeout=10,
     )
@@ -235,7 +235,7 @@ def list_rulesets(
     """List all rulesets for a repository. Resilient to GitHub's secondary
     rate limit (the dashboard fan-out burst) via bounded jittered retries."""
     resp = _get_with_retry(
-        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/rulesets",
         install_token=install_token,
         op="list_rulesets",
     )

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -61,8 +61,12 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[f"https://{_SPA_DOMAIN}", f"https://www.{_SPA_DOMAIN}"],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    # Enumerate the methods/headers the SPA actually uses rather than "*".
+    # The origin allowlist above is the real gate, but with credentials
+    # enabled there's no reason to reflect a wildcard surface into the
+    # preflight response. (Audit #9.)
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type"],
 )
 
 

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -91,7 +91,7 @@ def _fetch_pr_diff(
     """GET the PR unified diff. `Accept: application/vnd.github.diff`
     returns the raw diff body rather than the JSON metadata."""
     resp = httpx.get(
-        f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}",
+        f"https://api.github.com/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}",
         headers={
             "Authorization": f"Bearer {install_token}",
             "Accept": "application/vnd.github.diff",
@@ -163,7 +163,7 @@ def _fetch_pr_review_comments(
     out: list[dict] = []
     for page in range(1, _MAX_COMMENT_PAGES + 1):
         resp = httpx.get(
-            f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}/comments",
+            f"https://api.github.com/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}/comments",
             params={"per_page": 100, "page": page},
             headers={
                 "Authorization": f"Bearer {install_token}",

--- a/services/api/tests/test_cf_auth.py
+++ b/services/api/tests/test_cf_auth.py
@@ -6,9 +6,10 @@ validates the `X-Grug-CF-Secret` header on every non-`/livez` request.
 
 Behaviors covered:
 - /livez always passes (DD synthetics + smoke tests need un-authenticated access)
-- Env var unset: fail-open (operator hasn't deployed Pulumi yet)
-- SSM returns empty: fail-open (impossible-by-accident config; logged + permissive)
-- SSM throws ParameterNotFound: fail-open (Worker/middleware deploy race)
+- Env var unset: fail-CLOSED 503 by default (audit #4); fail-open only
+  when GRUG_CF_AUTH_FAIL_OPEN is set (initial bring-up)
+- SSM returns empty: fail-CLOSED 503 (fail-open under the bring-up flag)
+- SSM throws ParameterNotFound: fail-CLOSED 503 (fail-open under the flag)
 - Strict mode + missing header: 401
 - Strict mode + mismatched header: 401
 - Strict mode + matching header (constant-time compare): pass-through
@@ -26,12 +27,17 @@ from cf_auth import CfAuthMiddleware
 
 
 @pytest.fixture(autouse=True)
-def _reset_throttle_state():
+def _reset_throttle_state(monkeypatch):
     """`_last_unconfigured_log_at` is module-scope and would persist
     across tests, masking the throttled-log signal. Clear before each
     test so the WARN-on-first-event semantics are honored.
+
+    Also force fail-CLOSED by default (delete the bring-up escape-hatch
+    flag) so a stray GRUG_CF_AUTH_FAIL_OPEN in the dev shell can't mask
+    the default-deny contract; the fail-open tests opt back in explicitly.
     """
     cf_auth._last_unconfigured_log_at.clear()
+    monkeypatch.delenv("GRUG_CF_AUTH_FAIL_OPEN", raising=False)
 
 
 def _build_app(*, secret_loader=None):
@@ -108,9 +114,23 @@ def test_strict_matching_header_passes_through() -> None:
     assert r.json() == {"status": "reached"}
 
 
-def test_unconfigured_env_var_fail_open() -> None:
-    """Operator hasn't deployed Pulumi yet — env var absent, middleware
-    must NOT block requests."""
+def test_unconfigured_env_var_fail_closed() -> None:
+    """Default (audit #4): env var absent -> deny 503 rather than silently
+    disable the origin-auth boundary."""
+    def raise_unconfigured():
+        raise LookupError("GRUG_CF_SHARED_SECRET_SSM env var unset")
+
+    app = _build_app(secret_loader=raise_unconfigured)
+    client = TestClient(app)
+    r = client.get("/protected", headers={"X-Grug-CF-Secret": "anything"})
+    assert r.status_code == 503
+
+
+def test_unconfigured_env_var_fail_open_when_flag_set(monkeypatch) -> None:
+    """Bring-up escape hatch: GRUG_CF_AUTH_FAIL_OPEN=1 restores fail-open
+    so the first Pulumi->Worker->service rollout isn't 503'd."""
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "1")
+
     def raise_unconfigured():
         raise LookupError("GRUG_CF_SHARED_SECRET_SSM env var unset")
 
@@ -120,19 +140,25 @@ def test_unconfigured_env_var_fail_open() -> None:
     assert r.status_code == 200
 
 
-def test_empty_ssm_value_fail_open() -> None:
-    """SSM returned an empty string — impossible-by-accident, but if it
-    happens the rollout property still holds (fail-open + log error)."""
+def test_empty_ssm_value_fail_closed() -> None:
+    """SSM returned an empty string — deny 503 by default (audit #4)."""
+    app = _build_app(secret_loader=lambda: "")
+    client = TestClient(app)
+    r = client.get("/protected")
+    assert r.status_code == 503
+
+
+def test_empty_ssm_value_fail_open_when_flag_set(monkeypatch) -> None:
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "true")
     app = _build_app(secret_loader=lambda: "")
     client = TestClient(app)
     r = client.get("/protected")
     assert r.status_code == 200
 
 
-def test_ssm_not_found_fail_open() -> None:
-    """Lambda env var points at a SSM param that doesn't exist (Pulumi
-    drift or rollout race). Fail-open — Workers' header injection still
-    works in the meantime. Uses botocore ClientError to mimic the real
+def test_ssm_not_found_fail_closed() -> None:
+    """SSM param doesn't exist (Pulumi drift / rollout race). Default
+    deny 503 (audit #4). Uses botocore ClientError to mimic the real
     boto3 ParameterNotFound shape."""
     from botocore.exceptions import ClientError
 
@@ -145,7 +171,7 @@ def test_ssm_not_found_fail_open() -> None:
     app = _build_app(secret_loader=raise_not_found)
     client = TestClient(app)
     r = client.get("/protected")
-    assert r.status_code == 200
+    assert r.status_code == 503
 
 
 def test_programmer_bug_propagates_as_500() -> None:
@@ -287,12 +313,12 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     client = TestClient(app)
 
     with patch.object(cf_auth.log, "warning") as mock_warn:
-        # First request: should log.
+        # First request: should log. (Default fail-CLOSED -> 503.)
         r1 = client.get("/protected")
-        assert r1.status_code == 200
-        # Second request immediately after: throttle suppresses.
+        assert r1.status_code == 503
+        # Second request immediately after: throttle suppresses the log.
         r2 = client.get("/protected")
-        assert r2.status_code == 200
+        assert r2.status_code == 503
 
     assert mock_warn.call_count == 1, (
         f"throttle did not suppress duplicate log: {mock_warn.call_count} calls"
@@ -323,8 +349,9 @@ def test_throttle_distinguishes_reasons() -> None:
     with patch.object(cf_auth.log, "warning") as mock_warn:
         r1 = client.get("/protected")
         r2 = client.get("/protected")
-        assert r1.status_code == 200
-        assert r2.status_code == 200
+        # Default fail-CLOSED -> 503 for both reasons.
+        assert r1.status_code == 503
+        assert r2.status_code == 503
 
-    # Two distinct reasons → two distinct first-logs.
+    # Two distinct reasons -> two distinct first-logs.
     assert mock_warn.call_count == 2

--- a/services/api/tests/test_oauth_routes.py
+++ b/services/api/tests/test_oauth_routes.py
@@ -18,6 +18,11 @@ def _oauth_mod(monkeypatch):
     monkeypatch.setenv("GITHUB_APP_CLIENT_ID_SSM", "/grug/test-client-id")
     monkeypatch.setenv("GITHUB_APP_CLIENT_SECRET_SSM", "/grug/test-client-secret")
     monkeypatch.setenv("GRUG_DOMAIN", "grug.lol")
+    # CfAuthMiddleware now fail-CLOSES by default (audit #4). These tests
+    # exercise the OAuth router, not the CF boundary, so run them in
+    # bring-up mode (boundary effectively disabled) — the CF boundary has
+    # its own suite in test_cf_auth.py.
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "1")
     import auth.github_oauth as mod
     # State CSRF + session cookie signing both use `_state_secret` —
     # no separate `_session_secret` function exists. The session HMAC

--- a/services/webhook/cf_auth.py
+++ b/services/webhook/cf_auth.py
@@ -7,12 +7,14 @@ the same value sourced from SSM `/grug/cf-shared-secret`. Direct hits
 on the Lambda Function URL that bypass CF arrive without the header
 and get 401.
 
-Fail-open is the safe default during deploy churn — if the env var is
-unset OR the SSM lookup fails (ParameterNotFound, empty value), the
-middleware logs the misconfiguration and lets requests through. The
-Worker side mirrors this: when its `GRUG_CF_SECRET` binding is absent,
-no header is injected, so a strict-mode middleware would 401 every
-legitimate request. Pulumi-first rollout depends on this symmetry.
+Fail-CLOSED by default (audit #4): if the env var is unset OR the SSM
+lookup fails (ParameterNotFound, empty value), the middleware logs the
+misconfiguration and returns 503 rather than silently disabling the
+origin-auth boundary. During the very first Pulumi->Worker->service
+rollout the Worker's `GRUG_CF_SECRET` binding may not exist yet (no
+header injected), which a fail-closed boundary would 503; set
+`GRUG_CF_AUTH_FAIL_OPEN=1` for that bring-up window ONLY, then remove it
+once the secret is live so prod runs fail-closed.
 
 `/livez` is always exempt so DD synthetics and post-deploy smoke tests
 can reach the Lambda without a header.
@@ -89,6 +91,32 @@ def _ssm_cache_clear() -> None:
     _default_secret_loader.cache_clear()
 
 
+def _fail_open_enabled() -> bool:
+    """Fail-OPEN only when explicitly opted in for initial bring-up.
+
+    Default is fail-CLOSED (audit #4): a misconfigured / empty / unreachable
+    CF secret denies (503) rather than silently disabling the origin-auth
+    boundary. Set `GRUG_CF_AUTH_FAIL_OPEN=1` ONLY during the first
+    Pulumi->Worker->service rollout, when the Worker secret binding may not
+    exist yet; remove it once the secret is live.
+    """
+    return os.getenv("GRUG_CF_AUTH_FAIL_OPEN", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+
+
+def _fail_response() -> Response:
+    """503 returned when the boundary can't verify and fail-open is off.
+
+    503 (not 401): the cause is a server-side misconfig, not a bad client
+    credential. /livez + /readyz are exempt earlier in dispatch, so the pod
+    stays schedulable even while app traffic is denied."""
+    return JSONResponse(
+        {"detail": "auth boundary unavailable"},
+        status_code=503,
+    )
+
+
 class CfAuthMiddleware(BaseHTTPMiddleware):
     """Starlette/FastAPI middleware that enforces the auth boundary.
 
@@ -106,14 +134,17 @@ class CfAuthMiddleware(BaseHTTPMiddleware):
         """
         Args:
           secret_loader: zero-arg callable returning the SSM secret value.
-            - returns a non-empty `str` → strict mode for this request
-            - returns `""` → fail-open + `cf_shared_secret_unconfigured`
-              log with `reason="empty_ssm_value"` (throttled per reason)
+            - returns a non-empty `str` -> strict mode for this request
+            - returns `""` -> log `cf_shared_secret_unconfigured`
+              (reason="empty_ssm_value") then deny 503, UNLESS
+              `GRUG_CF_AUTH_FAIL_OPEN=1` (bring-up only), in which case
+              fail-open
             - raises any exception in `_FAIL_OPEN_ERRORS` (LookupError,
-              ClientError, BotoCoreError) → fail-open + same log with
-              `reason=<type name>` (throttled per reason)
+              ClientError, BotoCoreError) -> same log with
+              `reason=<type name>` then deny 503 (or fail-open under the
+              bring-up flag)
             Anything else (`AttributeError`, `NameError`, `TypeError`,
-            …) propagates as 500. Programmer bugs MUST NOT silently
+            ...) propagates as 500. Programmer bugs MUST NOT silently
             disable the auth boundary — see `_FAIL_OPEN_ERRORS` for the
             whitelist rationale.
         """
@@ -140,18 +171,22 @@ class CfAuthMiddleware(BaseHTTPMiddleware):
             # or background-task coroutines that would otherwise stall.
             expected = await asyncio.to_thread(self._secret_loader)
         except _FAIL_OPEN_ERRORS as e:
-            # Known misconfig classes — fail-open with throttled log.
-            # Programmer bugs (AttributeError, NameError, TypeError, etc.)
-            # are NOT in _FAIL_OPEN_ERRORS and propagate as 500 so the
-            # boundary doesn't silently disable on unexpected failures.
+            # Known misconfig classes. Programmer bugs (AttributeError,
+            # NameError, TypeError, etc.) are NOT in _FAIL_OPEN_ERRORS and
+            # propagate as 500. Default: fail CLOSED (503). Only the
+            # explicit bring-up flag lets the request through.
             _log_unconfigured_throttled(type(e).__name__, request.url.path)
-            return await call_next(request)
+            if _fail_open_enabled():
+                return await call_next(request)
+            return _fail_response()
 
         if not expected:
-            # Same fail-open behavior for empty-string. Distinguishing
-            # from "unconfigured" only matters for the log signal.
+            # Empty-string secret — same handling. Distinguishing from
+            # "unconfigured" only matters for the log signal.
             _log_unconfigured_throttled("empty_ssm_value", request.url.path)
-            return await call_next(request)
+            if _fail_open_enabled():
+                return await call_next(request)
+            return _fail_response()
 
         # Strict mode from here on.
         received = request.headers.get(SECRET_HEADER, "")

--- a/services/webhook/conftest.py
+++ b/services/webhook/conftest.py
@@ -10,4 +10,21 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
+
+
+@pytest.fixture(autouse=True)
+def _cf_auth_bringup_mode(monkeypatch):
+    """Default app-level tests to CF-auth bring-up mode (fail-open).
+
+    CfAuthMiddleware now fail-CLOSES by default (audit #4) when the CF
+    shared secret is unconfigured, so any test that drives the full app via
+    TestClient without configuring the secret would 503 at the boundary even
+    though it is not testing the boundary. This conftest autouse fixture
+    runs BEFORE module-level autouse fixtures, so the cf_auth suites - which
+    delete this flag in their own autouse fixture - still exercise the real
+    fail-closed default.
+    """
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "1")

--- a/services/webhook/github_checks_client.py
+++ b/services/webhook/github_checks_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Literal
+from urllib.parse import quote
 
 import httpx
 
@@ -68,7 +69,7 @@ def post_check_run(
         body["external_id"] = external_id
 
     resp = httpx.post(
-        f"{_GH_API}/repos/{owner}/{repo}/check-runs",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/check-runs",
         json=body,
         headers={
             "Authorization": f"Bearer {install_token}",

--- a/services/webhook/github_reviews_client.py
+++ b/services/webhook/github_reviews_client.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict, dataclass
 from typing import Literal, get_args
+from urllib.parse import quote
 
 import httpx
 
@@ -138,7 +139,7 @@ def post_review(
     # stay in lockstep with field renames; this stays correct by
     # construction.
     resp = httpx.post(
-        f"{_GH_API}/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}/reviews",
         json=asdict(result),
         headers={
             "Authorization": f"Bearer {install_token}",
@@ -175,7 +176,7 @@ def get_review_comments(
     out: list[dict] = []
     for page in range(1, _MAX_REVIEW_COMMENT_PAGES + 1):
         resp = httpx.get(
-            f"{_GH_API}/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments",
+            f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}/reviews/{review_id}/comments",
             params={"per_page": 100, "page": page},
             headers={
                 "Authorization": f"Bearer {install_token}",

--- a/services/webhook/github_rulesets_client.py
+++ b/services/webhook/github_rulesets_client.py
@@ -190,7 +190,7 @@ def create_ruleset(
         ],
     }
     resp = httpx.post(
-        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/rulesets",
         json=body,
         headers=_auth_headers(install_token),
         timeout=10,
@@ -220,7 +220,7 @@ def delete_ruleset(
 ) -> None:
     """Delete a ruleset by ID."""
     resp = httpx.delete(
-        f"{_GH_API}/repos/{owner}/{repo}/rulesets/{ruleset_id}",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/rulesets/{ruleset_id}",
         headers=_auth_headers(install_token),
         timeout=10,
     )
@@ -235,7 +235,7 @@ def list_rulesets(
     """List all rulesets for a repository. Resilient to GitHub's secondary
     rate limit (the dashboard fan-out burst) via bounded jittered retries."""
     resp = _get_with_retry(
-        f"{_GH_API}/repos/{owner}/{repo}/rulesets",
+        f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/rulesets",
         install_token=install_token,
         op="list_rulesets",
     )

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -91,7 +91,7 @@ def _fetch_pr_diff(
     """GET the PR unified diff. `Accept: application/vnd.github.diff`
     returns the raw diff body rather than the JSON metadata."""
     resp = httpx.get(
-        f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}",
+        f"https://api.github.com/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}",
         headers={
             "Authorization": f"Bearer {install_token}",
             "Accept": "application/vnd.github.diff",
@@ -163,7 +163,7 @@ def _fetch_pr_review_comments(
     out: list[dict] = []
     for page in range(1, _MAX_COMMENT_PAGES + 1):
         resp = httpx.get(
-            f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}/comments",
+            f"https://api.github.com/repos/{quote(owner, safe='')}/{quote(repo, safe='')}/pulls/{pull_number}/comments",
             params={"per_page": 100, "page": page},
             headers={
                 "Authorization": f"Bearer {install_token}",

--- a/services/webhook/rerun.py
+++ b/services/webhook/rerun.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -84,7 +85,7 @@ def _run_one(body: str) -> str:
     pr = with_install_token_retry(
         install_id,
         lambda tok: _gh_get(
-            tok, f"{_GH_API}/repos/{owner}/{repo_name}/pulls/{pr_number}"
+            tok, f"{_GH_API}/repos/{quote(owner, safe='')}/{quote(repo_name, safe='')}/pulls/{pr_number}"
         ),
     )
     repo_id = int(pr["base"]["repo"]["id"])

--- a/services/webhook/tests/test_cf_auth.py
+++ b/services/webhook/tests/test_cf_auth.py
@@ -6,9 +6,10 @@ validates the `X-Grug-CF-Secret` header on every non-`/livez` request.
 
 Behaviors covered:
 - /livez always passes (DD synthetics + smoke tests need un-authenticated access)
-- Env var unset: fail-open (operator hasn't deployed Pulumi yet)
-- SSM returns empty: fail-open (impossible-by-accident config; logged + permissive)
-- SSM throws ParameterNotFound: fail-open (Worker/middleware deploy race)
+- Env var unset: fail-CLOSED 503 by default (audit #4); fail-open only
+  when GRUG_CF_AUTH_FAIL_OPEN is set (initial bring-up)
+- SSM returns empty: fail-CLOSED 503 (fail-open under the bring-up flag)
+- SSM throws ParameterNotFound: fail-CLOSED 503 (fail-open under the flag)
 - Strict mode + missing header: 401
 - Strict mode + mismatched header: 401
 - Strict mode + matching header (constant-time compare): pass-through
@@ -26,12 +27,17 @@ from cf_auth import CfAuthMiddleware
 
 
 @pytest.fixture(autouse=True)
-def _reset_throttle_state():
+def _reset_throttle_state(monkeypatch):
     """`_last_unconfigured_log_at` is module-scope and would persist
     across tests, masking the throttled-log signal. Clear before each
     test so the WARN-on-first-event semantics are honored.
+
+    Also force fail-CLOSED by default (delete the bring-up escape-hatch
+    flag) so a stray GRUG_CF_AUTH_FAIL_OPEN in the dev shell can't mask
+    the default-deny contract; the fail-open tests opt back in explicitly.
     """
     cf_auth._last_unconfigured_log_at.clear()
+    monkeypatch.delenv("GRUG_CF_AUTH_FAIL_OPEN", raising=False)
 
 
 def _build_app(*, secret_loader=None):
@@ -108,9 +114,23 @@ def test_strict_matching_header_passes_through() -> None:
     assert r.json() == {"status": "reached"}
 
 
-def test_unconfigured_env_var_fail_open() -> None:
-    """Operator hasn't deployed Pulumi yet — env var absent, middleware
-    must NOT block requests."""
+def test_unconfigured_env_var_fail_closed() -> None:
+    """Default (audit #4): env var absent -> deny 503 rather than silently
+    disable the origin-auth boundary."""
+    def raise_unconfigured():
+        raise LookupError("GRUG_CF_SHARED_SECRET_SSM env var unset")
+
+    app = _build_app(secret_loader=raise_unconfigured)
+    client = TestClient(app)
+    r = client.get("/protected", headers={"X-Grug-CF-Secret": "anything"})
+    assert r.status_code == 503
+
+
+def test_unconfigured_env_var_fail_open_when_flag_set(monkeypatch) -> None:
+    """Bring-up escape hatch: GRUG_CF_AUTH_FAIL_OPEN=1 restores fail-open
+    so the first Pulumi->Worker->service rollout isn't 503'd."""
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "1")
+
     def raise_unconfigured():
         raise LookupError("GRUG_CF_SHARED_SECRET_SSM env var unset")
 
@@ -120,19 +140,25 @@ def test_unconfigured_env_var_fail_open() -> None:
     assert r.status_code == 200
 
 
-def test_empty_ssm_value_fail_open() -> None:
-    """SSM returned an empty string — impossible-by-accident, but if it
-    happens the rollout property still holds (fail-open + log error)."""
+def test_empty_ssm_value_fail_closed() -> None:
+    """SSM returned an empty string — deny 503 by default (audit #4)."""
+    app = _build_app(secret_loader=lambda: "")
+    client = TestClient(app)
+    r = client.get("/protected")
+    assert r.status_code == 503
+
+
+def test_empty_ssm_value_fail_open_when_flag_set(monkeypatch) -> None:
+    monkeypatch.setenv("GRUG_CF_AUTH_FAIL_OPEN", "true")
     app = _build_app(secret_loader=lambda: "")
     client = TestClient(app)
     r = client.get("/protected")
     assert r.status_code == 200
 
 
-def test_ssm_not_found_fail_open() -> None:
-    """Lambda env var points at a SSM param that doesn't exist (Pulumi
-    drift or rollout race). Fail-open — Workers' header injection still
-    works in the meantime. Uses botocore ClientError to mimic the real
+def test_ssm_not_found_fail_closed() -> None:
+    """SSM param doesn't exist (Pulumi drift / rollout race). Default
+    deny 503 (audit #4). Uses botocore ClientError to mimic the real
     boto3 ParameterNotFound shape."""
     from botocore.exceptions import ClientError
 
@@ -145,7 +171,7 @@ def test_ssm_not_found_fail_open() -> None:
     app = _build_app(secret_loader=raise_not_found)
     client = TestClient(app)
     r = client.get("/protected")
-    assert r.status_code == 200
+    assert r.status_code == 503
 
 
 def test_programmer_bug_propagates_as_500() -> None:
@@ -288,12 +314,12 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     client = TestClient(app)
 
     with patch.object(cf_auth.log, "warning") as mock_warn:
-        # First request: should log.
+        # First request: should log. (Default fail-CLOSED -> 503.)
         r1 = client.get("/protected")
-        assert r1.status_code == 200
-        # Second request immediately after: throttle suppresses.
+        assert r1.status_code == 503
+        # Second request immediately after: throttle suppresses the log.
         r2 = client.get("/protected")
-        assert r2.status_code == 200
+        assert r2.status_code == 503
 
     assert mock_warn.call_count == 1, (
         f"throttle did not suppress duplicate log: {mock_warn.call_count} calls"
@@ -325,8 +351,9 @@ def test_throttle_distinguishes_reasons() -> None:
     with patch.object(cf_auth.log, "warning") as mock_warn:
         r1 = client.get("/protected")
         r2 = client.get("/protected")
-        assert r1.status_code == 200
-        assert r2.status_code == 200
+        # Default fail-CLOSED -> 503 for both reasons.
+        assert r1.status_code == 503
+        assert r2.status_code == 503
 
-    # Two distinct reasons → two distinct first-logs.
+    # Two distinct reasons -> two distinct first-logs.
     assert mock_warn.call_count == 2


### PR DESCRIPTION
## Summary

Red/blue-team security audit hardening for grug, applied as one cohesive
batch now that the project is being forked and runs on self-hosted OKE
nodes. Covers fork-safety, IAM least-privilege, network segmentation,
auth-boundary fail-closed behavior, secret decoupling, supply-chain image
pinning, URL-encoding consistency, and info-leak scrubs. Finding #6 (static
key -> short-lived creds) is out of scope here and tracked via PRD #385 and
slices #386-#389. Every change is validated (unit tests, mirror check, ruff,
Pulumi preview, and an AWS policy-simulator pass for the IAM scope-down).

## Changes by audit finding

- #1 Fork-safety: empty admin-seed defaults + a guard so a fork can't seed the upstream maintainer as its admin; literal id scrubbed from docs.
- #2 OIDC deploy-role trust tightened from `main,feat/*,fix/*,hotfix/*` to `main` only.
- #2b Deploy-role IAM scoped from `iam:*` on `*` to least-privilege verbs on `grug-*` principals; dead `lambda:*`/`ecr:*`/`logs:*`/`cloudwatch:*`/`events:*` grants removed. Validated 15/15 via `aws iam simulate-custom-policy` (grants what Pulumi needs, denies escalation).
- #3 NetworkPolicy: default-deny ingress + HTTP-only allow + port-scoped egress for the `grug` namespace.
- #4 CF->origin auth middleware fail-CLOSED by default (was fail-open), with a `GRUG_CF_AUTH_FAIL_OPEN` bring-up escape hatch; mirrored to api+webhook.
- #5 Session/CSRF HMAC decoupled from the GitHub webhook secret via a dedicated `/grug/session-signing-secret` (zero-downtime fallback).
- #7 Deploy by immutable `@sha256` image digest instead of the mutable tag.
- #8 Uniform `quote()` of owner/repo across every GitHub client (api+webhook).
- #9 Scrub AWS account id + private-infra name from docs/monitor; narrow CORS methods/headers.

## Test plan

- [ ] CI green: build (api+webhook), temper verify, Datadog PR gates.
- [ ] api/webhook auth + cf_auth + oauth + github-client suites pass (223 targeted tests pass locally; cf_auth tests updated to the new fail-closed contract).
- [ ] Mirror check passes (29 pairs in lockstep) and ruff is clean on changed files.
- [ ] `pulumi preview` renders clean (only the intended deploy-role + monitor diffs); #2b policy simulator-validated.
- [ ] Post-merge: GHA `pulumi up` applies #2/#2b to prod and the k8s apply lands the NetworkPolicy; verify the deploy is healthy.

## Size

Size: L

## Out of scope

- Finding #6 (static pod key -> short-lived creds): PRD #385 + slices #386-#389.
- The `grug-cave-connector` principal's credential posture.
- Local `pulumi up` (deferred to GHA: the local env has an older Datadog provider that would churn unrelated resources).

closes #390
