### PR TITLE
docs(grug): de-Lambda SELF_HOST / HITL_PREREQUISITES / CUTOVER

### DIFF
--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -4,12 +4,18 @@ Migrating each consumer repo off `_reusable.grug-pr-gate.yml` to the
 hosted Grug App. Tracks slices #32 (canary on infrastructure) and
 #33 (bulk on remaining 9).
 
+> **Note:** this playbook moves *consumer repos* onto the hosted App — it
+> is unrelated to the App's own runtime. The App now runs on Kubernetes
+> (Postgres store, SQS, Cloudflare tunnel; see [`RUNBOOK.md`](RUNBOOK.md)
+> + [`NETWORK-TOPOLOGY.md`](NETWORK-TOPOLOGY.md)). The `curl /livez`
+> checks below hit the k8s pods, not the retired Lambdas.
+
 ## Pre-flight (one-time)
 
 Verify on grug.lol dashboard:
 - `https://grug.lol/admin` shows your admin USER# row
-- Webhook lambda alive: `curl -sI https://webhook.grug.lol/livez | head -1` returns `HTTP/2 200`
-- API lambda alive: `curl -sI https://api.grug.lol/livez | head -1` returns `HTTP/2 200`
+- Webhook alive: `curl -sI https://webhook.grug.lol/livez | head -1` returns `HTTP/2 200`
+- API alive: `curl -sI https://api.grug.lol/livez | head -1` returns `HTTP/2 200`
 
 If any fail, see [`RUNBOOK.md`](RUNBOOK.md) "First-time deploy" / "Common
 failure modes" before continuing.
@@ -22,7 +28,8 @@ UI: https://github.com/apps/grug-boss/installations/new → pick the
 target repo → install.
 
 Webhook fires `installation` event → grug-webhook records the install
-in DDB. Verify on `/admin` that the new INST# row appears (refresh).
+in Postgres (`grug_kv`). Verify on `/admin` that the new INST# row
+appears (refresh).
 
 ### 2. Test the App posts a check-run
 

--- a/docs/HITL_PREREQUISITES.md
+++ b/docs/HITL_PREREQUISITES.md
@@ -77,14 +77,16 @@ aws ssm put-parameter --region us-east-1 \
 # projects use them too), skip these — grug's Pulumi just reads them.
 #
 # OpenRouter API key — for Elder persona LLM calls (PRD #181). Mint at
-# https://openrouter.ai/settings/keys. Webhook Lambda only.
+# https://openrouter.ai/settings/keys. Read by the Elder-running workloads
+# (webhook + consumer + poller), loaded from SSM at startup.
 aws ssm put-parameter --region us-east-1 \
   --name /infra/llm/openrouter_api_key \
   --type SecureString \
   --value "sk-or-v1-..."
 
 # Poolside API key — second backend for Elder persona round-robin
-# (installation_id % 2). Mint at https://poolside.ai/. Webhook Lambda only.
+# (installation_id % 2). Mint at https://poolside.ai/. Read by the
+# Elder-running workloads (webhook + consumer + poller).
 aws ssm put-parameter --region us-east-1 \
   --name /infra/llm/poolside_api_key \
   --type SecureString \
@@ -142,39 +144,37 @@ to create the Pages project + apex domain binding (idempotent — safe
 to re-run if you forget). After that, the `web.deploy.yml` workflow
 handles every subsequent build/deploy via `wrangler pages deploy`.
 
-## 6. Datadog notify handle (Slice 9 #30)
+## 6. Datadog alert routing (Slice 9 #30)
 
-DD monitors fire on Lambda 5xx, sig-verify failures, etc. Notification
-target lives in SSM `/grug/dd-notify-handle`.
-
-Format: any string DD knows how to route — Discord webhook handle
-(`@webhook-grug`), email mention (`@evan@grug.lol`), PagerDuty
-integration name (`@pagerduty-grug-prod`), or `@slack-channel-grug`.
-
-```bash
-aws ssm put-parameter --region us-east-1 \
-  --name /grug/dd-notify-handle --type String \
-  --value "<handle>"
-```
-
-**Important — handle is baked into monitor messages at `pulumi up`
-time.** If you change the SSM value later, you MUST re-run `pulumi up`
-for the new handle to take effect on existing monitors. The Pulumi
-diff will show every monitor's `message` field changing. (For more
-flexible routing without re-deploys, set the SSM handle to a stable
-DD notification target — e.g. `@webhook-grug-router` — and change
-the routing inside DD's notification settings.)
-
-DD also needs the App key (in addition to the API key) for monitor
-creation:
+DD monitors fire on workload-not-ready, CrashLoopBackOff, sig-verify
+failures, etc. (Kubernetes-State-Metrics-based since #406). Routing is
+NOT a free-form handle anymore: the Pulumi program builds a Datadog
+Webhook integration (`grug-discord-monitoring`) from a Discord webhook
+URL in SSM, and every monitor references `@webhook-grug-discord-monitoring`.
+Pre-load the Discord webhook URL (the old `/grug/dd-notify-handle`
+placeholder is retired — it pointed at an undeliverable `@grug-stub`):
 
 ```bash
 aws ssm put-parameter --region us-east-1 \
-  --name /shared/datadog-app-key --type SecureString --value "<app key>"
+  --name /infra/discord/monitoring-alerts --type SecureString \
+  --value "https://discord.com/api/webhooks/<id>/<token>"
 ```
 
-(API key already loaded for the Lambda extension; App key is
-admin-scoped and only needed by the deploy role.)
+(To route somewhere other than Discord, swap the `Webhook`/notify-handle
+wiring in `infra/pulumi/__main__.py` for your target.)
+
+DD also needs an App key (in addition to the API key) for monitor
+creation. Both are the shared-infra keys (`/shared/datadog-*` were
+revoked):
+
+```bash
+aws ssm put-parameter --region us-east-1 \
+  --name /infra/datadog/app_key --type SecureString --value "<app key>"
+```
+
+(The API key `/infra/datadog/api_key` ships traces/logs via the
+cluster's node-local Datadog agent; the App key is admin-scoped and
+only needed by the deploy role for monitor/dashboard/RUM management.)
 
 ## When done
 
@@ -182,6 +182,6 @@ Tell me "HITL done" and I'll run `pulumi up` to provision the dev stack.
 
 ## Recovery / rotation
 
-- **App private key compromised:** generate a new one in GH UI, `aws ssm put-parameter --overwrite ...`, redeploy Lambda (env var read at cold start)
-- **Webhook secret compromised:** generate new `openssl rand -hex 32`, update both GH App + SSM (`--overwrite`), Lambda picks up on next cold start
-- **OAuth client secret compromised:** rotate in GH App UI, update SSM, redeploy
+- **App private key compromised:** generate a new one in GH UI, `aws ssm put-parameter --overwrite ...`, then `kubectl -n grug rollout restart deploy/grug-api deploy/grug-webhook deploy/grug-consumer` (pods read the SSM value at startup)
+- **Webhook secret compromised:** generate new `openssl rand -hex 32`, update both GH App + SSM (`--overwrite`), then rollout-restart the pods to pick it up
+- **OAuth client secret compromised:** rotate in GH App UI, update SSM, rollout-restart the pods

--- a/docs/SELF_HOST.md
+++ b/docs/SELF_HOST.md
@@ -44,9 +44,10 @@ aws ssm put-parameter --name /grug/cloudflare-api-token --value "<your_cf_token>
 aws ssm put-parameter --name /grug/cloudflare-zone-id --value "<your_zone_id>" --type String
 aws ssm put-parameter --name /grug/cloudflare-account-id --value "<your_account_id>" --type String
 
-# Datadog (optional — skip if you removed dd_monitors)
-aws ssm put-parameter --name /shared/datadog-api-key --value "<dd_api_key>" --type SecureString
-aws ssm put-parameter --name /shared/datadog-app-key --value "<dd_app_key>" --type SecureString
+# Datadog (optional — skip if you removed dd_monitors). The Pulumi program
+# reads these shared-infra paths (NOT the retired /shared/datadog-* paths).
+aws ssm put-parameter --name /infra/datadog/api_key --value "<dd_api_key>" --type SecureString
+aws ssm put-parameter --name /infra/datadog/app_key --value "<dd_app_key>" --type SecureString
 
 # Pulumi access token
 aws ssm put-parameter --name /shared/pulumi-access-token --value "<pulumi_token>" --type SecureString
@@ -65,41 +66,58 @@ pulumi config set env dev
 pulumi config set domain <your-domain>   # e.g. grug.example.com
 ```
 
-### 4. Bootstrap the Lambda image
+### 4. Provision the Postgres store
 
-Lambda Image-mode rejects `public.ecr.aws/*` URIs, so we need a private
-ECR copy of the AWS Python base image:
+Grug stores everything in a single Postgres table `grug_kv` (the #354
+store swap retired DynamoDB). Create a database on any Postgres you run
+(the hosted instance uses CloudNativePG on Kubernetes), create the
+`grug_kv` table, and put the connection string in SSM:
 
 ```bash
-# Provision ECR first (this fails Lambda creation but creates the repo)
-pulumi up --stack dev --target 'urn:pulumi:dev::grug::aws:ecr/repository:Repository::grug-webhook'
-pulumi up --stack dev --target 'urn:pulumi:dev::grug::aws:ecr/repository:Repository::grug-api'
-
-# Then bootstrap the base image into both repos
-make bootstrap-images   # uses crane to copy public python:3.13-arm64 into your private ECR
+aws ssm put-parameter --name /grug/database-url \
+  --value "postgresql://user:pass@host:5432/grug" --type SecureString
 ```
 
-### 5. First full deploy
+Schema (`pk`, `sk`, `data jsonb`, `gsi1pk`, `gsi1sk`, `ttl`) and the lazy
+pool live in `services/{api,webhook}/adapters/pg_base.py`.
+
+### 5. Deploy the AWS infra (Pulumi)
 
 ```bash
 pulumi up --stack dev --yes
 ```
 
-Roughly 5-7 min cold deploy. Should create:
-- 2 Lambda Functions (grug-webhook, grug-api) on Function URLs
-- DynamoDB single-table `grug-main`
-- KMS CMK `alias/grug-tokens`
-- IAM OIDC role for GitHub Actions
-- Cloudflare DNS records pointing webhook/api subdomains at the
-  Function URL hosts (proxied through CF Workers for host-rewrite)
+Creates the AWS-side infra (no Lambda, no ECR — those retired at #354):
+- KMS CMK `alias/grug-tokens` (OAuth-token envelope encryption)
+- 3 SQS FIFO queues (`grug-rerun-jobs`, `grug-cave-jobs`, `grug-cave-results`) + DLQs
+- S3 cave-diff bucket (`grug-cave-diffs*`)
+- IAM OIDC role for GitHub Actions + the `grug-k8s-pod` and rotator IAM users
+- DD monitors + dashboard + RUM app
+- the legacy `grug-main` DynamoDB table (unused — kept in state pending a separate removal)
 
-### 6. Configure your GitHub App webhook URL
+### 6. Deploy the app to Kubernetes
+
+The services run as pods, not Lambdas. The reference deploy is
+`.github/workflows/deploy.k8s.yml`: it builds the arm64 images, pushes
+them to your registry, seeds the in-cluster Secrets from SSM/SQS/S3, and
+`kubectl apply -k k8s/`. You need:
+- a Kubernetes cluster (arm64 nodes) + an image registry
+- a Cloudflare tunnel routing `api`/`webhook.<your-domain>` to the
+  in-cluster Services on `:8080`, with the `*-host-rewrite` Workers
+  deployed via `infra/cloudflare/deploy.sh` (sets `X-Grug-CF-Secret` +
+  the `/grug/{api,webhook}-upstream-host` upstream)
+
+See [`docs/RUNBOOK.md`](RUNBOOK.md) and
+[`docs/NETWORK-TOPOLOGY.md`](NETWORK-TOPOLOGY.md) for the full deploy and
+topology details.
+
+### 7. Configure your GitHub App webhook URL
 
 Go back to your App settings on GitHub:
 - Webhook URL = `https://webhook.<your-domain>/webhook/github`
 - Webhook secret = the value you put into SSM above
 
-### 7. Bootstrap admin USER# row in DDB
+### 8. Bootstrap the admin USER# row in Postgres
 
 ```bash
 GRUG_ADMIN_USER_ID=<your_gh_user_id> \
@@ -110,33 +128,35 @@ make seed-admin
 
 ## Day-2 ops
 
-- **Tear-down + rebuild round-trip:** `make rebuild` (see RUNBOOK.md
-  "Tear-down + rebuild" section). Should reproduce in ~15 min from a
-  clean slate. This is the load-bearing acceptance criterion that
-  `pulumi destroy && pulumi up` reproduces from code alone — covered
-  by Slice 10 #31.
+- **Tear-down + rebuild round-trip:** `pulumi destroy && pulumi up`
+  reproduces the AWS infra from code alone; the app redeploys by
+  re-running `deploy.k8s.yml` (rebuilds the images + re-applies `k8s/`).
+  See RUNBOOK.md "Tear-down + rebuild". The Postgres `grug_kv` data is
+  the only state that must be backed up/restored separately.
 - **Allowlist new users:** sign in to your hosted dashboard
   (`https://<your-domain>/dashboard`) as admin, navigate to /admin,
   toggle the user.
 - **Per-repo persona toggles:** install on the target repo via the
   GitHub App's install URL, then toggle in the dashboard.
-- **Monitors + alerts:** Datadog dashboard wires automatically (5
-  monitors per stack via `infra/pulumi/components/dd_monitors.py`).
-  Notifications go to whatever handle you put in
-  `/grug/dd-notify-handle` SSM parameter.
+- **Monitors + alerts:** the Datadog monitors + dashboard wire
+  automatically via `infra/pulumi/components/dd_monitors.py`
+  (Kubernetes-State-Metrics-based since #406). Notifications route to a
+  Datadog Webhook the Pulumi program builds from SSM
+  `/infra/discord/monitoring-alerts` (the old `/grug/dd-notify-handle`
+  placeholder is retired).
 
 ## Differences from the hosted SaaS
 
 The hosted instance at grug.lol carries:
-- Pre-allowlisted admin (Evan + collaborators)
-- Pre-configured DD monitor handle (#grug Discord channel)
-- DD APM extension layer baked into Lambda images at the published tag
+- Pre-allowlisted admin (the operator + collaborators)
+- Pre-configured DD alert routing (a Discord webhook)
+- A node-local Datadog agent on the cluster for APM/logs (DD_AGENT_HOST
+  per pod); the app images are instrumented with `ddtrace`
 
 For self-hosters:
 - You set your own admin via the seed-admin make target
-- You control your own DD notify handle (or remove DD entirely)
-- DD extension version is configurable via Pulumi
-  (`pulumi config set dd_extension_version 65`)
+- You control your own DD alert routing (or remove DD entirely)
+- You run your own cluster's Datadog agent (or drop `DD_*` from the manifests)
 
 ## Compliance with AGPL-3.0
 


### PR DESCRIPTION
## Summary

Fourth PR in the per-doc accuracy sweep (after RUNBOOK #420, NETWORK-TOPOLOGY #421, top-level docs #422). The self-host, prerequisites, and cutover docs still walked operators through the retired Lambda/ECR/DynamoDB/Function-URL setup and stale SSM paths. SELF_HOST now provisions Postgres + uses the two deploy planes (pulumi up for AWS infra, deploy.k8s.yml for the pods), with an accurate pulumi-up resource list and DD keys at `/infra/datadog/*`. HITL section 6 is rewritten: alert routing is a DD Webhook built from `/infra/discord/monitoring-alerts` (the `/grug/dd-notify-handle` placeholder is retired), the DD app key lives at `/infra/datadog/app_key` (the `/shared/datadog-*` keys were revoked), and secret rotation is a pod rollout-restart, not a Lambda redeploy. CUTOVER gets a note that the App runs on k8s now (its `/livez` checks hit pods) and records installs in Postgres. Every SSM path and resource was verified against the live Pulumi program + manifests, not assumed.

## Test plan

- [ ] SELF_HOST steps describe provision-Postgres + pulumi-up (AWS infra) + deploy.k8s.yml (pods); no ECR/crane/Lambda-image bootstrap; resource list matches `infra/pulumi/__main__.py`
- [ ] DD key paths = `/infra/datadog/{api_key,app_key}`; alert routing via `/infra/discord/monitoring-alerts` DD Webhook; no `/grug/dd-notify-handle` or `/shared/datadog-*` as current
- [ ] Rotation steps = `kubectl rollout restart`, not "redeploy Lambda"
- [ ] CUTOVER `/livez` checks + install-record noun corrected (pods + Postgres)
- [ ] Leak sweep clean across all three files

Size: M

## Out of scope

- Fixing the Makefile `bootstrap-images` / `rebuild` / `seed-admin` targets themselves (code) - separate code-cleanup PR; this PR stops referencing the dead `bootstrap-images` target
- Scrubbing the pre-existing private consumer-repo names listed in CUTOVER.md (separate public-repo-hygiene decision)
- Removing the legacy `grug-main` DynamoDB table

closes none (doc-sync; part of the documentation-accuracy sweep)