### PR TITLE
feat(elder): subprocess-no-timeout rule (runaway-process class)

### DIFF
--- a/services/api/code_review_prompt.py
+++ b/services/api/code_review_prompt.py
@@ -329,6 +329,23 @@ RULES: tuple[ReviewRule, ...] = (
         good_example="items = []  # loop until a short page / no cursor",
         severity="high",
     ),
+    # ── weekly harvest: runaway-process class (claude-stuff #356, #368) ──
+    ReviewRule(
+        name="subprocess-no-timeout",
+        bug_class="robustness",
+        description="A subprocess / child-process call that invokes an EXTERNAL "
+        "or potentially-blocking command (a network CLI, another model/agent, "
+        "ssh, a build/test runner) with NO timeout — `subprocess.run`/`call`/"
+        "`check_output`, `Popen(...).communicate()`, or a shell-spawned "
+        "`node`/`curl` without `timeout`/`--max-time`. A wedged provider then "
+        "hangs the whole chain forever with no diagnostic (the runaway-process "
+        "class). Distinct from missing-timeout, which is HTTP-client libs. A "
+        "fast local command (`git rev-parse`) does NOT need one — flag only "
+        "commands that can plausibly stall (network, another agent, remote).",
+        bad_example="subprocess.run(cmd, capture_output=True)  # external reviewer CLI; can hang",
+        good_example="subprocess.run(cmd, capture_output=True, timeout=600)",
+        severity="medium",
+    ),
 )
 
 

--- a/services/api/tests/test_code_review_prompt.py
+++ b/services/api/tests/test_code_review_prompt.py
@@ -163,3 +163,11 @@ def test_covers_core_audit_bug_classes():
         "mock",        # mock-vs-real exception divergence
     ):
         assert needle in blob.lower(), f"missing audit bug class: {needle}"
+
+
+def test_subprocess_no_timeout_rule_present():
+    """Weekly harvest: an external/blocking subprocess (or shell node/curl)
+    call without a timeout is the runaway-process class — one wedged
+    provider hangs the whole chain (claude-stuff #356, #368)."""
+    assert any(r.name == "subprocess-no-timeout" for r in crp.RULES)
+    assert "subprocess-no-timeout" in crp.build_system_prompt()

--- a/services/webhook/code_review_prompt.py
+++ b/services/webhook/code_review_prompt.py
@@ -329,6 +329,23 @@ RULES: tuple[ReviewRule, ...] = (
         good_example="items = []  # loop until a short page / no cursor",
         severity="high",
     ),
+    # ── weekly harvest: runaway-process class (claude-stuff #356, #368) ──
+    ReviewRule(
+        name="subprocess-no-timeout",
+        bug_class="robustness",
+        description="A subprocess / child-process call that invokes an EXTERNAL "
+        "or potentially-blocking command (a network CLI, another model/agent, "
+        "ssh, a build/test runner) with NO timeout — `subprocess.run`/`call`/"
+        "`check_output`, `Popen(...).communicate()`, or a shell-spawned "
+        "`node`/`curl` without `timeout`/`--max-time`. A wedged provider then "
+        "hangs the whole chain forever with no diagnostic (the runaway-process "
+        "class). Distinct from missing-timeout, which is HTTP-client libs. A "
+        "fast local command (`git rev-parse`) does NOT need one — flag only "
+        "commands that can plausibly stall (network, another agent, remote).",
+        bad_example="subprocess.run(cmd, capture_output=True)  # external reviewer CLI; can hang",
+        good_example="subprocess.run(cmd, capture_output=True, timeout=600)",
+        severity="medium",
+    ),
 )
 
 

--- a/services/webhook/tests/test_code_review_prompt.py
+++ b/services/webhook/tests/test_code_review_prompt.py
@@ -195,6 +195,14 @@ def test_new_high_value_rules_present(monkeypatch):
     assert "performance" in crp._BUG_CLASSES  # query-in-loop's class
 
 
+def test_subprocess_no_timeout_rule_present():
+    """Weekly harvest: an external/blocking subprocess (or shell node/curl)
+    call without a timeout is the runaway-process class — one wedged
+    provider hangs the whole chain (claude-stuff #356, #368)."""
+    assert any(r.name == "subprocess-no-timeout" for r in crp.RULES)
+    assert "subprocess-no-timeout" in crp.build_system_prompt()
+
+
 def test_voice_has_mandatory_bookend_structure():
     """#343: the voice instruction mandates the structural bookends that
     keep the caveman cadence from slipping to plain English under technical


### PR DESCRIPTION
## Why

Weekly fix-PR harvest across the fleet. Two merged fix PRs in the last 7 days each bounded an **external child-process call that had no timeout** — the runaway-process class, where one wedged provider hangs the whole chain forever with no diagnostic:

- **claude-stuff#356** — `peer_review_llmobs.py` exec-mode `subprocess.run(cmd, ...)` ran an arbitrary reviewer CLI (read from argv) with **no `timeout=`**; a stalled provider blocked the whole peer-review/audit chain. Fix added `PEER_REVIEW_EXEC_TIMEOUT` (default 600s) + `TimeoutExpired` → rc 124.
- **claude-stuff#368** — `run-chain.sh` invoked `node codex-companion.mjs … --wait` with no outer timeout (the only unguarded reviewer of four; the other three already use `curl --max-time`). Fix wrapped it with `timeout`.

grug's existing `missing-timeout` rule only covers HTTP-client libs (`requests`/`httpx`/`urllib`/`socket`), so this child-process shape slips through every PR. This rule closes that gap and the Elder then enforces it fleet-wide automatically.

## Summary

- Adds one `ReviewRule` (`subprocess-no-timeout`, bug_class `robustness`, default severity `medium`) to `RULES`.
- **Scoped to external / potentially-blocking commands** (network CLI, another model/agent, ssh, build/test runner) so a fast local command (`git rev-parse`) is explicitly *not* flagged — keeps the precision bias and avoids firing on every subprocess fleet-wide.
- Mirrored byte-identical into both `services/webhook/` and `services/api/` per ADR-0001; presence test added on each side.

## Acceptance criteria

- [x] `subprocess-no-timeout` present in `RULES` and rendered into `build_system_prompt()`
- [x] Identical edit mirrored to `services/api/code_review_prompt.py` and `services/webhook/code_review_prompt.py`
- [x] `bash scripts/check-mirrored-files.sh` green (30 pairs verified)
- [x] A test on each side asserts the rule is in `RULES` and in the built prompt
- [x] `bug_class` is an existing `_BUG_CLASSES` member (`robustness`) — no taxonomy change

## Test plan

- `bash scripts/check-mirrored-files.sh` → `OK: 30 mirrored file pairs verified`
- Import-check both services: module imports clean (`__post_init__` validation runs at import), `len(RULES) == 24`, rule renders, `build_system_prompt()` deterministic
- New `test_subprocess_no_timeout_rule_present` on each side (full CI runs pytest)

Size: XS

## Out of scope

- The `missing-timeout` HTTP-client rule (unchanged — distinct class).
- Any /audit catalog patterns from this week's harvest (separate claude-stuff PR).
