### PR TITLE
ci(smoke): migrate iac + web smoke tests to shared reusable

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -104,15 +104,24 @@ jobs:
         run: bash infra/cloudflare/deploy.sh
         env:
           PULUMI_CWD: infra/pulumi
-      - name: 12. Smoke test public endpoints
-        run: |
-          set -euo pipefail
-          DOMAIN_API="https://api.grug.lol"; DOMAIN_WH="https://webhook.grug.lol"
-          probe() {
-            local name="$1" url="$2" expected="$3"; shift 3
-            local actual; actual=$(curl -sS -o /dev/null -w "%{http_code}" --max-time 30 --retry 3 --retry-delay 5 --retry-all-errors "$@" "$url")
-            [ "$actual" = "$expected" ] || { echo "::error::$name expected $expected got $actual ($url)"; return 1; }
-            echo "✓ $name ($actual)"; }
-          probe "api /livez" "$DOMAIN_API/livez" 200
-          probe "webhook /livez" "$DOMAIN_WH/livez" 200
-          probe "webhook unsigned POST" "$DOMAIN_WH/webhook/github" 401 -X POST -H "Content-Type: application/json" -H "X-GitHub-Event: ping" -d '{"zen":"smoke"}'
+
+  # Public-endpoint smoke test, migrated to the shared reusable so the
+  # curl-retry + status-assert pattern lives in one place (githumps/infra-public
+  # #24, githumps/infrastructure#840). SHA-pinned to the reusable PR branch tip;
+  # repins to the merge commit once that PR lands.
+  smoke:
+    needs: pulumi-up
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+    uses: githumps/infra-public/.github/workflows/_reusable.smoke-test.yml@91c46ceed4656a992e9143fbe29cc52744c9f524
+    with:
+      retries: 3
+      retry-delay: 5
+      timeout: 30
+      endpoints: |
+        [
+          {"name": "api /livez", "url": "https://api.grug.lol/livez", "expect-status": "200"},
+          {"name": "webhook /livez", "url": "https://webhook.grug.lol/livez", "expect-status": "200"},
+          {"name": "webhook unsigned POST", "url": "https://webhook.grug.lol/webhook/github", "expect-status": "401", "method": "POST", "headers": ["Content-Type: application/json", "X-GitHub-Event: ping"], "body": "{\"zen\":\"smoke\"}"}
+        ]

--- a/.github/workflows/web.deploy.yml
+++ b/.github/workflows/web.deploy.yml
@@ -204,29 +204,29 @@ jobs:
             echo "$body"
           fi
 
-      # Production smoke test — only runs for prod-eligible refs (main +
-      # version tags). Asserts that the deploy actually took effect by
-      # checking three load-bearing strings in the landing page response.
-      # Catches the "wrangler succeeded but CF cache served the previous
-      # build" failure mode and any URL-canon drift.
-      - name: 10. Smoke test grug.lol
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
-        run: |
-          set -euo pipefail
-          echo "Waiting 30s for Cloudflare Pages propagation..."
-          sleep 30
-          BODY=$(curl --fail --silent --show-error --location \
-            --max-time 15 --retry 3 --retry-delay 5 \
-            -A "grug-deploy-smoke/1.0" \
-            https://grug.lol/)
-          assert() {
-            if grep -Fq "$1" <<<"$BODY"; then
-              echo "✓ found: $1"
-            else
-              echo "::error::smoke test failed — landing page missing: $1"
-              exit 1
-            fi
-          }
-          assert 'href="/signin"'
-          assert 'grug-tribe'
-          echo "✓ grug.lol smoke test passed"
+  # Production smoke test - only runs for prod-eligible refs (main +
+  # version tags). Asserts the deploy actually took effect by checking
+  # load-bearing strings in the landing page response - catches the
+  # "wrangler succeeded but CF cache served the previous build" failure
+  # mode and any URL-canon drift. Migrated to the shared reusable so the
+  # curl-retry + content-assert pattern lives in one place
+  # (githumps/infra-public#24, githumps/infrastructure#840). The 30s
+  # pre-delay covers Cloudflare Pages propagation. SHA-pinned to the
+  # reusable PR branch tip; repins to the merge commit once that PR lands.
+  smoke:
+    needs: build-and-deploy
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: read
+    uses: githumps/infra-public/.github/workflows/_reusable.smoke-test.yml@91c46ceed4656a992e9143fbe29cc52744c9f524
+    with:
+      retries: 3
+      retry-delay: 5
+      timeout: 15
+      pre-delay: 30
+      user-agent: "grug-deploy-smoke/1.0"
+      endpoints: |
+        [
+          {"name": "grug.lol signin link", "url": "https://grug.lol/", "expect-status": "200", "contains": "href=\"/signin\""},
+          {"name": "grug.lol grug-tribe", "url": "https://grug.lol/", "expect-status": "200", "contains": "grug-tribe"}
+        ]


### PR DESCRIPTION
## Why / Summary
The iac.deploy and web.deploy workflows each carried their own hand-rolled curl-retry smoke probe. Any change to the probe pattern (retry tuning, status/content-assert shape) had to be duplicated across both. This migrates both to a single shared reusable so the pattern lives in one SHA-pinned place.

Both smoke tests now call `githumps/infra-public/.github/workflows/_reusable.smoke-test.yml` pinned to commit `91c46ceed4656a992e9143fbe29cc52744c9f524` (infra-public PR https://github.com/githumps/infra-public/pull/24). The reusable takes a JSON `endpoints` array (per-probe name, url, expected status, optional content substring, method, headers, body) plus configurable retries/timeout/pre-delay.

Probe targets, expected statuses, content asserts, retry counts and the 30s propagation delay are preserved exactly. Triggers and ref guards are unchanged: the iac smoke runs post-deploy on non-PR pushes; the web smoke runs only for main + version tags.

## Acceptance criteria
- [x] Both smoke tests call the shared reusable via a SHA-pinned `uses:` (commit 91c46ce)
- [x] Probe contract preserved: api/webhook /livez 200, unsigned webhook POST 401 (with headers+body), grug.lol landing asserts href="/signin" + grug-tribe
- [x] Trigger conditions and ref guards unchanged (smoke jobs `needs:` the deploy job and keep the original `if:` ref guards)
- [x] actionlint clean on both workflows; caller `with:` keys all match the reusable's input contract (only required input `endpoints` always supplied)

## Test plan
- `actionlint .github/workflows/iac.deploy.yml .github/workflows/web.deploy.yml` -> exit 0.
- Cross-checked every caller `with:` key against the reusable's declared inputs (all present; endpoints JSON parses).
- Pre-verified the exact migrated probe payloads against the live endpoints (api/webhook /livez 200, unsigned POST 401, grug.lol content strings) - all pass; an injected wrong-status / missing-substring fails as designed.
- Reusable repins to the infra-public merge commit once PR #24 lands; CI green on the next deploy proves the wiring end to end.

## Size
S - two workflow files, smoke step -> thin caller job, no app/source changes.

## Out of scope
- Authoring the reusable itself (infra-public PR https://github.com/githumps/infra-public/pull/24).
- Any change to deploy logic, probe targets, or assertions.

## Issue
Closes githumps/infrastructure#840