### PR TITLE
fix(grug): fix_enforcement catches httpx.RequestError -> 503 (#331)

### DIFF
--- a/services/api/installations.py
+++ b/services/api/installations.py
@@ -39,7 +39,7 @@ from adapters.install_store import (
 )
 from adapters.user_store import UserIdentity
 from auth.dependencies import require_authenticated
-from github_app_auth import get_install_token, with_install_token_retry
+from github_app_auth import with_install_token_retry
 from review_types import verdict as derive_verdict
 
 log = logging.getLogger("grug.api.installations")
@@ -538,6 +538,24 @@ def fix_enforcement(
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=f"GitHub rejected the ruleset ({gh_status}): {detail}",
+        ) from e
+    except httpx.RequestError as e:
+        # Transport-level failure (DNS, connect/read timeout, connection
+        # reset) reaching GitHub, even after with_install_token_retry's
+        # bounded retries. Unlike HTTPStatusError this carries NO response -
+        # GitHub is unreachable, not rejecting - so the old code let it
+        # propagate as an opaque 500 (#331). Return 503 (retryable) with a
+        # structured log so the dashboard "Fix" button shows an actionable
+        # "try again" and DD can alert. Mirrors get_enforcement's
+        # (HTTPStatusError, RequestError) handling on this same resource.
+        log.warning(
+            "fix_enforcement_transport_error",
+            extra={"install_id": install_id, "repo_id": repo_id,
+                   "kind": type(e).__name__, "err": str(e)},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="GitHub unreachable while applying enforcement; please retry.",
         ) from e
 
 

--- a/services/api/tests/test_installations_routes.py
+++ b/services/api/tests/test_installations_routes.py
@@ -164,3 +164,40 @@ def test_get_enforcement_404_propagates_not_swallowed(_mod, monkeypatch):
     with pytest.raises(HTTPException) as exc:
         inst.get_enforcement(1, 2, user=_user(role="admin"))
     assert exc.value.status_code == 404
+
+
+# --- fix_enforcement transport-error handling (#331) ------------------------
+
+def _throw(err):
+    """Return a with_install_token_retry stub that raises `err`."""
+    def _stub(install_id, fn):
+        raise err
+    return _stub
+
+
+def test_fix_enforcement_transport_error_returns_503(monkeypatch):
+    """#331: a transport-level failure (httpx.RequestError) reaching GitHub
+    must return 503 (retryable upstream-unreachable), not an opaque 500."""
+    import httpx
+    import installations as inst
+    monkeypatch.setattr(inst, "get_installation", lambda iid: {"installed_by_user_id": "100"})
+    req = httpx.Request("POST", "https://api.github.com/repos/o/r/rulesets")
+    err = httpx.ConnectTimeout("dns/connect boom", request=req)
+    monkeypatch.setattr(inst, "with_install_token_retry", _throw(err))
+    with pytest.raises(HTTPException) as exc:
+        inst.fix_enforcement(1, 2, user=_user("100"))
+    assert exc.value.status_code == 503
+
+
+def test_fix_enforcement_github_4xx_still_returns_502(monkeypatch):
+    """Regression: a GitHub rejection (HTTPStatusError) keeps its 502 path
+    (the contributor's fix must not change existing 4xx behavior)."""
+    import httpx
+    import installations as inst
+    monkeypatch.setattr(inst, "get_installation", lambda iid: {"installed_by_user_id": "100"})
+    req = httpx.Request("POST", "https://api.github.com/repos/o/r/rulesets")
+    err = httpx.HTTPStatusError("422", request=req, response=httpx.Response(422, request=req, text="dup name"))
+    monkeypatch.setattr(inst, "with_install_token_retry", _throw(err))
+    with pytest.raises(HTTPException) as exc:
+        inst.fix_enforcement(1, 2, user=_user("100"))
+    assert exc.value.status_code == 502


### PR DESCRIPTION
## Summary

`fix_enforcement` (the dashboard "Fix" button, `POST .../enforcement`) only
caught `httpx.HTTPStatusError`, so a transport-level failure (DNS / connect /
read timeout, connection reset) reaching the GitHub API inside
`with_install_token_retry` propagated as an opaque HTTP 500 with no log
context. This adds an `httpx.RequestError` branch that returns 503 (retryable)
with a structured `fix_enforcement_transport_error` log, mirroring the
`(HTTPStatusError, RequestError)` handling the sibling `get_enforcement`
already has on the same resource. The existing GitHub-4xx -> 502 path is
unchanged.

## Test plan

- [ ] `test_fix_enforcement_transport_error_returns_503` - a `RequestError` (ConnectTimeout) now yields 503, not an unhandled 500 (red before the fix, green after).
- [ ] `test_fix_enforcement_github_4xx_still_returns_502` - regression guard: GitHub `HTTPStatusError` keeps its 502 path.
- [ ] `ruff` clean; full `test_installations_routes.py` suite passes (pg-dependent cases run via testcontainers in CI).

## Size

Size: XS

## Out of scope

- Adding retry logic to `fix_enforcement` (separate improvement, per the issue).
- Changing the GitHub Rulesets client.
- The mirrored-twin extraction (#77) - `installations.py` is api-only, not mirrored.

closes #331
