### PR TITLE
chore(grug): record the first real SAST benchmark baseline (#392)

### DIFF
--- a/services/webhook/sast_benchmark/baseline.json
+++ b/services/webhook/sast_benchmark/baseline.json
@@ -1,4 +1,38 @@
 {
-  "_comment": "Recorded by the benchmark.sast.yml workflow_dispatch job (joins tailnet for sparkles, uses the free OpenRouter/Poolside key secrets). Empty until the first --record run; `python -m sast_benchmark --check` skips any backend with no baseline entry. Do not hand-edit recall numbers (AC4: no fabricated verdicts).",
-  "backends": {}
+  "backends": {
+    "openrouter": {
+      "backend": "openrouter",
+      "fp_flagged": [],
+      "overall_recall": 0.0,
+      "per_class_recall": {
+        "cleartext-secret-log": 0.0,
+        "command-injection": 0.0,
+        "hardcoded-credential": 0.0,
+        "path-traversal": 0.0,
+        "sql-injection": 0.0,
+        "ssrf": 0.0,
+        "template-injection": 0.0,
+        "unsafe-deserialization": 0.0,
+        "weak-crypto": 0.0
+      },
+      "precision": 1.0
+    },
+    "poolside": {
+      "backend": "poolside",
+      "fp_flagged": [],
+      "overall_recall": 0.7777777777777778,
+      "per_class_recall": {
+        "cleartext-secret-log": 1.0,
+        "command-injection": 1.0,
+        "hardcoded-credential": 1.0,
+        "path-traversal": 0.0,
+        "sql-injection": 1.0,
+        "ssrf": 1.0,
+        "template-injection": 1.0,
+        "unsafe-deserialization": 1.0,
+        "weak-crypto": 0.0
+      },
+      "precision": 1.0
+    }
+  }
 }


### PR DESCRIPTION
## Why

Records the first real SAST-benchmark baseline in-repo (the #392 gate). The
`benchmark.sast` harness was non-functional until this session's fixes (#445
missing AWS region at import; #446 invalid prompt variant -> all samples
errored); with those merged, run 27848698321 produced a valid baseline.

## Summary

Replace the placeholder `baseline.json` with the recorded run. Poolside
(Elder's production backend): **overall recall 0.78, precision 1.00**;
weak-crypto consistently missed, the other miss shifts run-to-run (LLM
nondeterminism). OpenRouter records 0.0 (unfunded / no useful output).
Cave/sparkles not benchmarked (no tailnet key) - honest partial baseline.

## Test plan

- `baseline.json` is the verbatim artifact from `benchmark.sast` run
  27848698321 on `main` (record mode), not hand-edited.
- Valid JSON matching the `sast_benchmark` baseline schema (backends ->
  per_class_recall / overall_recall / precision / fp_flagged).
- No code change; the per-PR `test_sast_benchmark` scoring tests are unaffected.

## Size

XS

## Out of scope

- Improving Elder recall (weak-crypto) or flipping `code_reviewer_blocking` -
  the baseline says stay advisory; those are follow-on #392 work.

## Repo scope

grug-local benchmark artifact; nothing for infra-public.

Refs #392
