### PR TITLE
fix(grug): trace-flush warning dropped in first 60s after boot (flaky CI fix)

### DIFF
--- a/services/webhook/consumer.py
+++ b/services/webhook/consumer.py
@@ -198,7 +198,12 @@ def _warm_trace_writer() -> None:
         log.warning("trace_writer_warmup_failed", exc_info=True)
 
 
-_last_flush_warn = 0.0
+# -inf, NOT 0.0: the rate-limit compares against time.monotonic() (seconds
+# since boot, NOT epoch). On a freshly-booted pod monotonic() can be < the
+# interval, so a 0.0 sentinel makes `now - 0.0 > INTERVAL` False and SILENTLY
+# DROPS the first flush warning in the first 60s after start - exactly when
+# startup trouble matters. -inf means the first real failure always warns.
+_last_flush_warn = float("-inf")
 _FLUSH_WARN_INTERVAL_S = 60.0
 
 
@@ -227,17 +232,30 @@ def _flush_traces() -> None:
     ~once/min, not 12x/min and not never."""
     global _last_flush_warn
     try:
-        import ddtrace
-    except ImportError:
-        log.debug("trace_flush_skipped_no_ddtrace")
-        return
-    try:
-        ddtrace.tracer.flush()
+        _flush_tracer()
     except Exception:  # noqa: BLE001 - telemetry is never worth crashing on
         now = time.monotonic()
         if now - _last_flush_warn > _FLUSH_WARN_INTERVAL_S:
             log.warning("trace_flush_failed", exc_info=True)
             _last_flush_warn = now
+
+
+def _flush_tracer() -> None:
+    """Flush the global APM tracer once (the testable seam for #412).
+
+    ddtrace absent (tests run without it) is a no-op. Isolated from
+    `_flush_traces` so a test can force a flush FAILURE deterministically by
+    patching THIS function. Patching `ddtrace.tracer` (or its `.flush`)
+    directly is order/version dependent and silently no-ops on some hosted
+    runners - it passed locally and flaked red on CI, which is what this seam
+    retires. grug-local: this is a webhook-service test seam, NOT a reusable /
+    CI-workflow concern."""
+    try:
+        import ddtrace
+    except ImportError:
+        log.debug("trace_flush_skipped_no_ddtrace")
+        return
+    ddtrace.tracer.flush()
 
 
 def _startup_check() -> None:

--- a/services/webhook/tests/test_consumer.py
+++ b/services/webhook/tests/test_consumer.py
@@ -242,33 +242,40 @@ def test_flush_traces_never_raises():
     consumer._flush_traces()  # must not raise
 
 
-def test_flush_failure_is_visible_but_rate_limited(monkeypatch, caplog):
+def test_flush_failure_is_visible_but_rate_limited(monkeypatch):
     """#412 audit: a REAL flush failure must NOT be silent (that's the
     zero-spans-and-blind state this slice kills) - log WARNING - but rate-limit
-    so a sustained agent outage logs ~once/min, not on every 5s tick."""
-    import logging
-    import types
+    so a sustained agent outage logs ~once/min, not on every 5s tick.
 
-    import ddtrace
+    Forces the failure by patching the `_flush_tracer` SEAM and asserts on a
+    patched logger. Both deliberately avoid ddtrace internals AND caplog: the
+    old approach (swap `ddtrace.tracer`, read `caplog`) was order/version/
+    log-propagation dependent and flaked green-local / red-CI on hosted
+    runners. This path is deterministic everywhere."""
+    from unittest.mock import MagicMock
 
-    monkeypatch.setattr(consumer, "_last_flush_warn", 0.0)
+    # -inf = "never warned" (NOT 0.0: the rate-limit compares against
+    # time.monotonic() = since-boot, which on a fresh runner can be < the
+    # interval, suppressing the first warning -> the real green-local/red-CI
+    # flake this fixes).
+    monkeypatch.setattr(consumer, "_last_flush_warn", float("-inf"))
+    monkeypatch.setattr(
+        consumer,
+        "_flush_tracer",
+        MagicMock(side_effect=RuntimeError("agent unreachable")),
+    )
+    mock_log = MagicMock()
+    monkeypatch.setattr(consumer, "log", mock_log)
 
-    def _boom():
-        raise RuntimeError("agent unreachable")
+    consumer._flush_traces()  # first failure -> warns
+    consumer._flush_traces()  # immediate retry -> rate-limited, no second warn
 
-    # Replace the WHOLE tracer object, not just `.flush` — under ddtrace's
-    # proxy/lazy tracer, patching the `.flush` attribute is order/version
-    # dependent and silently no-ops on some hosted runners (the real flush
-    # then succeeds and nothing warns -> a deterministic CI failure that
-    # cannot reproduce locally). `_flush_traces` only calls `ddtrace.tracer
-    # .flush()`, so a SimpleNamespace stands in deterministically.
-    monkeypatch.setattr(ddtrace, "tracer", types.SimpleNamespace(flush=_boom))
-    with caplog.at_level(logging.WARNING):
-        consumer._flush_traces()  # first failure -> warns
-        consumer._flush_traces()  # immediate retry -> rate-limited, no second warn
-    warns = [r for r in caplog.records if r.msg == "trace_flush_failed"]
+    warns = [
+        c for c in mock_log.warning.call_args_list
+        if c.args and c.args[0] == "trace_flush_failed"
+    ]
     assert len(warns) == 1, "real flush failure must warn exactly once (rate-limited)"
-    assert warns[0].levelno == logging.WARNING
+    assert warns[0].kwargs.get("exc_info") is True
 
 
 def test_watchdog_flushes_traces_each_tick(monkeypatch):


### PR DESCRIPTION
## Why

`test_consumer.py::test_flush_failure_is_visible_but_rate_limited` flaked
**green-local / red-CI** and has been RED on `main` since the #440 merge,
blocking every PR's clean merge.

**Root cause (not what the old comment claimed):** the rate-limit sentinel, not
ddtrace/caplog. `_last_flush_warn` defaulted to `0.0`, and the guard compares
against `time.monotonic()` = seconds **since boot**. On a freshly-booted runner
`monotonic()` can be **< the 60s interval**, so `now - 0.0 > 60` is False and
the FIRST warning is suppressed -> 0 warnings -> red. A long-up dev box has a
huge `monotonic()`, so it passes. This also explains why one earlier runner
happened to pass.

This is also a real **production** bug: a pod in its first 60s after boot would
silently drop the first trace-flush warning - exactly when startup trouble
matters most.

## Summary

- **The fix:** initialize `_last_flush_warn = float('-inf')` so the first real
  failure always warns regardless of the clock's since-boot value. Proven
  locally by simulating `monotonic()=5s`: `0.0` -> 0 warnings (reproduces the
  flake), `-inf` -> 1 warning.
- **Hardening:** also move the test off ddtrace internals + caplog - a
  `_flush_tracer()` seam the test patches to fail deterministically, asserting
  on a patched logger - so it can never depend on ddtrace's proxy resolution or
  log propagation again either.

## Test plan

- Reproduced the flake locally: with `monotonic()` mocked to 5s, the old `0.0`
  sentinel yields 0 warnings; `-inf` yields 1. (Direct repro in the PR
  description's mechanism.)
- `test_flush_failure_is_visible_but_rate_limited` rewritten + green; full
  consumer suite 17 passed; full webhook suite 736 passed, 2 skipped locally.
- Production behavior otherwise identical (same flush, same rate-limited warn).

## Size

XS

## Out of scope

- ddtrace deprecation-warning noise in CI logs (cosmetic).

## Repo scope (per request)

**grug-local** webhook-service code + a unit-test seam - NOT a CI workflow or
shared action. **Nothing here is reusable for `infra-public`**; it is specific
to this service's consumer and must never be abstracted out.

Refs #412
