### PR TITLE
fix(grug): Elder parser handles a list-shaped LLM response (#416)

### DIFF
--- a/services/api/llm_client.py
+++ b/services/api/llm_client.py
@@ -543,7 +543,17 @@ def _parse_response(
         parsed = json.loads(content)
     except json.JSONDecodeError:
         return (), model_name, "llm returned non-json — parse failed"
-    raw_findings = parsed.get("findings", [])
+    # Models sometimes return a bare JSON array of findings instead of the
+    # documented {"findings": [...]} object (#416 — Poolside did this and the
+    # old `parsed.get(...)` crashed with `'list' object has no attribute 'get'`,
+    # dropping a live review). Accept both shapes; anything else is a graceful
+    # parse failure, never an unhandled crash.
+    if isinstance(parsed, list):
+        raw_findings = parsed
+    elif isinstance(parsed, dict):
+        raw_findings = parsed.get("findings", [])
+    else:
+        return (), model_name, "llm content is neither object nor array"
     if not isinstance(raw_findings, list):
         return (), model_name, "findings field is not a list"
     coerced: list[Finding] = []

--- a/services/api/tests/test_llm_client.py
+++ b/services/api/tests/test_llm_client.py
@@ -459,3 +459,27 @@ def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
     # other backend would likely return the same edge HTML).
     assert out.kind == "parse_failed"
     assert "envelope" in out.error.lower() or "json" in out.error.lower()
+
+
+def test_parse_response_handles_list_shaped_content() -> None:
+    """#416: a model returning a bare JSON ARRAY of findings (not the
+    documented {"findings": [...]} object) must be parsed as the findings
+    list, NOT crash with `'list' object has no attribute 'get'` (which dropped
+    a live Elder review, delivery 831476f0)."""
+    content = '[{"rule": "x", "path": "p", "line": 1, "severity": "low"}]'
+    findings, _model, err = lc._parse_response(
+        httpx.Response(200, json=_openai_json_response(content))
+    )
+    assert err == ""
+    assert len(findings) == 1
+
+
+def test_parse_response_scalar_content_is_graceful_not_crash() -> None:
+    """#416: content that is valid JSON but neither dict nor list (a bare
+    string/number) returns a graceful parse-failure error, never an unhandled
+    exception."""
+    findings, _model, err = lc._parse_response(
+        httpx.Response(200, json=_openai_json_response('"just a string"'))
+    )
+    assert findings == ()
+    assert err  # non-empty error string, no exception raised

--- a/services/webhook/llm_client.py
+++ b/services/webhook/llm_client.py
@@ -543,7 +543,17 @@ def _parse_response(
         parsed = json.loads(content)
     except json.JSONDecodeError:
         return (), model_name, "llm returned non-json — parse failed"
-    raw_findings = parsed.get("findings", [])
+    # Models sometimes return a bare JSON array of findings instead of the
+    # documented {"findings": [...]} object (#416 — Poolside did this and the
+    # old `parsed.get(...)` crashed with `'list' object has no attribute 'get'`,
+    # dropping a live review). Accept both shapes; anything else is a graceful
+    # parse failure, never an unhandled crash.
+    if isinstance(parsed, list):
+        raw_findings = parsed
+    elif isinstance(parsed, dict):
+        raw_findings = parsed.get("findings", [])
+    else:
+        return (), model_name, "llm content is neither object nor array"
     if not isinstance(raw_findings, list):
         return (), model_name, "findings field is not a list"
     coerced: list[Finding] = []

--- a/services/webhook/tests/test_llm_client.py
+++ b/services/webhook/tests/test_llm_client.py
@@ -522,6 +522,30 @@ def test_envelope_non_json_returns_parse_failed(monkeypatch) -> None:
     assert "envelope" in out.error.lower() or "json" in out.error.lower()
 
 
+def test_parse_response_handles_list_shaped_content() -> None:
+    """#416: a model returning a bare JSON ARRAY of findings (not the
+    documented {"findings": [...]} object) must be parsed as the findings
+    list, NOT crash with `'list' object has no attribute 'get'` (which dropped
+    a live Elder review, delivery 831476f0)."""
+    content = '[{"rule": "x", "path": "p", "line": 1, "severity": "low"}]'
+    findings, _model, err = lc._parse_response(
+        httpx.Response(200, json=_openai_json_response(content))
+    )
+    assert err == ""
+    assert len(findings) == 1
+
+
+def test_parse_response_scalar_content_is_graceful_not_crash() -> None:
+    """#416: content that is valid JSON but neither dict nor list (a bare
+    string/number) returns a graceful parse-failure error, never an unhandled
+    exception."""
+    findings, _model, err = lc._parse_response(
+        httpx.Response(200, json=_openai_json_response('"just a string"'))
+    )
+    assert findings == ()
+    assert err  # non-empty error string, no exception raised
+
+
 # ---------------------------------------------------------------------------
 # DD LLM Obs tracing — every successful LLM call emits a trace span with
 # prompt/response/latency/tokens; failures emit a span with error metadata.


### PR DESCRIPTION
## Summary

Live prod bug: Poolside returned a 200 with a bare JSON **array** body, and the Elder response parser did `parsed.get("findings", [])` assuming a dict, crashing with `'list' object has no attribute 'get'` -> `elder_job_unhandled` -> the Elder review for PR #415 was dropped -> P2 paged (delivery 831476f0). The parser already degrades gracefully for every other bad shape; it just missed "content is a valid JSON list". This accepts both a list and a dict, and returns a graceful parse-failure for anything else - never an unhandled crash that drops the review.

## Test plan

- [ ] `test_parse_response_handles_list_shaped_content` - a bare JSON array of findings is parsed as the findings list (no crash), on both api + webhook
- [ ] `test_parse_response_scalar_content_is_graceful_not_crash` - content that is neither dict nor list returns a graceful error string, no exception
- [ ] Both llm_client suites green (webhook 73, api 26); mirror check green (llm_client.py byte-identical)

Size: XS

## Out of scope

- Why Poolside returns a list-shaped body (the thinking-mode response trap) - this hardens the consumer side regardless of provider quirks.
- The consumer's `logging.basicConfig` (vs structured `configure_logging`) gap - separate observability follow-up; the Elder path (webhook) already logs structured + exc_info, which is how this root cause was found.

closes #416
