### PR TITLE
ci(grug): give benchmark.sast an AWS region so it can import (#392)

### DIFF
--- a/.github/workflows/benchmark.sast.yml
+++ b/.github/workflows/benchmark.sast.yml
@@ -65,6 +65,13 @@ jobs:
       - name: Run SAST benchmark
         working-directory: services/webhook
         env:
+          # secrets_loader builds boto3.client("ssm") at import (via llm_client),
+          # which needs a region just to construct - even though the benchmark
+          # never CALLS SSM (it uses the GRUG_BENCH_* keys directly). Dummy creds
+          # + region match check.python.yml so the import succeeds offline.
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: testing
+          AWS_SECRET_ACCESS_KEY: testing
           GRUG_BENCH_OPENROUTER_KEY: ${{ secrets.GRUG_BENCH_OPENROUTER_KEY }}
           GRUG_BENCH_POOLSIDE_KEY: ${{ secrets.GRUG_BENCH_POOLSIDE_KEY }}
           GRUG_BENCH_CAVE_URL: ${{ secrets.GRUG_BENCH_CAVE_URL }}


### PR DESCRIPTION
## Why

The SAST benchmark (`benchmark.sast.yml`, the #392 operator gate) failed the
first time it was actually dispatched - it died at **import**, before any LLM
call: `secrets_loader` builds `boto3.client("ssm")` at module load (via
`llm_client`), and boto3 needs a region just to construct a client. The
workflow set no AWS env, so the import raised a region-resolution error. The
benchmark never *calls* SSM (it uses the `GRUG_BENCH_*` keys directly), so this
is purely a client-construction requirement that was latent until the gate ran.

## Summary

Add `AWS_DEFAULT_REGION` + dummy `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` to
the benchmark step env, matching what `check.python.yml` already does for the
test job. No AWS call is made; this only satisfies client construction at
import so the benchmark can reach the scoring path.

## Test plan

- Re-dispatch `benchmark.sast` (record mode) on `main` after merge and confirm
  the run gets past the `secrets_loader` import (was: traceback, 608-byte empty
  artifact) and reaches the scoring path.
- Confirm the uploaded `sast-benchmark` artifact contains a non-empty
  `baseline.json` with per-backend recall/precision (Poolside at minimum).
- Confirm no AWS API call is attempted (the dummy creds are never exercised -
  the benchmark uses the `GRUG_BENCH_*` keys), so the change is inert outside
  client construction.

## Size

XS

## Out of scope

- Making `secrets_loader` lazy-construct its SSM client (a broader refactor;
  the region env is the minimal, test-consistent fix).
- Seeding a Cave/sparkles backend (needs a tailnet key); this run is an honest
  partial baseline over the SaaS backends.

## Repo scope

grug-local: grug's own SAST-benchmark harness, not a reusable cross-repo
workflow. Nothing here belongs in infra-public.

Refs #392
