### PR TITLE
feat(elder): monotonic-zero-sentinel rule (boot-window throttle drop)

### DIFF
--- a/services/api/code_review_prompt.py
+++ b/services/api/code_review_prompt.py
@@ -346,6 +346,26 @@ RULES: tuple[ReviewRule, ...] = (
         good_example="subprocess.run(cmd, capture_output=True, timeout=600)",
         severity="medium",
     ),
+    # ── weekly harvest: monotonic-clock throttle sentinel (grug #450, #444) ──
+    ReviewRule(
+        name="monotonic-zero-sentinel",
+        bug_class="correctness",
+        description="A rate-limit / throttle / debounce whose 'last fired' "
+        "timestamp is initialized to 0 / 0.0 and then compared against "
+        "time.monotonic() / time.perf_counter() — both are SECONDS-SINCE-BOOT, "
+        "not epoch. On a freshly-booted pod/runner monotonic() can be SMALLER "
+        "than the interval, so `now - 0.0 < WINDOW` (or `now - 0.0 > INTERVAL` "
+        "being False) holds and the FIRST event in the first window after boot "
+        "is silently suppressed — exactly the startup / rollout misconfig signal "
+        "you most want to see. Initialize the sentinel to float('-inf') so the "
+        "first occurrence per key always fires. (A 0.0 sentinel is correct only "
+        "when compared against time.time()/epoch.)",
+        bad_example="_last = 0.0  # vs time.monotonic(): drops first event after boot\n"
+        "if time.monotonic() - _last < WINDOW: return",
+        good_example="_last = float('-inf')\n"
+        "if time.monotonic() - _last < WINDOW: return",
+        severity="medium",
+    ),
 )
 
 

--- a/services/api/tests/test_code_review_prompt.py
+++ b/services/api/tests/test_code_review_prompt.py
@@ -171,3 +171,12 @@ def test_subprocess_no_timeout_rule_present():
     provider hangs the whole chain (claude-stuff #356, #368)."""
     assert any(r.name == "subprocess-no-timeout" for r in crp.RULES)
     assert "subprocess-no-timeout" in crp.build_system_prompt()
+
+
+def test_monotonic_zero_sentinel_rule_present():
+    """Weekly harvest: a throttle/rate-limit sentinel initialized to 0.0 but
+    compared against time.monotonic() (since-boot, not epoch) silently drops
+    the FIRST event in the first window after boot — fix is float('-inf')
+    (grug #450 cf_auth, #444 trace-flush)."""
+    assert any(r.name == "monotonic-zero-sentinel" for r in crp.RULES)
+    assert "monotonic-zero-sentinel" in crp.build_system_prompt()

--- a/services/webhook/code_review_prompt.py
+++ b/services/webhook/code_review_prompt.py
@@ -346,6 +346,26 @@ RULES: tuple[ReviewRule, ...] = (
         good_example="subprocess.run(cmd, capture_output=True, timeout=600)",
         severity="medium",
     ),
+    # ── weekly harvest: monotonic-clock throttle sentinel (grug #450, #444) ──
+    ReviewRule(
+        name="monotonic-zero-sentinel",
+        bug_class="correctness",
+        description="A rate-limit / throttle / debounce whose 'last fired' "
+        "timestamp is initialized to 0 / 0.0 and then compared against "
+        "time.monotonic() / time.perf_counter() — both are SECONDS-SINCE-BOOT, "
+        "not epoch. On a freshly-booted pod/runner monotonic() can be SMALLER "
+        "than the interval, so `now - 0.0 < WINDOW` (or `now - 0.0 > INTERVAL` "
+        "being False) holds and the FIRST event in the first window after boot "
+        "is silently suppressed — exactly the startup / rollout misconfig signal "
+        "you most want to see. Initialize the sentinel to float('-inf') so the "
+        "first occurrence per key always fires. (A 0.0 sentinel is correct only "
+        "when compared against time.time()/epoch.)",
+        bad_example="_last = 0.0  # vs time.monotonic(): drops first event after boot\n"
+        "if time.monotonic() - _last < WINDOW: return",
+        good_example="_last = float('-inf')\n"
+        "if time.monotonic() - _last < WINDOW: return",
+        severity="medium",
+    ),
 )
 
 

--- a/services/webhook/tests/test_code_review_prompt.py
+++ b/services/webhook/tests/test_code_review_prompt.py
@@ -203,6 +203,15 @@ def test_subprocess_no_timeout_rule_present():
     assert "subprocess-no-timeout" in crp.build_system_prompt()
 
 
+def test_monotonic_zero_sentinel_rule_present():
+    """Weekly harvest: a throttle/rate-limit sentinel initialized to 0.0 but
+    compared against time.monotonic() (since-boot, not epoch) silently drops
+    the FIRST event in the first window after boot — fix is float('-inf')
+    (grug #450 cf_auth, #444 trace-flush)."""
+    assert any(r.name == "monotonic-zero-sentinel" for r in crp.RULES)
+    assert "monotonic-zero-sentinel" in crp.build_system_prompt()
+
+
 def test_voice_has_mandatory_bookend_structure():
     """#343: the voice instruction mandates the structural bookends that
     keep the caveman cadence from slipping to plain English under technical


### PR DESCRIPTION
## Why / Summary

Weekly pattern-harvest. Two merged fix PRs the SAME week fixed the identical bug shape, so it earns an Elder rule that enforces on every PR fleet-wide:

- **#450** `fix(grug): cf_auth throttle drops first warning in first 60s after boot` — `_last_unconfigured_log_at.get(reason, 0.0)` compared against `time.monotonic()`.
- **#444** `fix(grug): trace-flush warning dropped in first 60s after boot` — `_last_flush_warn = 0.0` compared against `time.monotonic()`.

In both, the throttle "last fired" sentinel was `0.0`, but the comparison is against `time.monotonic()` — **seconds since boot, not epoch**. On a freshly-booted pod/runner `monotonic()` can be smaller than the window, so `now - 0.0 < WINDOW` (or `now - 0.0 > INTERVAL` being False) holds and the **first** event in the first window after boot is silently suppressed — exactly the startup/rollout misconfig signal you most want to see. Both fixes changed the sentinel to `float("-inf")`.

This is LLM-checkable in a single diff (a `0`/`0.0` sentinel paired with a `time.monotonic()`/`perf_counter()` comparison), so it routes to the Elder RULES rather than the /audit catalog.

## What changed

- Append one `ReviewRule` `monotonic-zero-sentinel` (bug_class `correctness`, severity `medium`, with bad/good examples) to `RULES` in `services/webhook/code_review_prompt.py`, mirrored byte-identically to `services/api/code_review_prompt.py` (ADR-0001).
- Add `test_monotonic_zero_sentinel_rule_present` to both `tests/test_code_review_prompt.py` suites (asserts the rule is in `RULES` and reaches `build_system_prompt()`), mirroring the existing `subprocess-no-timeout` test.
- No new bug_class needed (`correctness` already in the closed taxonomy).

## Test plan

- [x] `bash scripts/check-mirrored-files.sh` → green (33 pairs; `code_review_prompt.py` body byte-identical).
- [x] Both modules import cleanly (so the `ReviewRule.__post_init__` invariants pass) and `monotonic-zero-sentinel` appears in `build_system_prompt()`; `RULES` now 25.
- [x] Rule cites only real, read PRs (#450, #444); no speculative pattern.

## Size

XS

## Out of scope

- Re-auditing existing throttles in the codebase (both known instances already fixed by #450/#444).
- The cross-file/runtime patterns from this week's sweep — routed to the /audit catalog separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7K3aGRf4eY5hLzKiDeiJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01W7K3aGRf4eY5hLzKiDeiJc)_