### PR TITLE
fix(grug): deploy role needs s3:ListAllMyBuckets (regression from #2b)

### DIFF
--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -263,6 +263,20 @@ def create(
                             "arn:aws:s3:::grug-*/*",
                         ],
                     },
+                    {
+                        # The deploy.k8s secret-seed discovers the cave-diff
+                        # bucket's (random-suffixed) name via `aws s3api
+                        # list-buckets`. ListAllMyBuckets is ACCOUNT-level and
+                        # only accepts Resource "*" - the grug-* bucket scope
+                        # above can't grant it, so the seed silently got an
+                        # empty GRUG_CAVE_DIFF_BUCKET under the scoped role
+                        # (caught by the seed's empty-value guard). List bucket
+                        # NAMES only; no data access. (Cleaner future: export
+                        # the bucket name to SSM and drop this.)
+                        "Effect": "Allow",
+                        "Action": "s3:ListAllMyBuckets",
+                        "Resource": "*",
+                    },
                 ],
             },
         )


### PR DESCRIPTION
## Summary

deploy.k8s discovers the cave-diff bucket name via aws s3api list-buckets; ListAllMyBuckets is account-level (Resource * only) and #2b scoped S3 to grug-* ARNs, so the seed got an empty GRUG_CAVE_DIFF_BUCKET under the scoped role (now caught by the new empty-value guard). Adds the account-level list (bucket names only, no data access).

## Test plan

- [ ] iac.deploy applies the grant; deploy.k8s seeds GRUG_CAVE_DIFF_BUCKET non-empty.
- [ ] simulate confirms s3:ListAllMyBuckets allowed, data ops still grug-* scoped.
- [ ] hand-applied grug-gha-deploy-s3list-hotfix removed after convergence.

## Size

Size: XS

## Out of scope

- Replacing list-buckets with an SSM-exported bucket name (cleaner future).