### PR TITLE
fix(grug): offload ACK-path sync calls + remove dead Lambda self-invoke (closes #371)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -185,18 +185,20 @@ use namespace-level `service:grug`); `env:prod`; `version:<image-sha>`;
 `receive_github_webhook` is **`async def`** (it `await request.body()` so HMAC
 verifies the raw wire bytes; a sync `def` with `Body(...)` lets Pydantic
 JSON-decode before bytes-validation and 422 before HMAC runs — see the comment
-in `main.py`). Its downstream sync I/O (boto3, sync httpx GitHub posts, KMS)
-runs directly on the event loop — an `async def` handler does NOT get
-Starlette's `run_in_threadpool` offload.
+in `main.py`). Because it is `async def`, its sync I/O does NOT get Starlette's
+`run_in_threadpool` offload — it would run directly on the event loop.
 
 **On k8s this is a live concern, not a free invariant.** Under Lambda there was
 one invocation per warm container, so the loop had no peer coroutines to starve.
 A uvicorn pod serves **concurrent** requests on one loop, so a slow sync call in
-the async handler CAN delay peers. Keep the handler's per-call work bounded
-(each httpx call is individually timeout-bounded) and, if anything adds
-concurrent fan-out / streaming / background tasks, wrap sync calls in
-`await asyncio.to_thread(...)` (as `cf_auth.py` already does) or move to
-`httpx.AsyncClient` + `aioboto3`. (Originally #68; re-opened by the k8s move.)
+the async handler delays peers, stretching their ACK toward GitHub's ~10s
+timeout. So the ACK-path sync calls are offloaded with
+`await asyncio.to_thread(...)` (#371): the SSM secret fetch and `dispatch` (its
+remaining sync httpx/store work) run in a worker thread — the same offload
+`cf_auth.py`'s middleware uses. The heavy Elder review is already off-loop on a
+background thread (#368). Any NEW sync I/O added to this handler must be wrapped
+the same way (or moved to `httpx.AsyncClient` + `aioboto3`). (Originally #68;
+re-opened by the k8s move, fixed in #371.)
 
 ### Mirrored files between services/api/ + services/webhook/
 

--- a/services/webhook/async_dispatch.py
+++ b/services/webhook/async_dispatch.py
@@ -1,48 +1,43 @@
-# WEBHOOK-ONLY (NOT mirrored): self-invoke of the grug-webhook Lambda + its
-# async-job routing. The api service has no webhook ACK path, so there is no
-# api sibling — like dispatcher.py / main.py / lambda_handler.py. Per ADR-0001,
-# only modules BOTH services run are mirrored.
+# WEBHOOK-ONLY (NOT mirrored): Elder async-offload + its async-job routing.
+# The api service has no webhook ACK path, so there is no api sibling — like
+# dispatcher.py / main.py / lambda_handler.py. Per ADR-0001, only modules BOTH
+# services run are mirrored.
 """Async offload of the Elder LLM review off the webhook ACK path (#272).
 
 `receive_github_webhook` must ACK GitHub in <10s, but the Elder persona
 makes 1–2 LLM calls (worst case ~300s with retries) — far over GitHub's
-~10s delivery timeout. So the webhook **self-invokes** the same Lambda
-asynchronously (`InvocationType="Event"`) and returns immediately; the
-async invocation runs the Elder dispatch with the full Lambda budget.
+~10s delivery timeout. So the review is run OFF the ACK path: the handler
+enqueues it and returns immediately.
 
-Why self-invoke the SAME function rather than a dedicated worker Lambda
-or SQS: the webhook image already carries every dependency the Elder
-path needs (GitHub-App auth, LLM keys, DDB, LLM-Obs, KMS) — a separate
-worker would duplicate ~15 env vars + secret grants + a role + the
-mirror surface (the drift ADR-0001 exists to prevent). A same-function
-async invocation IS the async worker. See `specs/DESIGN.md` →
-"Async Elder offload (#272)".
+On the k8s runtime (#354/#368) the offload is an in-process background
+thread (`_spawn_local_elder`): the webhook pod already carries every
+dependency the Elder path needs (GitHub-App auth, LLM keys, Postgres,
+LLM-Obs, KMS), so a separate worker would duplicate ~15 env vars + secret
+grants + a role + the mirror surface ADR-0001 exists to prevent. The
+thread runs with the pod's full lifetime; a pod restart mid-review drops
+the in-flight review, the same best-effort contract Lambda's async invoke
+had (a dropped review re-triggers on the next push). See `specs/DESIGN.md`
+→ "Async Elder offload (#272)".
 
-Routing: the async invocation arrives at `lambda_handler.handler` as a
-RAW event (not a Function-URL HTTP event), so the handler sniffs the
-`grug_async_job` sentinel and calls `run_elder_job` BEFORE handing the
-event to Mangum (which would choke on a non-HTTP shape).
+Routing: a self-invoked async job is still tagged with the `grug_async_job`
+sentinel so `lambda_handler.handler` (reused as the SQS event router by
+consumer.py) can dispatch raw async events to `run_elder_job`.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import threading
 from typing import Any
 
-import boto3
-
 log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.async_dispatch")
 
-# Sentinel marking a self-invoked async job. `lambda_handler.handler`
-# routes on `event.get("grug_async_job")` truthiness; the value names the
-# job kind so a future second async job type can fan out from one router.
+# Sentinel marking an async job. `lambda_handler.handler` routes on
+# `event.get("grug_async_job")` truthiness; the value names the job kind so a
+# future second async job type can fan out from one router.
 ASYNC_JOB_KEY = "grug_async_job"
 ELDER_REVIEW_JOB = "elder_review"
-
-_lambda = boto3.client("lambda")
 
 
 def _slim_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -50,14 +45,10 @@ def _slim_payload(payload: dict[str, Any]) -> dict[str, Any]:
     (`dispatch_code_review`) reads: `action`, the PR number + head sha,
     the repo owner/name, and the installation id. The worker re-fetches
     the diff from GitHub by those IDs, so forwarding the full payload is
-    not just unnecessary — it's DANGEROUS: an async (`InvocationType=
-    "Event"`) invoke caps the request payload at 256 KB, and a large PR
-    (long body + two full repo objects + sender/org) can blow past that
-    → `InvalidRequestContentException` → the review is dropped, and since
-    every re-push re-sends the same oversized payload it NEVER recovers.
-    The slim projection keeps the event tiny and bounded regardless of PR
-    size. Mirrors `dispatch_code_review`'s reads — keep in sync if that
-    function starts consuming new payload fields.
+    unnecessary: the slim projection keeps the job minimal and bounded
+    regardless of PR size (a long body + two full repo objects + sender/org
+    are all dropped). Mirrors `dispatch_code_review`'s reads — keep in sync
+    if that function starts consuming new payload fields.
     """
     pr = payload.get("pull_request") or {}
     repo = payload.get("repository") or {}
@@ -81,61 +72,38 @@ def enqueue_elder_review(
     delivery_id: str,
     blocking: bool,
 ) -> bool:
-    """Fire-and-forget self-invoke to run the Elder review async.
+    """Fire-and-forget offload to run the Elder review async.
 
-    Returns ``True`` if the async invocation was accepted, ``False`` on
+    Returns ``True`` if the async job was accepted, ``False`` on
     any failure (logged). Best-effort by design: the caller logs the
     failure and returns ``result="enqueue_failed"`` — it does NOT fall
     back to a synchronous Elder run, because that would re-block the ACK
     path and break the <10s guarantee. A dropped review re-triggers on
     the next push.
 
-    The target function is the caller's OWN function, read from the
-    Lambda-runtime-provided ``AWS_LAMBDA_FUNCTION_NAME``. Off-Lambda
-    there are two cases (#368): the k8s runtime (``GRUG_K8S_RUNTIME``
-    set in the pod manifests) runs the job in-process on a background
-    thread — a pod has no Lambda-style invoke budget to escape, the ACK
-    handler returns immediately while the thread runs with the pod's
-    full lifetime. Local / test (neither env set) → return False.
+    The k8s runtime (``GRUG_K8S_RUNTIME`` set in the pod manifests, #368)
+    runs the job in-process on a background thread: the ACK handler returns
+    immediately while the thread runs with the pod's full lifetime. This is
+    the only async path post-Lambda (#354); local / test (the flag unset)
+    has no offload and returns False.
 
     k8s trade-off (vs a queue + worker Deployment, recorded in
     specs/DESIGN.md): a pod restart mid-review drops the in-flight
-    review — the SAME best-effort contract as Lambda's async invoke
-    (a dropped review re-triggers on the next push). In exchange we
-    avoid a new queue + consumer + IAM surface for the hot path.
+    review — a best-effort contract (a dropped review re-triggers on the
+    next push). In exchange we avoid a new queue + consumer + IAM surface
+    for the hot path.
     """
     job = {
         ASYNC_JOB_KEY: ELDER_REVIEW_JOB,
         "delivery_id": delivery_id,
         "blocking": blocking,
-        # Slim projection — NOT the full payload (256 KB Event cap). See
-        # _slim_payload.
+        # Slim projection — NOT the full payload. See _slim_payload.
         "payload": _slim_payload(payload),
     }
-    function_name = os.getenv("AWS_LAMBDA_FUNCTION_NAME", "")
-    if not function_name:
-        if os.getenv("GRUG_K8S_RUNTIME"):
-            return _spawn_local_elder(job)
-        log.warning(
-            "elder_enqueue_no_function_name", extra={"delivery_id": delivery_id}
-        )
-        return False
-    try:
-        _lambda.invoke(
-            FunctionName=function_name,
-            InvocationType="Event",  # async; returns 202, does not wait
-            Payload=json.dumps(job).encode("utf-8"),
-        )
-        return True
-    except Exception as e:  # noqa: BLE001 — best-effort enqueue; never break the ACK
-        # Distinct token from the caller's `elder_enqueue_failed` so the
-        # offload-failure monitor (which watches the caller's log) counts
-        # one line per dropped review, not two. This line adds the cause.
-        log.error(
-            "elder_enqueue_invoke_error",
-            extra={"delivery_id": delivery_id, "kind": type(e).__name__},
-        )
-        return False
+    if os.getenv("GRUG_K8S_RUNTIME"):
+        return _spawn_local_elder(job)
+    log.warning("elder_enqueue_no_runtime", extra={"delivery_id": delivery_id})
+    return False
 
 
 def _spawn_local_elder(job: dict[str, Any]) -> bool:
@@ -166,7 +134,7 @@ def _spawn_local_elder(job: dict[str, Any]) -> bool:
 
 
 def run_elder_job(event: dict[str, Any]) -> dict[str, str]:
-    """Worker entry for a self-invoked Elder review job.
+    """Worker entry for an async Elder review job.
 
     Two-layer idempotency so the review is never double-posted:
     ``delivery_id`` (`install_store.claim_delivery`) skips a GitHub

--- a/services/webhook/dispatcher.py
+++ b/services/webhook/dispatcher.py
@@ -308,13 +308,14 @@ def _handle_pull_request(
         #
         # Elder makes 1–2 LLM calls (worst case ~300s) — far over
         # GitHub's ~10s delivery timeout — so it is OFFLOADED off the
-        # ACK path (#272): self-invoke the Lambda async and return
-        # `queued` immediately. TPM (fast, no LLM) already ran inline
-        # above. Idempotency keys on `delivery_id` inside the worker.
-        # Enqueue failure does NOT fall back to a sync run — that would
-        # re-block the ACK; a dropped review re-triggers on next push.
+        # ACK path (#272): enqueue the review (on k8s, a background
+        # thread — #368) and return `queued` immediately. TPM (fast, no
+        # LLM) already ran inline above. Idempotency keys on `delivery_id`
+        # inside the worker. Enqueue failure does NOT fall back to a sync
+        # run — that would re-block the ACK; a dropped review re-triggers
+        # on next push.
         cfg = get_repo_config(int(installation_id), int(repo_id))
-        from async_dispatch import enqueue_elder_review  # lazy: keeps boto3 lambda client off non-PR cold starts
+        from async_dispatch import enqueue_elder_review  # lazy import keeps cold-start cheap
         enqueued = enqueue_elder_review(
             payload=payload,
             delivery_id=delivery_id,

--- a/services/webhook/main.py
+++ b/services/webhook/main.py
@@ -11,6 +11,7 @@ plug in via the same dispatcher).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 
@@ -90,21 +91,22 @@ async def receive_github_webhook(
     # on the parsed dict not being bytes — so HMAC verify never runs.
     # Using `Request` keeps the wire bytes intact for HMAC verify.
     #
-    # This is `async def`, so the sync boto3 / httpx calls below (and the
-    # #272 `lambda.invoke` self-invoke in dispatch) run directly on the
-    # event loop — async handlers do NOT get Starlette's run_in_threadpool
-    # offload. That's safe ONLY because AWS Lambda runs one invocation per
-    # warm container: while this handler runs there are no peer request-
-    # coroutines to starve. It is an invariant of the execution model, not
-    # a guarantee — if anything ever adds concurrent coroutines to this loop
-    # (asyncio.gather fan-out, a streaming response, a background task), wrap
-    # the sync calls in `await asyncio.to_thread(...)` (as cf_auth.py's
-    # middleware already does for its sync ssm.get_parameter). See
-    # docs/RUNBOOK.md#sync-vs-async-route-handlers. Closes #68 (spirit) + the
-    # pre-Slice-11 422 regression.
+    # This is `async def` (it must be: reading the raw HMAC bytes needs
+    # `await request.body()` — see the 422 note above), so the sync boto3 /
+    # httpx calls below run on the event loop, and async handlers do NOT get
+    # Starlette's run_in_threadpool offload. On Lambda that was safe (one
+    # invocation per warm container, no peer coroutines to starve), but on the
+    # k8s runtime (#354) uvicorn serves CONCURRENT deliveries on one loop, so a
+    # sync call here would block every other in-flight delivery's ACK toward
+    # GitHub's ~10s timeout. So the blocking calls — the SSM secret fetch and
+    # `dispatch` (its remaining sync httpx/store work; the heavy Elder review is
+    # already off-loop via #368) — run in `await asyncio.to_thread(...)`, the
+    # same offload cf_auth.py's middleware uses for its sync ssm.get_parameter.
+    # See docs/RUNBOOK.md#sync-vs-async-route-handlers. Closes #371 + #68
+    # (spirit) + the pre-Slice-11 422 regression.
     body = await request.body()
 
-    secret = get_webhook_secret()
+    secret = await asyncio.to_thread(get_webhook_secret)
     if not verify_signature(secret, body, x_hub_signature_256):
         # Split the alert signal from internet noise. A genuine GitHub delivery
         # being REJECTED (webhook secret rotated / SSM drift — actionable)
@@ -163,7 +165,9 @@ async def receive_github_webhook(
         )
         raise HTTPException(status_code=400, detail="body_not_json")
 
-    outcome = dispatch(x_github_event, payload, delivery_id=x_github_delivery)
+    outcome = await asyncio.to_thread(
+        dispatch, x_github_event, payload, delivery_id=x_github_delivery
+    )
     log.info(
         "webhook_dispatched",
         extra={"delivery_id": x_github_delivery, **outcome},

--- a/services/webhook/tests/test_async_dispatch.py
+++ b/services/webhook/tests/test_async_dispatch.py
@@ -2,10 +2,10 @@
 
 Covers the three new seams that move the Elder LLM review off the webhook
 ACK path:
-  - `enqueue_elder_review` — the fire-and-forget self-invoke (shape of the
-    boto3 lambda.invoke; degrades to False, never raises).
+  - `enqueue_elder_review` — the fire-and-forget offload (on k8s, a
+    background thread; degrades to False, never raises).
   - `run_elder_job` — the async worker (idempotent on delivery_id; never
-    re-raises so AWS doesn't retry-storm).
+    re-raises so a retry doesn't storm).
   - `install_store.claim_delivery` — the win-once idempotency claim (only
     the error-propagation contract here; behavior is in the real-PG suite).
 """
@@ -27,7 +27,7 @@ import adapters.install_store as ins
 
 def _full_gh_payload(body=""):
     """A GitHub pull_request payload with the bulky fields that must NOT be
-    forwarded (the 256 KB Event cap)."""
+    forwarded to the worker (the worker re-fetches by id)."""
     return {
         "action": "opened",
         "pull_request": {
@@ -45,24 +45,11 @@ def _full_gh_payload(body=""):
     }
 
 
-def test_enqueue_invokes_self_async_with_slim_job_payload(monkeypatch):
-    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "grug-webhook")
-    with patch.object(ad._lambda, "invoke") as mock_invoke:
-        ok = ad.enqueue_elder_review(
-            payload=_full_gh_payload(body="m" * 5000),
-            delivery_id="d-1",
-            blocking=True,
-        )
-    assert ok is True
-    _, kwargs = mock_invoke.call_args
-    assert kwargs["FunctionName"] == "grug-webhook"
-    assert kwargs["InvocationType"] == "Event"  # async, doesn't wait
-    job = json.loads(kwargs["Payload"])
-    assert job[ad.ASYNC_JOB_KEY] == ad.ELDER_REVIEW_JOB
-    assert job["delivery_id"] == "d-1"
-    assert job["blocking"] is True
-    # Only the fields dispatch_code_review reads survive (256 KB Event cap).
-    assert job["payload"] == {
+def test_slim_payload_keeps_only_worker_fields():
+    """The slim projection forwards ONLY the fields dispatch_code_review
+    reads; the worker re-fetches the diff from GitHub by those ids."""
+    job_payload = ad._slim_payload(_full_gh_payload(body="m" * 5000))
+    assert job_payload == {
         "action": "opened",
         "pull_request": {"number": 7, "head": {"sha": "abc123"}},
         "repository": {"owner": {"login": "githumps"}, "name": "grug"},
@@ -70,38 +57,31 @@ def test_enqueue_invokes_self_async_with_slim_job_payload(monkeypatch):
     }
 
 
-def test_enqueue_drops_bulky_payload_fields(monkeypatch):
-    """The PR body, sender, and extra repo metadata (the parts that can
-    push a payload past the 256 KB async-invoke cap) must NOT be forwarded."""
-    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "grug-webhook")
-    huge_body = "z" * 200_000  # would blow the 256 KB cap if forwarded
-    with patch.object(ad._lambda, "invoke") as mock_invoke:
-        ad.enqueue_elder_review(
-            payload=_full_gh_payload(body=huge_body),
-            delivery_id="d-big",
-            blocking=False,
-        )
-    raw = mock_invoke.call_args.kwargs["Payload"]
+def test_slim_payload_drops_bulky_fields():
+    """The PR body, sender, and extra repo metadata must NOT be forwarded —
+    the job stays minimal and bounded regardless of PR size."""
+    huge_body = "z" * 200_000
+    slim = ad._slim_payload(_full_gh_payload(body=huge_body))
+    raw = json.dumps(slim)
     assert len(raw) < 1000  # slim, bounded — not ~200 KB
-    assert b"zzz" not in raw  # the huge body is gone
-    assert b"avatar_url" not in raw  # sender stripped
+    assert "zzz" not in raw  # the huge body is gone
+    assert "avatar_url" not in raw  # sender stripped
 
 
-def test_enqueue_returns_false_without_function_name(monkeypatch):
-    """Local/test (no AWS_LAMBDA_FUNCTION_NAME) → can't self-invoke → False,
-    no exception."""
-    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_NAME", raising=False)
-    with patch.object(ad._lambda, "invoke") as mock_invoke:
+def test_enqueue_returns_false_without_runtime(monkeypatch):
+    """Local/test (no GRUG_K8S_RUNTIME) → no offload path → False, no
+    exception, and no thread spawned."""
+    monkeypatch.delenv("GRUG_K8S_RUNTIME", raising=False)
+    with patch.object(ad.threading, "Thread") as mock_thread:
         ok = ad.enqueue_elder_review(payload={}, delivery_id="d-2", blocking=False)
     assert ok is False
-    mock_invoke.assert_not_called()
+    mock_thread.assert_not_called()
 
 
 def test_enqueue_k8s_runtime_runs_in_process_thread(monkeypatch):
-    """#368: off-Lambda with GRUG_K8S_RUNTIME set, the job runs in-process
-    on a background thread - same slim-projection job shape, no boto3
-    invoke, returns True (the review is NOT dropped)."""
-    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_NAME", raising=False)
+    """#368: with GRUG_K8S_RUNTIME set, the job runs in-process on a
+    background thread - slim-projection job shape, returns True (the review
+    is NOT dropped)."""
     monkeypatch.setenv("GRUG_K8S_RUNTIME", "1")
     ran = threading.Event()
     seen: dict = {}
@@ -111,10 +91,7 @@ def test_enqueue_k8s_runtime_runs_in_process_thread(monkeypatch):
         ran.set()
         return {"persona": "code_reviewer", "result": "pass"}
 
-    with (
-        patch.object(ad, "run_elder_job", side_effect=fake_job),
-        patch.object(ad._lambda, "invoke") as mock_invoke,
-    ):
+    with patch.object(ad, "run_elder_job", side_effect=fake_job):
         ok = ad.enqueue_elder_review(
             payload=_full_gh_payload(body="m" * 5000),
             delivery_id="d-k8s",
@@ -122,32 +99,20 @@ def test_enqueue_k8s_runtime_runs_in_process_thread(monkeypatch):
         )
         assert ran.wait(5.0), "background thread never ran the job"
     assert ok is True
-    mock_invoke.assert_not_called()
     assert seen["delivery_id"] == "d-k8s"
     assert seen["blocking"] is True
     assert seen[ad.ASYNC_JOB_KEY] == ad.ELDER_REVIEW_JOB
-    # Slim projection applies on the k8s path too (keep-in-sync contract).
+    # Slim projection applies on the thread path (keep-in-sync contract).
     assert seen["payload"]["pull_request"] == {"number": 7, "head": {"sha": "abc123"}}
     assert "sender" not in seen["payload"]
 
 
 def test_enqueue_k8s_spawn_failure_degrades_to_false(monkeypatch):
     """#368: a thread-spawn failure must NOT raise into the ACK path -
-    same degrade-to-False contract as a Lambda invoke error."""
-    monkeypatch.delenv("AWS_LAMBDA_FUNCTION_NAME", raising=False)
+    it degrades to False so the caller logs enqueue_failed and still ACKs."""
     monkeypatch.setenv("GRUG_K8S_RUNTIME", "1")
     with patch.object(ad.threading, "Thread", side_effect=RuntimeError("no threads")):
         ok = ad.enqueue_elder_review(payload={}, delivery_id="d-k8s2", blocking=False)
-    assert ok is False
-
-
-def test_enqueue_degrades_to_false_on_invoke_error(monkeypatch):
-    """A throttle/transport error on the invoke must NOT raise (the caller
-    must still ACK GitHub) — it returns False so the caller logs
-    enqueue_failed."""
-    monkeypatch.setenv("AWS_LAMBDA_FUNCTION_NAME", "grug-webhook")
-    with patch.object(ad._lambda, "invoke", side_effect=RuntimeError("throttled")):
-        ok = ad.enqueue_elder_review(payload={}, delivery_id="d-3", blocking=False)
     assert ok is False
 
 

--- a/services/webhook/tests/test_main_webhook_receiver.py
+++ b/services/webhook/tests/test_main_webhook_receiver.py
@@ -202,3 +202,66 @@ def test_receiver_threads_delivery_id_into_dispatch(_client):
         )
     assert r.status_code == 200
     assert captured["delivery_id"] == "deliv-xyz"
+
+
+def test_concurrent_deliveries_do_not_serialize_on_ack_path(monkeypatch):
+    """#371: on k8s, uvicorn serves concurrent deliveries on ONE event loop.
+    The ACK-path sync calls (SSM secret fetch, dispatch) must be offloaded via
+    asyncio.to_thread so two simultaneous deliveries don't serialize - one
+    handler's sync call must not block the other's ACK. Proven with a
+    max-concurrency counter: if the slow sync call runs on the loop, the two
+    deliveries serialize and max concurrency is 1; offloaded to threads they
+    overlap and reach 2."""
+    import asyncio
+    import threading
+    import time
+
+    import httpx
+
+    monkeypatch.setenv("GITHUB_APP_WEBHOOK_SECRET_SSM", "/grug/test-webhook-secret")
+    monkeypatch.setenv("GRUG_DDB_TABLE", "grug-main-test")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    import main as webhook_main
+    import dispatcher
+
+    state = {"current": 0, "max": 0}
+    lock = threading.Lock()
+
+    def slow_secret() -> str:
+        # Simulate the blocking SSM round-trip on the ACK path.
+        with lock:
+            state["current"] += 1
+            state["max"] = max(state["max"], state["current"])
+        time.sleep(0.2)
+        with lock:
+            state["current"] -= 1
+        return _WEBHOOK_SECRET
+
+    monkeypatch.setattr(webhook_main, "get_webhook_secret", slow_secret)
+    monkeypatch.setattr(
+        dispatcher,
+        "dispatch",
+        lambda event, payload, *, delivery_id="": {"status": "no_op"},
+    )
+
+    body = b'{"action":"opened"}'
+    headers = {
+        "X-GitHub-Event": "pull_request",
+        "X-Hub-Signature-256": _sign(_WEBHOOK_SECRET, body),
+    }
+
+    async def _drive() -> tuple[int, int]:
+        transport = httpx.ASGITransport(app=webhook_main.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+            async def _one() -> int:
+                r = await c.post("/webhook/github", content=body, headers=headers)
+                return r.status_code
+
+            return await asyncio.gather(_one(), _one())
+
+    codes = asyncio.run(_drive())
+    assert codes == [200, 200]
+    assert state["max"] == 2, (
+        "ACK-path sync call serialized the two deliveries on the event loop "
+        "(expected concurrent offload via asyncio.to_thread)"
+    )


### PR DESCRIPTION
## Why

`receive_github_webhook` is `async def` (it must be: reading the raw HMAC
bytes needs `await request.body()` - a sync handler with `Body(...)` lets
Pydantic JSON-decode before bytes-validation and 422s before HMAC runs). So
its sync calls ran directly on the event loop. That was safe under Lambda
(one invocation per warm container - no peer coroutines), but on the k8s
runtime uvicorn serves CONCURRENT deliveries on one loop, so one handler's
sync SSM/dispatch call blocks every other in-flight delivery's ACK toward
GitHub's ~10s delivery timeout.

While fixing it, the issue's premise ("the Lambda invariant is gone") surfaced
actual dead Lambda code: `async_dispatch.py` still built a boto3 lambda client
and had a `_lambda.invoke` self-invoke branch that is never reached on k8s
(bypassed by the `GRUG_K8S_RUNTIME` daemon-thread path from #368) and targets a
grug-webhook Lambda that no longer exists.

## Summary

Two commits:
1. **The fix** - wrap the two ACK-path blocking calls (`get_webhook_secret`
   SSM fetch, `dispatch`) in `await asyncio.to_thread(...)`, the same offload
   `cf_auth.py`'s middleware uses. The heavy Elder review is already off-loop
   on a background thread (#368), so this covers the remaining ~1-2s sync I/O.
2. **The cleanup** - remove the dead Lambda self-invoke path from
   `async_dispatch.py` (boto3 + json imports, the module-level lambda client,
   the `AWS_LAMBDA_FUNCTION_NAME`/invoke/invoke-error code) and de-Lambda the
   docstrings + the stale dispatcher comment. `enqueue_elder_review` now
   offloads via the thread or returns False.

`lambda_handler.handler` is intentionally KEPT - `consumer.py` reuses it as the
live SQS event router. Out of scope: the rest of the Lambda-era source sweep
(Dockerfile.lambda / mangum / lambda_handler shape).

## Test plan

- New `test_concurrent_deliveries_do_not_serialize_on_ack_path`: drives two
  concurrent deliveries through the ASGI app and asserts they overlap
  (max-concurrency counter reaches 2). Fails on `main` (serialized to 1),
  passes with the offload - verified red->green locally.
- `async_dispatch` tests retargeted to the live k8s-thread contract: slim
  projection (`_slim_payload` direct), thread runs the job, thread-spawn
  failure degrades to False, no-runtime returns False. The two tests that only
  exercised the dead `_lambda.invoke` path are removed.
- Full webhook suite: 734 passed, 2 skipped (store-backed, need a DB), no
  regressions. Existing 401/400/HMAC paths unchanged.

## Size

S

## Out of scope

- The broader Lambda-era source cleanup (Dockerfile.lambda, mangum,
  lambda_handler.py reshaping) - lambda_handler is still the live SQS router.
- Moving to `httpx.AsyncClient` / `aioboto3` (the to_thread offload is
  sufficient at current volume).

closes #371
