### PR TITLE
chore(grug): scrub private-infra identifiers from the public repo

### DIFF
--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -100,19 +100,17 @@ fully reversible until step 4 lands on default branch.
 Use a private repo you own first. Smallest blast radius, you control it, can iterate.
 Steps 1-5 above. Confirm everything green for ~24h before bulk-cutover.
 
-## Slice 12 — bulk-cutover remaining 9 repos
+## Slice 12 — bulk-cutover the remaining repos
 
-Order (smallest → largest, or by criticality):
+Order them smallest -> largest (or by criticality): start with low-traffic
+repos to build confidence, leave the largest / most-active production
+service for last. A rough sequence:
 
-1. `aws-solutions-architect-study` (low-traffic study repo)
-2. `gemini-plugin-cc` (small)
-3. `meow-now`
-4. `holdfast`
-5. `vroom-vroom`
-6. `claude-stuff`
-7. `conducted`
-8. `grugthink` (production-traffic AWS service)
-9. `somatic-scripts` (largest, most active)
+1. low-traffic / study repos (smallest blast radius)
+2. small utility repos
+3. mid-size active repos
+4. the production-traffic service(s)
+5. the largest, most-active repo last
 
 For each: re-run steps 1-5. Total wall-clock ~45 min if you batch,
 plus a few PRs per repo to merge.

--- a/docs/HITL_PREREQUISITES.md
+++ b/docs/HITL_PREREQUISITES.md
@@ -39,7 +39,7 @@ Copy the output. You'll paste this into both:
 
 ## 3. Pre-load SSM SecureString parameters
 
-Run from your laptop with AWS CLI authenticated to the same account as somatic-scripts (`<your-aws-account-id>`, region `us-east-1`):
+Run from your laptop with AWS CLI authenticated to your grug AWS account (`<your-aws-account-id>`, region `us-east-1`):
 
 ```bash
 # App ID — from step 1
@@ -111,7 +111,7 @@ aws iam list-open-id-connect-providers --region us-east-1
 # Should include: arn:aws:iam::<your-aws-account-id>:oidc-provider/token.actions.githubusercontent.com
 ```
 
-If missing (somatic-scripts deploys should have created it), Pulumi will create it.
+If missing (a prior deploy in the account may have created it), Pulumi will create it.
 
 ## 5. Cloudflare API token for Pulumi
 

--- a/docs/adr/0001-mirror-with-rule-of-three-deferral.md
+++ b/docs/adr/0001-mirror-with-rule-of-three-deferral.md
@@ -89,4 +89,4 @@ Until then: mirror with discipline.
 - `services/api/ports/token_cache.py` — comparable one-adapter Protocol; collapse decision (issue #141)
 - PRD #21 — v1.5+ roadmap (code-reviewer + release-manager + stuck-PR-pulse personas)
 - Sandi Metz, *Practical Object-Oriented Design* — "wrong abstraction" cost argument
-- somatic-scripts `services/pasto-api/` ↔ `services/tempo-api/` — sibling project applying the same mirror-with-discipline pattern at larger scale
+- A sibling private project applies the same mirror-with-discipline pattern at larger scale (two mirrored service packages kept in lockstep)

--- a/infra/cloudflare/deploy.sh
+++ b/infra/cloudflare/deploy.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Deploy the grug-webhook-host-rewrite CF Worker + bind to webhook.grug.lol/*.
 #
-# Mirrors the macchina-router / chef-lambda-host-rewrite /
-# tempo-lambda-host-rewrite pattern from somatic-scripts. Pulumi can't
-# manage CF Workers reliably (script-exists, main_module, route binding
-# all fail in different ways across pulumi-cloudflare versions).
+# Mirrors a host-rewrite Worker pattern the operator uses across other
+# services. Pulumi can't manage CF Workers reliably (script-exists,
+# main_module, route binding all fail in different ways across
+# pulumi-cloudflare versions).
 #
 # Idempotent: PUT replaces the script content; route POST is one-shot
 # (existing routes return 409 which we swallow).

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -37,7 +37,8 @@ from components import (
 # NOTE: CF Worker (grug-webhook-host-rewrite) is managed OUT OF BAND
 # via infra/cloudflare/deploy.sh because pulumi-cloudflare's
 # WorkerScript resource fails idempotency and main_module handling
-# (mirrors the macchina-router decision in somatic-scripts).
+# (mirrors the same out-of-band host-rewrite Worker decision the operator
+# made for other services).
 
 config = pulumi.Config()
 env = config.require("env")

--- a/infra/pulumi/components/oidc_role.py
+++ b/infra/pulumi/components/oidc_role.py
@@ -30,8 +30,8 @@ def _ensure_oidc_provider() -> str:
 
     The token.actions.githubusercontent.com provider is account-wide
     (only one allowed per AWS account). ARN is deterministic from the
-    account ID — no SDK lookup needed. somatic-scripts pulumi created
-    this resource already; we only reference it here.
+    account ID — no SDK lookup needed. A prior Pulumi stack in this
+    account created this resource already; we only reference it here.
 
     If the provider doesn't exist (fresh account), the assume-role
     policy will be created but the trust will reject all OIDC calls

--- a/k8s/networkpolicy.yaml
+++ b/k8s/networkpolicy.yaml
@@ -1,7 +1,7 @@
 # Network segmentation for the grug namespace (audit #3).
 #
-# The OKE cluster is shared (CNPG, digital-ledger, pasto, tempo, ... all
-# live alongside grug). Without a NetworkPolicy the namespace is flat /
+# The OKE cluster is shared (grug runs as one of several tenant
+# namespaces). Without a NetworkPolicy the namespace is flat /
 # default-allow: any compromised pod anywhere on the cluster can reach the
 # grug pods on any port, and a compromised grug pod has unrestricted
 # egress. These policies close the lateral-movement path and add port-level

--- a/services/webhook/Dockerfile.lambda
+++ b/services/webhook/Dockerfile.lambda
@@ -9,8 +9,8 @@
 
 # Datadog Lambda Extension — Lambda Container images cannot attach
 # layers, so we COPY the extension binary directly into the runtime
-# image. Pinned by version, bump in lockstep with somatic-scripts
-# (currently :96 in infra/docker/macchina-base/Dockerfile).
+# image. Pinned by version, bump in lockstep with the operator's shared
+# base image (currently :96).
 FROM public.ecr.aws/datadog/lambda-extension:96 AS dd-ext
 
 FROM public.ecr.aws/lambda/python:3.13-arm64 AS runtime

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -1375,8 +1375,8 @@
           <div class="dash-col">
             <h5>Installed repos <span class="count">7</span></h5>
             <div class="repo on active">
-              <div class="org">GH</div>
-              <div class="name"><b>somatic-scripts</b><span>githumps/ · 142 PRs</span></div>
+              <div class="org">YO</div>
+              <div class="name"><b>api-gateway</b><span>your-org/ · 142 PRs</span></div>
               <div class="sw"></div>
             </div>
             <div class="repo on">
@@ -1404,11 +1404,11 @@
 
           <!-- Personas -->
           <div class="dash-col dash-mid">
-            <h5>Active personas <span class="count">somatic-scripts</span></h5>
+            <h5>Active personas <span class="count">api-gateway</span></h5>
 
             <div class="repo-banner">
               <span>📁</span>
-              <span><b>githumps/somatic-scripts</b></span>
+              <span><b>your-org/api-gateway</b></span>
               <span class="badge">main</span>
             </div>
 


### PR DESCRIPTION
## Why

grug is a PUBLIC repo, but a comprehensive sweep found several files naming private githumps repos, services, and sibling cluster workloads — a leak of the operator's private-infra topology. Most visibly, the live `grug.lol` landing page showcased a real private repo (`githumps/somatic-scripts · 142 PRs`) in its dashboard mock. This genericizes every named private identifier with no behavior change (comments, docs, and landing-page mock data only).

## Summary

Replaced private names across 9 files: the landing-page mock repo → a generic `your-org/api-gateway` demo entry (matching the existing `your-org/*` mocks); `docs/CUTOVER.md`'s explicit private consumer-repo list → a generic smallest-to-largest ordering guide; and references to `somatic-scripts` / `macchina-router` / `pasto` / `tempo` / `digital-ledger` / `macchina-base` in `HITL_PREREQUISITES.md`, `adr/0001`, `infra/cloudflare/deploy.sh`, `infra/pulumi/__main__.py`, `infra/pulumi/components/oidc_role.py`, `k8s/networkpolicy.yaml`, and `services/webhook/Dockerfile.lambda` → generic descriptions. Generic infra terms already in use (`tailnet`, `OKE`) and the sanctioned self-hosted-LLM anonymization (the Cave / `grug-cave-*`) are intentionally left as-is.

## Test plan

- [ ] Full-repo `git grep` for private names (somatic/macchina/pasto/tempo/digital-ledger/grugthink/meow-now/holdfast/vroom-vroom/conducted/gemini-plugin/aws-solutions-architect) returns zero
- [ ] No behavior change: `py-compile` (Pulumi), `kubectl kustomize k8s/`, and `bash -n deploy.sh` all pass (edits are comment/doc/mock-data only)
- [ ] Landing-page mock repo reads as generic demo data consistent with the other `your-org/*` entries
- [ ] Generic terms (tailnet, OKE) and `grug-cave-*` anonymization preserved

Size: S

## Out of scope

- Deleting the retired `Dockerfile.lambda` files (dead-code cleanup, separate; here only the leak comment is scrubbed)
- Any functional/infra change — this is identifier hygiene only

closes none (public-repo hygiene; private-identifier scrub)