### PR TITLE
fix(grug): benchmark uses a valid prompt variant so it produces a real baseline (#392)

### DIFF
--- a/services/webhook/sast_benchmark/runner.py
+++ b/services/webhook/sast_benchmark/runner.py
@@ -31,6 +31,10 @@ log = logging.getLogger("grug.sast_benchmark")
 
 _TIMEOUT_SECONDS = 90.0
 _RETRY_ATTEMPTS = 2
+# Measure the SHIPPED prompt. `_build_messages` keys `_SYSTEM_PROMPTS` by
+# PromptVariant ("v1"/"v2", #191 A/B); "v1" is the production default. Passing
+# a non-member (the old "benchmark") raises KeyError -> every sample errors.
+_BENCH_PROMPT_VARIANT = "v1"
 
 
 def _post(backend: BenchBackend, messages: list[dict[str, str]]) -> httpx.Response:
@@ -76,7 +80,7 @@ def run_sample(backend: BenchBackend, sample: CorpusSample) -> tuple[int, bool]:
     """
     hunks = [Hunk(path=sample.path, body=sample.diff_body)]
     try:
-        messages = _build_messages(hunks, "benchmark")
+        messages = _build_messages(hunks, _BENCH_PROMPT_VARIANT)
         resp = _post(backend, messages)
         findings, _model, err = _parse_response(resp)
     except Exception as e:  # noqa: BLE001 — one sample must not abort the sweep


### PR DESCRIPTION
## Why

The SAST benchmark (#392 gate) reported "ALL N samples errored - skipping" for
every backend. Root cause: `run_sample` called `_build_messages(hunks,
"benchmark")`, but `_build_messages` keys `_SYSTEM_PROMPTS` by `PromptVariant`
(`"v1"`/`"v2"`, the #191 A/B arms) - `"benchmark"` is not a member, so every
sample raised `KeyError` -> caught as `bench_sample_errored` -> the backend was
discarded as "all errored". The harness was authored but never run end-to-end,
so this stayed latent (pyright also flags the bad literal as a type error). This
is the second latent bug, after the missing-region import fix (#445).

## Summary

Use the shipped prompt variant `"v1"` (via a named `_BENCH_PROMPT_VARIANT`
constant) so the benchmark measures the prompt Elder actually runs in
production. No behavior change to Elder itself - this is benchmark-harness only.

## Test plan

- Ran the benchmark locally against Poolside after the fix: it now reaches the
  scoring path and reports **recall 0.78, precision 0.88** over the corpus (was:
  all 10 samples errored, no valid run).
- Per-class recall is non-degenerate (7/9 classes at 1.00; ssrf + weak-crypto at
  0.00), and one false positive is surfaced - i.e. the harness now produces a
  real, interpretable baseline rather than an empty one.
- After merge, re-dispatch `benchmark.sast` (record) on `main` to capture the
  official `baseline.json` artifact for committing.

## Size

XS

## Out of scope

- Improving Elder's SSRF / weak-crypto recall or the public-config-path false
  positive (that's the actual #392 model work the baseline now quantifies).
- Cave/sparkles backend (needs a tailnet key; SaaS-only partial baseline here).

## Repo scope

grug-local: grug's own SAST-benchmark harness, not a reusable cross-repo
workflow. Nothing for infra-public.

Refs #392
