### PR TITLE
feat(grug): IaC misconfiguration scanning on the PR diff (closes #447)

### DIFF
--- a/scripts/check-mirrored-files.sh
+++ b/scripts/check-mirrored-files.sh
@@ -47,6 +47,7 @@ MIRRORED_WITH_HEADER=(
   "personas/code_reviewer/judge.py"
   "personas/code_reviewer/persona.py"
   "personas/code_reviewer/reactions.py"
+  "personas/code_reviewer/iac_scan.py"
   "personas/code_reviewer/sast.py"
   "personas/code_reviewer/sca.py"
   "personas/tpm/dor_checks.py"

--- a/services/api/personas/code_reviewer/dispatch.py
+++ b/services/api/personas/code_reviewer/dispatch.py
@@ -48,6 +48,7 @@ from personas.code_reviewer.persona import (
     CodeReviewEvaluation, Finding, evaluate_diff, with_extra_findings,
 )
 from personas.code_reviewer.sast import judge_candidates, scan_candidates
+from personas.code_reviewer.iac_scan import scan_iac
 from personas.code_reviewer.sca import scan_dependencies
 from personas.code_reviewer.secret_scan import scan_secrets
 from adapters.install_store import put_comment_record  # type: ignore
@@ -572,6 +573,7 @@ def dispatch_code_review(
             scan_secrets(hunks)
             + scan_candidates(hunks, file_contents=file_contents)
             + scan_dependencies(hunks)
+            + scan_iac(hunks)
         )
         # The shared judge fail-closes ABOVE its cap: past `_JUDGE_MAX_FINDINGS`
         # it returns no verdicts and EVERY candidate is suppressed (a noisy PR

--- a/services/api/personas/code_reviewer/iac_scan.py
+++ b/services/api/personas/code_reviewer/iac_scan.py
@@ -1,0 +1,197 @@
+# MIRRORED — sibling at services/webhook/personas/code_reviewer/iac_scan.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Infrastructure-as-code misconfiguration detection for Elder (#447, ADR-0007
+Track 1 slice 2 - the IaC half; follows the secret-scan half #436).
+
+Flags insecure IaC a PR INTRODUCES on added lines, producing the SAME
+`Candidate` shape the SAST/SCA/secret pipeline uses, so the exploitability judge
+(`sast.judge_candidates`) and the publish path are reused unchanged - IaC
+scanning is just a new candidate SOURCE.
+
+Why a dedicated source: the vendored SAST ruleset is `languages: [python]`, and
+SCA/secret cover deps + credentials - an open security group, a privileged k8s
+container, a public S3 ACL, or a root Dockerfile is invisible today. This
+detector is diff-scoped (added lines only, like the other Track-1 sources) and
+FILE-TYPE-AWARE: Terraform patterns fire only on `*.tf`/`*.tfvars`, k8s/compose
+patterns only on `*.yaml`/`*.yml`, Dockerfile patterns only on Dockerfiles; a
+few cross-cutting patterns (open CIDR, world-writable, pipe-to-shell) fire on
+any IaC file.
+
+Recall-liberal by design (a detector miss is unrecoverable; an over-flag is
+recovered by the judge, which can confirm an open `0.0.0.0/0` is a public ALB
+by design vs an exposed admin port). The snippet carries the misconfig KIND +
+the trimmed line - IaC config is not a secret value, so the line is safe to
+publish.
+
+Pure: no IO, no network, no logging - deterministic + unit-tested.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .diff_parser import DiffHunk
+from .sast import IAC_MISCONFIG, Candidate
+
+__all__ = ["IAC_MISCONFIG", "scan_iac"]
+
+# Cost bounds, mirroring secret_scan: cap candidates, skip pathological lines,
+# and stop once the diff's added text exceeds a total byte budget.
+_MAX_FINDINGS = 100
+_MAX_LINE_LEN = 4096
+_MAX_SCAN_BYTES = 1_048_576
+
+# Published snippet line is trimmed to keep the finding message bounded.
+_SNIPPET_MAX = 200
+
+
+def _is_dockerfile(path: str) -> bool:
+    base = path.rsplit("/", 1)[-1].lower()
+    return base == "dockerfile" or base.startswith("dockerfile.") or base.endswith(".dockerfile")
+
+
+def _is_terraform(path: str) -> bool:
+    p = path.lower()
+    return p.endswith(".tf") or p.endswith(".tfvars")
+
+
+def _is_yaml(path: str) -> bool:
+    p = path.lower()
+    return p.endswith(".yaml") or p.endswith(".yml")
+
+
+def _is_iac(path: str) -> bool:
+    return _is_dockerfile(path) or _is_terraform(path) or _is_yaml(path)
+
+
+@dataclass(frozen=True, slots=True)
+class _Rule:
+    """A high-signal IaC misconfiguration. `kind` labels it for the snippet,
+    `regex` matches the offending construct, `applies` gates it by file type so
+    a k8s pattern never fires on Terraform (and vice versa)."""
+
+    kind: str
+    regex: re.Pattern[str]
+    applies: Callable[[str], bool]
+
+
+# Each rule is a recognizable insecure construct. Matching one is strong
+# evidence; the judge still confirms it is exploitable in context.
+_RULES: tuple[_Rule, ...] = (
+    # --- cross-cutting (any IaC file) ---
+    _Rule("network open to the world (0.0.0.0/0)", re.compile(r"0\.0\.0\.0/0"), _is_iac),
+    _Rule("IPv6 network open to the world (::/0)", re.compile(r"(?<![:\w])::/0"), _is_iac),
+    _Rule("world-writable permissions (chmod 777)", re.compile(r"chmod\s+(?:-R\s+)?0?777\b"), _is_iac),
+    _Rule("pipe-to-shell install", re.compile(r"(?:curl|wget)\b[^|\n]*\|\s*(?:sudo\s+)?(?:ba|z|d)?sh\b"), _is_iac),
+    # --- Kubernetes / compose YAML ---
+    _Rule("privileged container", re.compile(r"(?i)privileged:\s*true\b"), _is_yaml),
+    _Rule("host network namespace", re.compile(r"(?i)hostNetwork:\s*true\b"), _is_yaml),
+    _Rule("host PID namespace", re.compile(r"(?i)hostPID:\s*true\b"), _is_yaml),
+    _Rule("host IPC namespace", re.compile(r"(?i)hostIPC:\s*true\b"), _is_yaml),
+    _Rule("privilege escalation allowed", re.compile(r"(?i)allowPrivilegeEscalation:\s*true\b"), _is_yaml),
+    _Rule("container may run as root", re.compile(r"(?i)runAsNonRoot:\s*false\b"), _is_yaml),
+    _Rule("writable root filesystem", re.compile(r"(?i)readOnlyRootFilesystem:\s*false\b"), _is_yaml),
+    _Rule("TLS verification disabled", re.compile(r"(?i)insecure-?skip-?tls-?verify:\s*true\b"), _is_yaml),
+    # --- Terraform ---
+    _Rule("public object ACL", re.compile(r"""(?i)acl\s*=\s*["']public-read(?:-write)?["']"""), _is_terraform),
+    _Rule("resource publicly accessible", re.compile(r"(?i)publicly_accessible\s*=\s*true\b"), _is_terraform),
+    _Rule("encryption disabled", re.compile(r"(?i)(?:encrypted|encryption|storage_encrypted)\s*=\s*false\b"), _is_terraform),
+    _Rule("deletion protection disabled", re.compile(r"(?i)(?:deletion_protection|enable_deletion_protection)\s*=\s*false\b"), _is_terraform),
+    # --- Dockerfile ---
+    _Rule("container runs as root (USER root)", re.compile(r"(?im)^\s*USER\s+root\b"), _is_dockerfile),
+    _Rule("unpinned :latest base image", re.compile(r"(?im)^\s*FROM\s+\S+:latest\b"), _is_dockerfile),
+    _Rule("remote fetch into image (ADD <url>)", re.compile(r"(?im)^\s*ADD\s+https?://"), _is_dockerfile),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Misconfig:
+    """A detected IaC misconfiguration on an added line. `(file, line)` anchor it
+    to the diff; `kind` labels it; `snippet` is the trimmed offending line."""
+
+    file: str
+    line: int
+    kind: str
+    snippet: str
+
+
+def _added_lines(hunk: DiffHunk) -> list[tuple[int, str]]:
+    """[(new_side_line_number, added_text)] for added lines in a hunk. New-side
+    number advances on added/context lines, not on removed lines. (Mirrors
+    secret_scan's helper - duplicated rather than shared while the rule-of-three
+    extraction is deferred, per ADR-0001.)"""
+    out: list[tuple[int, str]] = []
+    lineno = hunk.new_start
+    for raw in hunk.body.splitlines():
+        if raw.startswith("@@") or raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            out.append((lineno, raw[1:]))
+            lineno += 1
+        elif raw.startswith("-"):
+            continue
+        else:
+            lineno += 1
+    return out
+
+
+def _detect(path: str, text: str) -> tuple[str, str] | None:
+    """Return `(kind, matched)` for the first rule that applies to this file
+    type AND matches the line, else None. `matched` is the exact substring, used
+    only for in-memory dedup."""
+    for rule in _RULES:
+        if not rule.applies(path):
+            continue
+        m = rule.regex.search(text)
+        if m:
+            return rule.kind, m.group(0)
+    return None
+
+
+def scan_iac(hunks: tuple[DiffHunk, ...]) -> tuple[Candidate, ...]:
+    """IaC-misconfig candidate source: a Candidate per insecure IaC construct a
+    PR introduces, on added lines of Terraform / k8s-compose YAML / Dockerfiles.
+    Diff-scoped, file-type-aware, content-deduped by `(file, kind, matched)` (a
+    repeated misconfig in a file is reported once - bounds judge cost), capped at
+    `_MAX_FINDINGS`. Same `Candidate` shape the SAST pipeline judges + publishes,
+    so the judge decides whether the misconfig is actually exploitable (vs an
+    intentional public endpoint)."""
+    found: list[_Misconfig] = []
+    seen: set[tuple[str, str, str]] = set()
+    scanned = 0
+    for hunk in hunks:
+        if not _is_iac(hunk.file_path):
+            continue
+        for lineno, text in _added_lines(hunk):
+            if len(text) > _MAX_LINE_LEN:
+                continue
+            scanned += len(text)
+            if scanned > _MAX_SCAN_BYTES:
+                return _to_candidates(found)
+            hit = _detect(hunk.file_path, text)
+            if hit is None:
+                continue
+            kind, matched = hit
+            key = (hunk.file_path, kind, matched)
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(
+                _Misconfig(file=hunk.file_path, line=lineno, kind=kind, snippet=text.strip()[:_SNIPPET_MAX])
+            )
+            if len(found) >= _MAX_FINDINGS:
+                return _to_candidates(found)
+    return _to_candidates(found)
+
+
+def _to_candidates(found: list[_Misconfig]) -> tuple[Candidate, ...]:
+    return tuple(
+        Candidate(
+            vuln_class=IAC_MISCONFIG,
+            file=m.file,
+            line=m.line,
+            snippet=f"{m.kind}: {m.snippet}",
+        )
+        for m in found
+    )

--- a/services/api/personas/code_reviewer/sast.py
+++ b/services/api/personas/code_reviewer/sast.py
@@ -43,6 +43,10 @@ CLEARTEXT_SECRET_LOG = "cleartext-secret-log"
 # (secret_scan imports Candidate from this module). secret_scan re-imports it.
 EXPOSED_SECRET = "exposed-secret"
 
+# IaC misconfiguration class (#447). Defined here (not in iac_scan) for the same
+# no-cycle reason as EXPOSED_SECRET; iac_scan re-imports it.
+IAC_MISCONFIG = "iac-misconfig"
+
 # A logging / print SINK on an added line. Covers the stdlib + common logger
 # idioms (`logging.info`, `log.warning`, `logger.debug`, `self.log.error`) and
 # bare `print(`. Deliberately broad — the judge filters non-exploitable hits.
@@ -280,6 +284,7 @@ _CLASS_LABELS: dict[str, str] = {
     "hardcoded-credential": "Hardcoded credential",
     "vulnerable-dependency": "Vulnerable dependency",
     "exposed-secret": "Exposed secret or credential",
+    "iac-misconfig": "Infrastructure-as-code misconfiguration",
 }
 
 

--- a/services/webhook/personas/code_reviewer/dispatch.py
+++ b/services/webhook/personas/code_reviewer/dispatch.py
@@ -48,6 +48,7 @@ from personas.code_reviewer.persona import (
     CodeReviewEvaluation, Finding, evaluate_diff, with_extra_findings,
 )
 from personas.code_reviewer.sast import judge_candidates, scan_candidates
+from personas.code_reviewer.iac_scan import scan_iac
 from personas.code_reviewer.sca import scan_dependencies
 from personas.code_reviewer.secret_scan import scan_secrets
 from adapters.install_store import put_comment_record  # type: ignore
@@ -572,6 +573,7 @@ def dispatch_code_review(
             scan_secrets(hunks)
             + scan_candidates(hunks, file_contents=file_contents)
             + scan_dependencies(hunks)
+            + scan_iac(hunks)
         )
         # The shared judge fail-closes ABOVE its cap: past `_JUDGE_MAX_FINDINGS`
         # it returns no verdicts and EVERY candidate is suppressed (a noisy PR

--- a/services/webhook/personas/code_reviewer/iac_scan.py
+++ b/services/webhook/personas/code_reviewer/iac_scan.py
@@ -1,0 +1,197 @@
+# MIRRORED — sibling at services/api/personas/code_reviewer/iac_scan.py; keep in lockstep. See docs/adr/0001-mirror-with-rule-of-three-deferral.md.
+"""Infrastructure-as-code misconfiguration detection for Elder (#447, ADR-0007
+Track 1 slice 2 - the IaC half; follows the secret-scan half #436).
+
+Flags insecure IaC a PR INTRODUCES on added lines, producing the SAME
+`Candidate` shape the SAST/SCA/secret pipeline uses, so the exploitability judge
+(`sast.judge_candidates`) and the publish path are reused unchanged - IaC
+scanning is just a new candidate SOURCE.
+
+Why a dedicated source: the vendored SAST ruleset is `languages: [python]`, and
+SCA/secret cover deps + credentials - an open security group, a privileged k8s
+container, a public S3 ACL, or a root Dockerfile is invisible today. This
+detector is diff-scoped (added lines only, like the other Track-1 sources) and
+FILE-TYPE-AWARE: Terraform patterns fire only on `*.tf`/`*.tfvars`, k8s/compose
+patterns only on `*.yaml`/`*.yml`, Dockerfile patterns only on Dockerfiles; a
+few cross-cutting patterns (open CIDR, world-writable, pipe-to-shell) fire on
+any IaC file.
+
+Recall-liberal by design (a detector miss is unrecoverable; an over-flag is
+recovered by the judge, which can confirm an open `0.0.0.0/0` is a public ALB
+by design vs an exposed admin port). The snippet carries the misconfig KIND +
+the trimmed line - IaC config is not a secret value, so the line is safe to
+publish.
+
+Pure: no IO, no network, no logging - deterministic + unit-tested.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from .diff_parser import DiffHunk
+from .sast import IAC_MISCONFIG, Candidate
+
+__all__ = ["IAC_MISCONFIG", "scan_iac"]
+
+# Cost bounds, mirroring secret_scan: cap candidates, skip pathological lines,
+# and stop once the diff's added text exceeds a total byte budget.
+_MAX_FINDINGS = 100
+_MAX_LINE_LEN = 4096
+_MAX_SCAN_BYTES = 1_048_576
+
+# Published snippet line is trimmed to keep the finding message bounded.
+_SNIPPET_MAX = 200
+
+
+def _is_dockerfile(path: str) -> bool:
+    base = path.rsplit("/", 1)[-1].lower()
+    return base == "dockerfile" or base.startswith("dockerfile.") or base.endswith(".dockerfile")
+
+
+def _is_terraform(path: str) -> bool:
+    p = path.lower()
+    return p.endswith(".tf") or p.endswith(".tfvars")
+
+
+def _is_yaml(path: str) -> bool:
+    p = path.lower()
+    return p.endswith(".yaml") or p.endswith(".yml")
+
+
+def _is_iac(path: str) -> bool:
+    return _is_dockerfile(path) or _is_terraform(path) or _is_yaml(path)
+
+
+@dataclass(frozen=True, slots=True)
+class _Rule:
+    """A high-signal IaC misconfiguration. `kind` labels it for the snippet,
+    `regex` matches the offending construct, `applies` gates it by file type so
+    a k8s pattern never fires on Terraform (and vice versa)."""
+
+    kind: str
+    regex: re.Pattern[str]
+    applies: Callable[[str], bool]
+
+
+# Each rule is a recognizable insecure construct. Matching one is strong
+# evidence; the judge still confirms it is exploitable in context.
+_RULES: tuple[_Rule, ...] = (
+    # --- cross-cutting (any IaC file) ---
+    _Rule("network open to the world (0.0.0.0/0)", re.compile(r"0\.0\.0\.0/0"), _is_iac),
+    _Rule("IPv6 network open to the world (::/0)", re.compile(r"(?<![:\w])::/0"), _is_iac),
+    _Rule("world-writable permissions (chmod 777)", re.compile(r"chmod\s+(?:-R\s+)?0?777\b"), _is_iac),
+    _Rule("pipe-to-shell install", re.compile(r"(?:curl|wget)\b[^|\n]*\|\s*(?:sudo\s+)?(?:ba|z|d)?sh\b"), _is_iac),
+    # --- Kubernetes / compose YAML ---
+    _Rule("privileged container", re.compile(r"(?i)privileged:\s*true\b"), _is_yaml),
+    _Rule("host network namespace", re.compile(r"(?i)hostNetwork:\s*true\b"), _is_yaml),
+    _Rule("host PID namespace", re.compile(r"(?i)hostPID:\s*true\b"), _is_yaml),
+    _Rule("host IPC namespace", re.compile(r"(?i)hostIPC:\s*true\b"), _is_yaml),
+    _Rule("privilege escalation allowed", re.compile(r"(?i)allowPrivilegeEscalation:\s*true\b"), _is_yaml),
+    _Rule("container may run as root", re.compile(r"(?i)runAsNonRoot:\s*false\b"), _is_yaml),
+    _Rule("writable root filesystem", re.compile(r"(?i)readOnlyRootFilesystem:\s*false\b"), _is_yaml),
+    _Rule("TLS verification disabled", re.compile(r"(?i)insecure-?skip-?tls-?verify:\s*true\b"), _is_yaml),
+    # --- Terraform ---
+    _Rule("public object ACL", re.compile(r"""(?i)acl\s*=\s*["']public-read(?:-write)?["']"""), _is_terraform),
+    _Rule("resource publicly accessible", re.compile(r"(?i)publicly_accessible\s*=\s*true\b"), _is_terraform),
+    _Rule("encryption disabled", re.compile(r"(?i)(?:encrypted|encryption|storage_encrypted)\s*=\s*false\b"), _is_terraform),
+    _Rule("deletion protection disabled", re.compile(r"(?i)(?:deletion_protection|enable_deletion_protection)\s*=\s*false\b"), _is_terraform),
+    # --- Dockerfile ---
+    _Rule("container runs as root (USER root)", re.compile(r"(?im)^\s*USER\s+root\b"), _is_dockerfile),
+    _Rule("unpinned :latest base image", re.compile(r"(?im)^\s*FROM\s+\S+:latest\b"), _is_dockerfile),
+    _Rule("remote fetch into image (ADD <url>)", re.compile(r"(?im)^\s*ADD\s+https?://"), _is_dockerfile),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _Misconfig:
+    """A detected IaC misconfiguration on an added line. `(file, line)` anchor it
+    to the diff; `kind` labels it; `snippet` is the trimmed offending line."""
+
+    file: str
+    line: int
+    kind: str
+    snippet: str
+
+
+def _added_lines(hunk: DiffHunk) -> list[tuple[int, str]]:
+    """[(new_side_line_number, added_text)] for added lines in a hunk. New-side
+    number advances on added/context lines, not on removed lines. (Mirrors
+    secret_scan's helper - duplicated rather than shared while the rule-of-three
+    extraction is deferred, per ADR-0001.)"""
+    out: list[tuple[int, str]] = []
+    lineno = hunk.new_start
+    for raw in hunk.body.splitlines():
+        if raw.startswith("@@") or raw.startswith("+++") or raw.startswith("---"):
+            continue
+        if raw.startswith("+"):
+            out.append((lineno, raw[1:]))
+            lineno += 1
+        elif raw.startswith("-"):
+            continue
+        else:
+            lineno += 1
+    return out
+
+
+def _detect(path: str, text: str) -> tuple[str, str] | None:
+    """Return `(kind, matched)` for the first rule that applies to this file
+    type AND matches the line, else None. `matched` is the exact substring, used
+    only for in-memory dedup."""
+    for rule in _RULES:
+        if not rule.applies(path):
+            continue
+        m = rule.regex.search(text)
+        if m:
+            return rule.kind, m.group(0)
+    return None
+
+
+def scan_iac(hunks: tuple[DiffHunk, ...]) -> tuple[Candidate, ...]:
+    """IaC-misconfig candidate source: a Candidate per insecure IaC construct a
+    PR introduces, on added lines of Terraform / k8s-compose YAML / Dockerfiles.
+    Diff-scoped, file-type-aware, content-deduped by `(file, kind, matched)` (a
+    repeated misconfig in a file is reported once - bounds judge cost), capped at
+    `_MAX_FINDINGS`. Same `Candidate` shape the SAST pipeline judges + publishes,
+    so the judge decides whether the misconfig is actually exploitable (vs an
+    intentional public endpoint)."""
+    found: list[_Misconfig] = []
+    seen: set[tuple[str, str, str]] = set()
+    scanned = 0
+    for hunk in hunks:
+        if not _is_iac(hunk.file_path):
+            continue
+        for lineno, text in _added_lines(hunk):
+            if len(text) > _MAX_LINE_LEN:
+                continue
+            scanned += len(text)
+            if scanned > _MAX_SCAN_BYTES:
+                return _to_candidates(found)
+            hit = _detect(hunk.file_path, text)
+            if hit is None:
+                continue
+            kind, matched = hit
+            key = (hunk.file_path, kind, matched)
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(
+                _Misconfig(file=hunk.file_path, line=lineno, kind=kind, snippet=text.strip()[:_SNIPPET_MAX])
+            )
+            if len(found) >= _MAX_FINDINGS:
+                return _to_candidates(found)
+    return _to_candidates(found)
+
+
+def _to_candidates(found: list[_Misconfig]) -> tuple[Candidate, ...]:
+    return tuple(
+        Candidate(
+            vuln_class=IAC_MISCONFIG,
+            file=m.file,
+            line=m.line,
+            snippet=f"{m.kind}: {m.snippet}",
+        )
+        for m in found
+    )

--- a/services/webhook/personas/code_reviewer/sast.py
+++ b/services/webhook/personas/code_reviewer/sast.py
@@ -43,6 +43,10 @@ CLEARTEXT_SECRET_LOG = "cleartext-secret-log"
 # (secret_scan imports Candidate from this module). secret_scan re-imports it.
 EXPOSED_SECRET = "exposed-secret"
 
+# IaC misconfiguration class (#447). Defined here (not in iac_scan) for the same
+# no-cycle reason as EXPOSED_SECRET; iac_scan re-imports it.
+IAC_MISCONFIG = "iac-misconfig"
+
 # A logging / print SINK on an added line. Covers the stdlib + common logger
 # idioms (`logging.info`, `log.warning`, `logger.debug`, `self.log.error`) and
 # bare `print(`. Deliberately broad — the judge filters non-exploitable hits.
@@ -280,6 +284,7 @@ _CLASS_LABELS: dict[str, str] = {
     "hardcoded-credential": "Hardcoded credential",
     "vulnerable-dependency": "Vulnerable dependency",
     "exposed-secret": "Exposed secret or credential",
+    "iac-misconfig": "Infrastructure-as-code misconfiguration",
 }
 
 

--- a/services/webhook/tests/test_iac_scan.py
+++ b/services/webhook/tests/test_iac_scan.py
@@ -1,0 +1,144 @@
+"""Tests for iac_scan — IaC misconfiguration detection (#447, ADR-0007 Track 1).
+
+Covers: per-file-type recall, file-type-AWARENESS (a k8s pattern must not fire
+on Terraform and vice versa), diff-scoping (added lines only), dedup, cost
+bounds, the IAC_MISCONFIG vuln_class, and that the source flows through the
+existing dispatch concatenation.
+"""
+
+from __future__ import annotations
+
+from personas.code_reviewer.diff_parser import parse_diff
+from personas.code_reviewer.iac_scan import IAC_MISCONFIG, scan_iac
+
+
+def _hunks(diff):
+    return parse_diff(diff)
+
+
+def _diff(path, *added):
+    body = "".join(f"+{line}\n" for line in added)
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n+++ b/{path}\n"
+        f"@@ -0,0 +1,{len(added)} @@\n"
+        f"{body}"
+    )
+
+
+# --- per-file-type recall ---------------------------------------------------
+
+
+def test_flags_open_cidr_in_terraform():
+    cands = scan_iac(_hunks(_diff("main.tf", '  cidr_blocks = ["0.0.0.0/0"]')))
+    assert len(cands) == 1
+    assert cands[0].vuln_class == IAC_MISCONFIG
+    assert cands[0].file == "main.tf"
+    assert "0.0.0.0/0" in cands[0].snippet
+
+
+def test_flags_privileged_container_in_k8s_yaml():
+    cands = scan_iac(_hunks(_diff("deploy.yaml", "    privileged: true")))
+    assert len(cands) == 1
+    assert "privileged" in cands[0].snippet
+
+
+def test_flags_run_as_root_and_host_network():
+    cands = scan_iac(_hunks(_diff(
+        "pod.yml",
+        "      runAsNonRoot: false",
+        "  hostNetwork: true",
+    )))
+    kinds = " ".join(c.snippet for c in cands)
+    assert len(cands) == 2
+    assert "root" in kinds and "host network" in kinds
+
+
+def test_flags_public_acl_in_terraform():
+    cands = scan_iac(_hunks(_diff("s3.tf", '  acl = "public-read-write"')))
+    assert len(cands) == 1
+    assert "public" in cands[0].snippet.lower()
+
+
+def test_flags_dockerfile_user_root_and_latest():
+    cands = scan_iac(_hunks(_diff(
+        "Dockerfile",
+        "FROM python:latest",
+        "USER root",
+    )))
+    assert len(cands) == 2
+
+
+def test_flags_pipe_to_shell_anywhere():
+    cands = scan_iac(_hunks(_diff("Dockerfile", "RUN curl https://x.sh | sudo bash")))
+    assert len(cands) == 1
+    assert "pipe-to-shell" in cands[0].snippet
+
+
+# --- file-type AWARENESS (no cross-firing) ----------------------------------
+
+
+def test_k8s_pattern_does_not_fire_on_terraform():
+    # `privileged: true` is a k8s shape; on a .tf file it must NOT match.
+    cands = scan_iac(_hunks(_diff("main.tf", "  privileged: true")))
+    assert cands == ()
+
+
+def test_dockerfile_pattern_does_not_fire_on_yaml():
+    cands = scan_iac(_hunks(_diff("values.yaml", "USER root")))
+    assert cands == ()
+
+
+def test_non_iac_file_is_skipped_entirely():
+    # A python file containing a k8s-looking line is not IaC — skip it whole.
+    cands = scan_iac(_hunks(_diff("app.py", "    privileged = True  # privileged: true")))
+    assert cands == ()
+
+
+# --- diff-scoping, dedup, clean config --------------------------------------
+
+
+def test_only_added_lines_are_scanned():
+    # A removed `0.0.0.0/0` (a PR CLOSING an open CIDR) must not be flagged.
+    diff = (
+        "diff --git a/main.tf b/main.tf\n--- a/main.tf\n+++ b/main.tf\n"
+        "@@ -1,2 +1,2 @@\n"
+        '-  cidr_blocks = ["0.0.0.0/0"]\n'
+        '+  cidr_blocks = ["10.0.0.0/8"]\n'
+    )
+    assert scan_iac(_hunks(diff)) == ()
+
+
+def test_same_misconfig_twice_is_deduped():
+    cands = scan_iac(_hunks(_diff(
+        "sg.tf",
+        '  ingress { cidr_blocks = ["0.0.0.0/0"] }',
+        '  egress  { cidr_blocks = ["0.0.0.0/0"] }',
+    )))
+    assert len(cands) == 1  # same (file, kind, matched) -> one candidate
+
+
+def test_clean_config_produces_no_candidates():
+    cands = scan_iac(_hunks(_diff(
+        "deploy.yaml",
+        "    runAsNonRoot: true",
+        "    privileged: false",
+        "    readOnlyRootFilesystem: true",
+    )))
+    assert cands == ()
+
+
+def test_empty_input():
+    assert scan_iac(()) == ()
+
+
+# --- the source is wired into dispatch --------------------------------------
+
+
+def test_scan_iac_is_in_dispatch_concatenation():
+    import inspect
+
+    from personas.code_reviewer import dispatch
+
+    src = inspect.getsource(dispatch)
+    assert "scan_iac(hunks)" in src, "scan_iac must be concatenated into the candidate sources"


### PR DESCRIPTION
## Why

The vendored SAST ruleset is `languages: [python]`, and SCA/secret-scan cover
deps + credentials -- but an insecure infrastructure change a PR introduces (a
security group open to `0.0.0.0/0`, a privileged k8s container, a public S3
ACL, a root Dockerfile) is invisible to Elder today. IaC misconfig is the named
next class in ADR-0007 Track 1 (epic #433), after SCA (#434) and secrets (#436).

## Summary

New pure, diff-scoped, file-type-aware candidate source `iac_scan.scan_iac`,
mirroring `secret_scan`: flags high-signal IaC misconfigs on added lines of
Terraform / k8s-compose YAML / Dockerfiles, producing the same `Candidate`
shape so the exploitability judge decides whether the misconfig is real (a
`0.0.0.0/0` on a public ALB vs an exposed admin port) and the existing
advisory-publish path is reused. New `IAC_MISCONFIG` vuln_class in `sast.py`
(defined there like `EXPOSED_SECRET`, to avoid an import cycle), wired into the
`dispatch` candidate concatenation, cost-bounded like `secret_scan`. No change
to Elder's behavior on non-IaC files.

## Test plan

- 14 new unit tests (`test_iac_scan.py`): per-file-type recall (open CIDR / k8s
  privileged+hostNetwork+runAsNonRoot / TF public ACL / Dockerfile root+latest /
  pipe-to-shell).
- File-type AWARENESS: a k8s pattern does NOT fire on `.tf`, a Dockerfile
  pattern does NOT fire on `.yaml`, and a non-IaC file (`.py`) is skipped whole.
- Diff-scoping (a REMOVED `0.0.0.0/0` is not flagged), dedup (same misconfig
  twice -> one candidate), clean-config no-fire, and a wiring test asserting
  `scan_iac` is in the dispatch concatenation.
- Full webhook suite: 750 passed, 2 skipped (no regressions). `services/api` +
  `services/webhook` body-identical; `scripts/check-mirrored-files.sh` passes
  (33 pairs, iac_scan added to the enforced list). api-side import smoke OK.

## Size

M

## Out of scope

- Full Semgrep IaC rule packs (this is the high-signal builtin detector; a
  Semgrep-engine IaC ruleset can follow behind the same boundary later).
- Cross-file / repo-graph static depth (slice 3, epic #433).

closes #447
