### PR TITLE
fix(grug): deploy role must read /infra/* SSM params (regression from #2b)

### DIFF
--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -151,13 +151,25 @@ def create(
                         ],
                     },
                     {
-                        # SSM reads: the stack's own `/grug/*` params + the
-                        # cross-repo Pulumi token at `/shared/*`.
+                        # SSM reads. The stack's own `/grug/*`, the cross-repo
+                        # Pulumi token at `/shared/*`, AND the shared `/infra/*`
+                        # params the PROGRAM reads at invoke time: the Datadog
+                        # provider creds (/infra/datadog/api_key + app_key), the
+                        # LLM keys (/infra/llm/*), and the Discord alert handle
+                        # (/infra/discord/*). Missing /infra here 403s every
+                        # `pulumi up` at program-eval before any apply - the
+                        # first deploy that RUNS under the scoped role dies (the
+                        # initial scope-down deploy passed only because it ran
+                        # under the old broad policy and applied the narrow one
+                        # last). Tested via simulate-custom-policy incl. these.
                         "Effect": "Allow",
                         "Action": ["ssm:GetParameter*"],
                         "Resource": [
                             "arn:aws:ssm:*:*:parameter/grug/*",
                             "arn:aws:ssm:*:*:parameter/shared/*",
+                            "arn:aws:ssm:*:*:parameter/infra/datadog/*",
+                            "arn:aws:ssm:*:*:parameter/infra/llm/*",
+                            "arn:aws:ssm:*:*:parameter/infra/discord/*",
                         ],
                     },
                     {


### PR DESCRIPTION
## Summary

Fix a regression introduced by the #2b deploy-role IAM scope-down (in audit
batch #391): the scoped `ssm:GetParameter*` was limited to `/grug/*` +
`/shared/*`, but the Pulumi program also reads `/infra/datadog/api_key` +
`/infra/datadog/app_key` (Datadog provider creds), `/infra/llm/*`, and
`/infra/discord/*` at program-eval time. The FIRST `pulumi up` to run under
the scoped role 403s before any apply (the scope-down deploy itself only
passed because it ran under the old broad policy and applied the narrow one
at the end). This blocks all deploys; adds the three `/infra` prefixes back.

## Test plan

- [ ] `simulate-custom-policy` on the rendered policy: `/infra/{datadog,llm,discord}/*` + `/grug/*` + `/shared/*` GetParameter allowed; other `/infra/*` and unrelated paths denied (verified 8/8).
- [ ] `iac.deploy` (pulumi up) goes green again and creates the #386 rotator resources (already merged to main) - no `/infra/datadog` AccessDenied.
- [ ] The hand-applied `grug-gha-deploy-infra-read-hotfix` live policy is removed after this converges (all-Pulumi restored).

## Size

Size: XS

## Out of scope

- Any other #2b scoping (IAM/SQS/DDB/S3/KMS verified live-correct already).
