### PR TITLE
fix(grug): restore DD_VERSION substitution broken by digest pinning (#7)

### DIFF
--- a/.github/workflows/deploy.k8s.yml
+++ b/.github/workflows/deploy.k8s.yml
@@ -165,14 +165,16 @@ jobs:
           REGISTRY_HOST: ${{ vars.DEPLOY_REGISTRY_HOST }}
         run: |
           set -euo pipefail
-          # Substitute each service's full image ref with the digest-pinned
-          # form captured at push time (audit #7). REGISTRY_PLACEHOLDER only
-          # ever appears inside image lines, so replacing the whole
-          # registry/name:tag token is sufficient — there's no longer a
-          # separate mutable tag substitution.
+          # Pin images by digest (audit #7): replace each FULL
+          # registry/name:tag image token with the @sha256 digest captured at
+          # push time. Order matters - do the image tokens FIRST, then the
+          # bare `TAG_PLACEHOLDER` substitution below only hits the remaining
+          # standalone uses (the DD_VERSION env value: TAG_PLACEHOLDER), which
+          # must still resolve to the git SHA for version tagging.
           sed -i \
             -e "s|REGISTRY_PLACEHOLDER/grug-api:TAG_PLACEHOLDER|${IMAGE_API}|g" \
             -e "s|REGISTRY_PLACEHOLDER/grug-webhook:TAG_PLACEHOLDER|${IMAGE_WEBHOOK}|g" \
+            -e "s|TAG_PLACEHOLDER|${GITHUB_SHA}|g" \
             k8s/*.yaml
           # Post-sed sentinel: a future manifest that escapes substitution
           # must fail the deploy, not ship a literal placeholder (F7).


### PR DESCRIPTION
## Summary

Hotfix for the k8s deploy broken by the #7 digest-pinning change (audit
batch PR #391). The new image substitution replaced only the full
`REGISTRY_PLACEHOLDER/grug-*:TAG_PLACEHOLDER` image token and removed the
bare `TAG_PLACEHOLDER`->SHA substitution, so the `DD_VERSION` env (`value:
TAG_PLACEHOLDER`) was left unsubstituted and the post-sed sentinel correctly
failed the deploy before `kubectl apply` (cluster was left unchanged). This
restores the bare substitution AFTER the image-digest subs.

## Test plan

- [ ] Dry-run of the three-stage sed over all k8s manifests leaves zero `REGISTRY_PLACEHOLDER`/`TAG_PLACEHOLDER` (sentinel passes) - verified locally.
- [ ] Images resolve to `@sha256` digests; `DD_VERSION` resolves to the git SHA (not a digest).
- [ ] deploy.k8s run goes green through `kubectl apply -k`, the rollout, and the poller smoke job.
- [ ] NetworkPolicy (#3) + session-secret env (#5) land on the cluster as part of this apply.

## Size

Size: XS

## Out of scope

- Any change to the digest-pinning behavior itself (#7) - this only restores the DD_VERSION substitution it dropped.
