### PR TITLE
fix(grug): guard install-token exchange against malformed GitHub 200 (closes #341)

### DIFF
--- a/services/api/github_app_auth/__init__.py
+++ b/services/api/github_app_auth/__init__.py
@@ -5,6 +5,7 @@ Per PRD #21 Q17: warm-container module-scope cache. Cold start re-signs.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -13,6 +14,8 @@ import httpx
 import jwt
 
 from ports.token_cache import InMemoryTokenCache
+
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.github_app_auth")
 
 _cache = InMemoryTokenCache()
 _GH_API = "https://api.github.com"
@@ -70,8 +73,26 @@ def get_install_token(installation_id: int, *, force_refresh: bool = False) -> s
         timeout=10,
     )
     resp.raise_for_status()
-    payload = resp.json()
-    token = payload["token"]
+    # raise_for_status() validates only the HTTP status, not the body schema.
+    # A 200 can still carry a truncated body, a gateway interstitial that
+    # parses as JSON-without-`token`, or an unexpected schema. Guard the parse
+    # + key access so this hot path fails with an actionable typed error and a
+    # structured log line instead of a bare KeyError/ValueError opaque 500
+    # (which, on the webhook side, makes GitHub retry the delivery). Mirrors
+    # the defensive parsing in llm_client._parse_envelope. The response body is
+    # NOT logged (it may contain a token-shaped value).
+    try:
+        payload = resp.json()
+        token = payload["token"]
+    except (ValueError, KeyError, TypeError) as e:
+        log.warning(
+            "install_token_exchange_malformed_response",
+            extra={"installation_id": installation_id, "error": type(e).__name__},
+        )
+        raise RuntimeError(
+            "GitHub returned a 200 without a usable installation token "
+            f"(installation {installation_id}): {type(e).__name__}"
+        ) from e
     # GitHub returns expires_at ISO; default 1hr from creation.
     _cache.put(key, token, ttl_seconds=55 * 60)
     return token

--- a/services/webhook/github_app_auth/__init__.py
+++ b/services/webhook/github_app_auth/__init__.py
@@ -5,6 +5,7 @@ Per PRD #21 Q17: warm-container module-scope cache. Cold start re-signs.
 
 from __future__ import annotations
 
+import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
@@ -13,6 +14,8 @@ import httpx
 import jwt
 
 from ports.token_cache import InMemoryTokenCache
+
+log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.github_app_auth")
 
 _cache = InMemoryTokenCache()
 _GH_API = "https://api.github.com"
@@ -70,8 +73,26 @@ def get_install_token(installation_id: int, *, force_refresh: bool = False) -> s
         timeout=10,
     )
     resp.raise_for_status()
-    payload = resp.json()
-    token = payload["token"]
+    # raise_for_status() validates only the HTTP status, not the body schema.
+    # A 200 can still carry a truncated body, a gateway interstitial that
+    # parses as JSON-without-`token`, or an unexpected schema. Guard the parse
+    # + key access so this hot path fails with an actionable typed error and a
+    # structured log line instead of a bare KeyError/ValueError opaque 500
+    # (which, on the webhook side, makes GitHub retry the delivery). Mirrors
+    # the defensive parsing in llm_client._parse_envelope. The response body is
+    # NOT logged (it may contain a token-shaped value).
+    try:
+        payload = resp.json()
+        token = payload["token"]
+    except (ValueError, KeyError, TypeError) as e:
+        log.warning(
+            "install_token_exchange_malformed_response",
+            extra={"installation_id": installation_id, "error": type(e).__name__},
+        )
+        raise RuntimeError(
+            "GitHub returned a 200 without a usable installation token "
+            f"(installation {installation_id}): {type(e).__name__}"
+        ) from e
     # GitHub returns expires_at ISO; default 1hr from creation.
     _cache.put(key, token, ttl_seconds=55 * 60)
     return token

--- a/services/webhook/tests/test_github_app_auth.py
+++ b/services/webhook/tests/test_github_app_auth.py
@@ -179,3 +179,43 @@ def test_get_install_token_propagates_401(_stub_secrets):
         with pytest.raises(httpx.HTTPStatusError) as exc:
             gh.get_install_token(1)
     assert exc.value.response.status_code == 401
+
+
+def test_get_install_token_missing_token_key_raises_typed_error(_stub_secrets, caplog):
+    """A 200 whose body lacks `token` raises a clear typed error (not a bare
+    KeyError) and emits a structured warning DD can alert on (#341)."""
+    import logging
+
+    import github_app_auth as gh
+    fake = MagicMock()
+    fake.raise_for_status = MagicMock()
+    fake.json = MagicMock(return_value={"expires_at": "2026-01-01T00:00:00Z"})
+
+    with patch("httpx.post", return_value=fake):
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(RuntimeError) as exc:
+                gh.get_install_token(4242)
+
+    # Typed, descriptive, and does NOT leak a response body.
+    assert "4242" in str(exc.value)
+    assert not isinstance(exc.value, KeyError)
+    assert "install_token_exchange_malformed_response" in caplog.text
+
+
+def test_get_install_token_non_json_body_raises_typed_error(_stub_secrets, caplog):
+    """A 200 with an unparseable body (`resp.json()` raises) is handled the same
+    actionable way rather than surfacing as an opaque 500 (#341)."""
+    import logging
+
+    import github_app_auth as gh
+    fake = MagicMock()
+    fake.raise_for_status = MagicMock()
+    fake.json = MagicMock(side_effect=ValueError("Expecting value"))
+
+    with patch("httpx.post", return_value=fake):
+        with caplog.at_level(logging.WARNING):
+            with pytest.raises(RuntimeError) as exc:
+                gh.get_install_token(7)
+
+    assert "7" in str(exc.value)
+    assert "install_token_exchange_malformed_response" in caplog.text


### PR DESCRIPTION
## Why

`get_install_token` (github_app_auth) exchanges the App JWT for an
installation token and read `token = payload["token"]` directly after
`resp.raise_for_status()`. `raise_for_status()` validates only the HTTP
status, not the body schema. A 200 with a truncated body, a Cloudflare/gateway
interstitial that parses as JSON-without-`token`, or an unexpected schema
raised a bare `KeyError` (or `ValueError` from `resp.json()`). This is on the
hot path of essentially every persona action (TPM check-run, code-review,
enforcement): the error surfaced as an opaque 500 with no structured log line,
and on the webhook side a 500 makes GitHub retry the delivery (duplicate work).

## Summary

Guard the parse + key access in `get_install_token`. On a malformed 200, emit
a structured `install_token_exchange_malformed_response` `log.warning` (DD can
alert on it; the response body is NOT logged since it may contain a
token-shaped value) and raise a descriptive `RuntimeError` instead of a bare
`KeyError`/`ValueError`. Mirrors the defensive parsing already in
`llm_client._parse_envelope`. Applied byte-identically to both the api and
webhook copies (mirror discipline, ADR-0001).

## Test plan

- New `test_get_install_token_missing_token_key_raises_typed_error`: a 200
  body lacking `token` raises a typed `RuntimeError` (not `KeyError`), message
  carries the installation id, and the structured warning is emitted.
- New `test_get_install_token_non_json_body_raises_typed_error`: a 200 whose
  body fails to parse is handled the same actionable way.
- Both new tests fail on `main` (bare `KeyError`/`ValueError`) and pass with
  the fix (verified red->green locally).
- Full webhook suite: 736 passed, 2 skipped (store-backed, need a DB), no
  regressions. Happy path + existing 401-retry path unchanged.
- `services/api` and `services/webhook` copies are byte-identical
  (`diff -q` clean), so the drift-lint stays green.

## Size

XS

## Out of scope

- Extracting `github_app_auth` to `services/_shared/` (tracked in #77).
- Broader retry logic beyond the existing 401-retry semantics.

closes #341
