### PR TITLE
fix(grug): cf_auth throttle drops first warning in first 60s after boot (#359)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,24 +31,12 @@ test: webhook-test api-test
 webhook-test:
 	@if [ -n "$$CI" ] && [ -z "$$GRUG_TEST_DATABASE_URL" ]; then \
 		echo "FATAL: store-backed tests would SKIP in CI (GRUG_TEST_DATABASE_URL unset) - a skipped gate is a silent pass (audit H4)"; exit 1; fi
-	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum --with 'psycopg[binary,pool]' --with 'ddtrace>=3.5,<4' --with 'datadog-lambda>=6.107,<7' pytest tests/ -q \
-		--deselect tests/test_cf_auth.py::test_unconfigured_warning_throttled_within_window \
-		--deselect tests/test_cf_auth.py::test_throttle_distinguishes_reasons
-	# ^ cf_auth throttle pair: hosted-runner-only intermittent 0-warnings,
-	# locally irreproducible across versions/order/env - #359 root-causes.
-	# (#356 dispatcher/enforcement quartet restored: the unmocked store
-	# boundary is now patched like every sibling test.) Do NOT widen this
-	# list without an issue.
+	cd services/webhook && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with fastapi --with mangum --with 'psycopg[binary,pool]' --with 'ddtrace>=3.5,<4' --with 'datadog-lambda>=6.107,<7' pytest tests/ -q
 
 api-test:
 	@if [ -n "$$CI" ] && [ -z "$$GRUG_TEST_DATABASE_URL" ]; then \
 		echo "FATAL: store-backed tests would SKIP in CI (GRUG_TEST_DATABASE_URL unset) - a skipped gate is a silent pass (audit H4)"; exit 1; fi
-	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum --with 'psycopg[binary,pool]' pytest tests/ -q \
-		--deselect tests/test_cf_auth.py::test_unconfigured_warning_throttled_within_window \
-		--deselect tests/test_cf_auth.py::test_throttle_distinguishes_reasons
-	# ^ cf_auth throttle pair: hosted-runner-only flake, #359 (twin of webhook).
-	# (#356 update_config pair restored: the unmocked previous_cfg store
-	# read is now patched.)
+	cd services/api && uv run --with pytest --with httpx --with pyjwt --with cryptography --with boto3 --with moto --with pydantic --with fastapi --with mangum --with 'psycopg[binary,pool]' pytest tests/ -q
 
 # Real-Postgres store tests (#354). REQUIRE a reachable Postgres via
 # GRUG_TEST_DATABASE_URL (CI: workflow service container) - they skip

--- a/services/api/cf_auth.py
+++ b/services/api/cf_auth.py
@@ -218,7 +218,14 @@ def _log_unconfigured_throttled(reason: str, path: str) -> None:
     independently).
     """
     now = time.monotonic()
-    last = _last_unconfigured_log_at.get(reason, 0.0)
+    # -inf, NOT 0.0: the comparison is against time.monotonic() (seconds since
+    # BOOT, not epoch). On a freshly-booted pod/runner monotonic() can be < the
+    # throttle window, so a 0.0 default makes `now - 0.0 < WINDOW` True and
+    # SILENTLY DROPS the FIRST warning per reason - exactly the
+    # `cf_shared_secret_unconfigured` misconfig signal you want during a rollout.
+    # -inf means the first occurrence of each reason always logs. (#359: this was
+    # the green-local / red-CI flake, NOT a ddtrace logger-rebinding race.)
+    last = _last_unconfigured_log_at.get(reason, float("-inf"))
     if now - last < _LOG_THROTTLE_SECONDS:
         return
     _last_unconfigured_log_at[reason] = now

--- a/services/api/tests/test_cf_auth.py
+++ b/services/api/tests/test_cf_auth.py
@@ -303,8 +303,9 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     — the exact bug the throttle was introduced to prevent.
     """
     # Module-global throttle state: clear it so this test is
-    # order-independent (same latent hole surfaced in the webhook twin
-    # on PR #358).
+    # order-independent (a fail-open warning from ANY earlier test
+    # within the 60s window otherwise suppresses ours - surfaced as a
+    # branch-dependent flake on PR #358).
     cf_auth._last_unconfigured_log_at.clear()
     def raise_unconfigured():
         raise LookupError("env var unset")
@@ -312,7 +313,11 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     app = _build_app(secret_loader=raise_unconfigured)
     client = TestClient(app)
 
-    with patch.object(cf_auth.log, "warning") as mock_warn:
+    # Patch the WHOLE module logger, not `.warning` on it: under ddtrace
+    # log-injection the logger's bound methods can be rebound, so patching the
+    # attribute can race on slower runners (the #359 suspect). Swapping the
+    # whole `cf_auth.log` object is immune to that.
+    with patch.object(cf_auth, "log") as mock_log:
         # First request: should log. (Default fail-CLOSED -> 503.)
         r1 = client.get("/protected")
         assert r1.status_code == 503
@@ -320,8 +325,8 @@ def test_unconfigured_warning_throttled_within_window() -> None:
         r2 = client.get("/protected")
         assert r2.status_code == 503
 
-    assert mock_warn.call_count == 1, (
-        f"throttle did not suppress duplicate log: {mock_warn.call_count} calls"
+    assert mock_log.warning.call_count == 1, (
+        f"throttle did not suppress duplicate log: {mock_log.warning.call_count} calls"
     )
 
 
@@ -331,8 +336,9 @@ def test_throttle_distinguishes_reasons() -> None:
     signals, each deserving its own first log.
     """
     # Module-global throttle state: clear it so this test is
-    # order-independent (same latent hole surfaced in the webhook twin
-    # on PR #358).
+    # order-independent (a fail-open warning from ANY earlier test
+    # within the 60s window otherwise suppresses ours - surfaced as a
+    # branch-dependent flake on PR #358).
     cf_auth._last_unconfigured_log_at.clear()
     # Custom loader: first call raises LookupError, second returns "".
     state = {"calls": 0}
@@ -346,7 +352,11 @@ def test_throttle_distinguishes_reasons() -> None:
     app = _build_app(secret_loader=loader_two_reasons)
     client = TestClient(app)
 
-    with patch.object(cf_auth.log, "warning") as mock_warn:
+    # Patch the WHOLE module logger, not `.warning` on it: under ddtrace
+    # log-injection the logger's bound methods can be rebound, so patching the
+    # attribute can race on slower runners (the #359 suspect). Swapping the
+    # whole `cf_auth.log` object is immune to that.
+    with patch.object(cf_auth, "log") as mock_log:
         r1 = client.get("/protected")
         r2 = client.get("/protected")
         # Default fail-CLOSED -> 503 for both reasons.
@@ -354,4 +364,4 @@ def test_throttle_distinguishes_reasons() -> None:
         assert r2.status_code == 503
 
     # Two distinct reasons -> two distinct first-logs.
-    assert mock_warn.call_count == 2
+    assert mock_log.warning.call_count == 2

--- a/services/webhook/cf_auth.py
+++ b/services/webhook/cf_auth.py
@@ -218,7 +218,14 @@ def _log_unconfigured_throttled(reason: str, path: str) -> None:
     independently).
     """
     now = time.monotonic()
-    last = _last_unconfigured_log_at.get(reason, 0.0)
+    # -inf, NOT 0.0: the comparison is against time.monotonic() (seconds since
+    # BOOT, not epoch). On a freshly-booted pod/runner monotonic() can be < the
+    # throttle window, so a 0.0 default makes `now - 0.0 < WINDOW` True and
+    # SILENTLY DROPS the FIRST warning per reason - exactly the
+    # `cf_shared_secret_unconfigured` misconfig signal you want during a rollout.
+    # -inf means the first occurrence of each reason always logs. (#359: this was
+    # the green-local / red-CI flake, NOT a ddtrace logger-rebinding race.)
+    last = _last_unconfigured_log_at.get(reason, float("-inf"))
     if now - last < _LOG_THROTTLE_SECONDS:
         return
     _last_unconfigured_log_at[reason] = now

--- a/services/webhook/tests/test_cf_auth.py
+++ b/services/webhook/tests/test_cf_auth.py
@@ -313,7 +313,11 @@ def test_unconfigured_warning_throttled_within_window() -> None:
     app = _build_app(secret_loader=raise_unconfigured)
     client = TestClient(app)
 
-    with patch.object(cf_auth.log, "warning") as mock_warn:
+    # Patch the WHOLE module logger, not `.warning` on it: under ddtrace
+    # log-injection the logger's bound methods can be rebound, so patching the
+    # attribute can race on slower runners (the #359 suspect). Swapping the
+    # whole `cf_auth.log` object is immune to that.
+    with patch.object(cf_auth, "log") as mock_log:
         # First request: should log. (Default fail-CLOSED -> 503.)
         r1 = client.get("/protected")
         assert r1.status_code == 503
@@ -321,8 +325,8 @@ def test_unconfigured_warning_throttled_within_window() -> None:
         r2 = client.get("/protected")
         assert r2.status_code == 503
 
-    assert mock_warn.call_count == 1, (
-        f"throttle did not suppress duplicate log: {mock_warn.call_count} calls"
+    assert mock_log.warning.call_count == 1, (
+        f"throttle did not suppress duplicate log: {mock_log.warning.call_count} calls"
     )
 
 
@@ -348,7 +352,11 @@ def test_throttle_distinguishes_reasons() -> None:
     app = _build_app(secret_loader=loader_two_reasons)
     client = TestClient(app)
 
-    with patch.object(cf_auth.log, "warning") as mock_warn:
+    # Patch the WHOLE module logger, not `.warning` on it: under ddtrace
+    # log-injection the logger's bound methods can be rebound, so patching the
+    # attribute can race on slower runners (the #359 suspect). Swapping the
+    # whole `cf_auth.log` object is immune to that.
+    with patch.object(cf_auth, "log") as mock_log:
         r1 = client.get("/protected")
         r2 = client.get("/protected")
         # Default fail-CLOSED -> 503 for both reasons.
@@ -356,4 +364,4 @@ def test_throttle_distinguishes_reasons() -> None:
         assert r2.status_code == 503
 
     # Two distinct reasons -> two distinct first-logs.
-    assert mock_warn.call_count == 2
+    assert mock_log.warning.call_count == 2


### PR DESCRIPTION
## Why

Two cf_auth throttle tests (`test_unconfigured_warning_throttled_within_window`,
`test_throttle_distinguishes_reasons`) flaked **hosted-runner-only** with 0
warnings observed, never reproducible locally -- and were deselected in
webhook-test + api-test pending #359. The suspected cause (ddtrace logger
rebinding) was a red herring. The real bug is the SAME class as #412's
trace-flush flake: `_log_unconfigured_throttled` defaulted
`_last_unconfigured_log_at[reason]` to `0.0` and compared against
`time.monotonic()` (seconds since BOOT). On a freshly-booted runner where
`monotonic() < 60`, `now - 0.0 < 60` is True, so the FIRST
`cf_shared_secret_unconfigured` warning per reason is silently dropped -> 0
warnings -> red. A long-up dev box has a huge `monotonic()`, so it passes.

This is also a real **production** bug: a pod drops its first misconfig warning
in its first 60s -- exactly during a rollout window.

## Summary

- Default the throttle sentinel to `float('-inf')` so the first occurrence of
  each reason always logs, regardless of the clock's since-boot value.
- Harden the two tests off the ddtrace suspect: patch the WHOLE `cf_auth.log`
  rather than its `.warning` attribute (immune to any logger-method rebinding).
- Remove the Makefile deselects (webhook + api) so the tests run again.
- Mirror `cf_auth.py` to `services/api` (body-identical; drift-lint passes).

## Test plan

- Reproduced the cause locally: with `monotonic()` mocked to 5s, the `-inf`
  default yields 1 warning (the `0.0` default would yield 0 -- the flake).
- Both restored tests pass; full `cf_auth` suite 21 passed.
- Full webhook suite 736 passed, 2 skipped (store-backed) with the deselects
  removed -- no regressions.
- `services/webhook` + `services/api` `cf_auth.py` body-identical;
  `check-mirrored-files.sh` passes.

## Size

S

## Out of scope

- The "10 consecutive green CI runs" observation in #359's AC -- a post-merge
  monitoring step, not a code change; this PR fixes the root cause so they
  should now be deterministic. Leaving #359 open to confirm that tail.

## Repo scope

grug-local webhook/api service code; nothing for infra-public.

Refs #359
