### PR TITLE
feat(cave): cut Elder cave-fallback over to the shared spark_cave envelope (#1610)

### DIFF
--- a/services/webhook/cave_fallback.py
+++ b/services/webhook/cave_fallback.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-from dataclasses import dataclass
 from typing import Any, Optional
 
 import boto3
@@ -28,6 +27,16 @@ from activity_log import record_check_verdict
 from github_app_auth import with_install_token_retry
 from github_checks_client import CheckRunResult, post_check_run
 from llm_client import Hunk
+
+# Shared Spark-Cave airlock library (#1610). Vendored from githumps/infra-public
+# (see spark_cave/VENDOR.md), so grug (public) and the macchina lane (private)
+# share ONE persona-generic wire envelope read by one connector. grug's rich
+# review fields (install_id/repo/pr/head_sha/diff_ref) ride INSIDE the generic
+# `payload`; the DiffRef codec below still spills a large diff to S3 BEFORE the
+# envelope, so the packed payload is always small (inline). The connector replies
+# with a generic FallbackResult whose `result` carries grug's findings + model.
+from spark_cave.enqueue import enqueue as _sc_enqueue
+from spark_cave.schema import FallbackResult as _SharedResult
 
 log = logging.getLogger(f"{os.getenv('DD_SERVICE', 'grug')}.cave_fallback")
 
@@ -38,10 +47,11 @@ _sqs = boto3.client("sqs")
 # queue isn't wired yet (best-effort, same discipline as the #272 offload).
 _JOBS_QUEUE_URL = os.getenv("GRUG_CAVE_JOBS_QUEUE_URL", "")
 
-# Wire-shape version. v2 (#311) carries a `diff_ref` (inline-or-S3) instead of
-# v1's raw inline `hunks` — bump so the connector (a separate repo) rejects an
-# unknown version instead of silently mis-parsing.
-SCHEMA_VERSION = 2
+# PAYLOAD-shape version, carried INSIDE the generic envelope's `payload` (the
+# envelope itself is versioned by the shared spark_cave schema). v2 (#311)
+# carries a `diff_ref` (inline-or-S3) instead of v1's raw inline `hunks` — the
+# connector rejects an unknown payload_version instead of mis-parsing.
+PAYLOAD_VERSION = 2
 
 # The one persona that falls back today. Carried on the message so a future
 # multi-persona airlock routes without a schema change.
@@ -60,81 +70,23 @@ _DIFF_BUCKET = os.getenv("GRUG_CAVE_DIFF_BUCKET", "")
 _s3 = boto3.client("s3")
 
 
-@dataclass(frozen=True, slots=True)
-class FallbackJob:
-    """A review job handed to the Cave connector over `grug-cave-jobs`.
-
-    Carries the PR coords + a `diff_ref` (the DiffRef codec's output: the diff
-    inline for small PRs, or an S3 pointer for large ones — #311) and NO GitHub
-    credential. The connector calls `unpack_diff(diff_ref)` to reconstruct the
-    same review units `review_diff` would have seen — reading the diff from S3,
-    never from GitHub (the creds boundary).
-    """
-
-    schema_version: int
-    install_id: int
-    repo: str  # "owner/name"
-    pr_number: int
-    head_sha: str
-    persona: str
-    diff_ref: dict[str, Any]  # DiffRef: {"kind": "inline"|"s3", ...}
-
-    def to_json(self) -> str:
-        return json.dumps(
-            {
-                "schema_version": self.schema_version,
-                "install_id": self.install_id,
-                "repo": self.repo,
-                "pr_number": self.pr_number,
-                "head_sha": self.head_sha,
-                "persona": self.persona,
-                "diff_ref": self.diff_ref,
-            }
-        )
+# grug's review job/result now ride the shared generic envelope (FallbackJob /
+# FallbackResult in spark_cave.schema). The job's `payload` carries grug's rich
+# fields below; the result's `result` carries the connector's findings + model.
+# Helpers to map between grug's coords and the generic envelope's
+# principal_id/request_id (the only two routing handles the shared schema has):
+#   principal_id = str(install_id)            -> FIFO group "elder:<install>"
+#   request_id   = "<repo>:<pr>:<head_sha>"   -> dedup is head-scoped (a new push
+#                                                is a new request_id => enqueues)
+def _request_id(repo: str, pr_number: int, head_sha: str) -> str:
+    return f"{repo}:{pr_number}:{head_sha}"
 
 
-@dataclass(frozen=True, slots=True)
-class FallbackResult:
-    """The connector's answer on `grug-cave-results`: findings (or a degraded
-    marker) for one (install, repo, pr, head). Consumed by the webhook to
-    publish the check-run + heal the verdict.
-
-    `findings` are kept as primitive dicts (the connector's wire shape) — the
-    result handler validates them into persona `Finding`s, mirroring how
-    `_coerce_finding` defends the live LLM path.
-    """
-
-    schema_version: int
-    install_id: int
-    repo: str
-    pr_number: int
-    head_sha: str
-    persona: str
-    findings: tuple[dict[str, Any], ...]
-    degraded: bool = False
-    degraded_reason: str = ""
-    model: str = ""
-
-    @classmethod
-    def from_json(cls, raw: str) -> "FallbackResult":
-        d = json.loads(raw)
-        if not isinstance(d, dict):
-            raise ValueError("FallbackResult body is not a JSON object")
-        findings = d.get("findings", [])
-        if not isinstance(findings, list):
-            findings = []
-        return cls(
-            schema_version=int(d["schema_version"]),
-            install_id=int(d["install_id"]),
-            repo=str(d["repo"]),
-            pr_number=int(d["pr_number"]),
-            head_sha=str(d["head_sha"]),
-            persona=str(d.get("persona", _PERSONA)),
-            findings=tuple(f for f in findings if isinstance(f, dict)),
-            degraded=bool(d.get("degraded", False)),
-            degraded_reason=str(d.get("degraded_reason", "")),
-            model=str(d.get("model", "")),
-        )
+def _parse_request_id(request_id: str) -> tuple[str, int, str]:
+    """Inverse of `_request_id`. repo ("owner/name") and head_sha never contain
+    ':', so an rsplit on the last two ':' recovers (repo, pr_number, head_sha)."""
+    repo, pr_raw, head_sha = request_id.rsplit(":", 2)
+    return repo, int(pr_raw), head_sha
 
 
 # ---------------------------------------------------------------------------
@@ -216,14 +168,6 @@ def unpack_diff(diff_ref: dict[str, Any]) -> list[Hunk]:
     ]
 
 
-def _dedup_id(install_id: int, repo: str, pr_number: int, head_sha: str) -> str:
-    """FIFO content-dedup key. Includes `head_sha` deliberately: a NEW push (new
-    head) is a DIFFERENT review that must enqueue, so it must not dedup against
-    the prior commit's job; but a double-fire on the SAME head within the 5-min
-    FIFO window is dropped for free (a redelivery / re-trigger guard)."""
-    return f"{install_id}:{repo}:{pr_number}:{_PERSONA}:{head_sha}"
-
-
 def enqueue_fallback(
     hunks: list[Hunk],
     *,
@@ -264,24 +208,25 @@ def enqueue_fallback(
     if diff_ref is None:
         return False
 
-    job = FallbackJob(
-        schema_version=SCHEMA_VERSION,
-        install_id=installation_id,
-        repo=repo,
-        pr_number=pr_number,
-        head_sha=head_sha,
-        persona=_PERSONA,
-        diff_ref=diff_ref,
-    )
-    body = job.to_json()
+    # grug's rich review fields ride INSIDE the generic envelope's payload. The
+    # diff was already spilled to S3 by pack_diff if large, so this payload is
+    # always small -> the shared packer keeps it inline (put_s3 unused).
+    payload = {
+        "payload_version": PAYLOAD_VERSION,
+        "install_id": installation_id,
+        "repo": repo,
+        "pr_number": pr_number,
+        "head_sha": head_sha,
+        "diff_ref": diff_ref,
+    }
     try:
-        _sqs.send_message(
-            QueueUrl=_JOBS_QUEUE_URL,
-            MessageBody=body,
-            MessageGroupId=str(installation_id),
-            MessageDeduplicationId=_dedup_id(
-                installation_id, repo, pr_number, head_sha
-            ),
+        _sc_enqueue(
+            sqs=_sqs,
+            queue_url=_JOBS_QUEUE_URL,
+            persona=_PERSONA,
+            principal_id=str(installation_id),
+            request_id=_request_id(repo, pr_number, head_sha),
+            payload=payload,
         )
     except Exception as e:  # noqa: BLE001 — best-effort: a lost fallback re-triggers next push
         log.warning(
@@ -370,27 +315,34 @@ def _summarize(findings: tuple[dict[str, Any], ...]) -> tuple[str, str]:
 
 
 def _heal_one(body: str) -> None:
-    """Publish + heal for ONE `FallbackResult`. Raises on a malformed body or a
-    publish error — `handle_fallback_result` catches per-record."""
-    res = FallbackResult.from_json(body)
-    if res.degraded:
+    """Publish + heal for ONE generic `FallbackResult`. Raises on a malformed
+    body or a publish error — `handle_fallback_result` catches per-record.
+
+    Maps the generic envelope back to grug's coords: `principal_id` is the
+    install id, `request_id` decodes to (repo, pr, head_sha), and the connector's
+    findings + model ride in `result`. `ok=False` is the degraded marker (the
+    Cave itself failed)."""
+    res = _SharedResult.from_json(body)
+    install_id = int(res.principal_id)
+    repo, pr_number, head_sha = _parse_request_id(res.request_id)
+    if not res.ok:
         # The Cave ALSO failed (or the connector couldn't review). Don't fake a
         # review — leave the verdict `errored` and log so the double-outage is
         # visible (this is what the re-scoped degraded monitor catches).
         log.warning(
             "elder_fallback_result_degraded",
-            extra={
-                "repo": res.repo,
-                "pr": res.pr_number,
-                "reason": res.degraded_reason,
-            },
+            extra={"repo": repo, "pr": pr_number, "reason": res.error},
         )
         return
-    owner, _, repo_name = res.repo.partition("/")
-    title, summary = _summarize(res.findings)
+    result = res.result or {}
+    raw_findings = result.get("findings", [])
+    # Same tolerance the old wire shape had: keep only dict findings.
+    findings = tuple(f for f in raw_findings if isinstance(f, dict)) if isinstance(raw_findings, list) else ()
+    owner, _, repo_name = repo.partition("/")
+    title, summary = _summarize(findings)
     check = CheckRunResult(
         name=_CHECK_NAME,
-        head_sha=res.head_sha,
+        head_sha=head_sha,
         status="completed",
         # Elder is advisory-by-default; a healed fallback is advisory. Blocking-
         # aware fallback (read RepoConfig, fail on high/critical) is a follow-up.
@@ -399,36 +351,32 @@ def _heal_one(body: str) -> None:
         summary=summary,
     )
     with_install_token_retry(
-        res.install_id,
+        install_id,
         lambda token: post_check_run(
             token,
             owner,
             repo_name,
             check,
-            external_id=f"grug-cr:{res.repo}#{res.pr_number}:{res.head_sha}",
+            external_id=f"grug-cr:{repo}#{pr_number}:{head_sha}",
         ),
     )
     # Heal the Activity verdict: errored → reviewed (warn/pass). Idempotent per
     # (persona, head_sha) at the store layer; never raises.
     record_check_verdict(
-        install_id=res.install_id,
+        install_id=install_id,
         persona_key=_PERSONA_KEY,
-        repo=res.repo,
-        pr_number=res.pr_number,
-        head_sha=res.head_sha,
+        repo=repo,
+        pr_number=pr_number,
+        head_sha=head_sha,
         conclusion="neutral",
         summary=title,
-        findings_count=len(res.findings),
+        findings_count=len(findings),
         blocking=False,
         degraded_reason=None,
     )
     log.info(
         "elder_fallback_healed",
-        extra={
-            "repo": res.repo,
-            "pr": res.pr_number,
-            "findings": len(res.findings),
-        },
+        extra={"repo": repo, "pr": pr_number, "findings": len(findings)},
     )
 
 

--- a/services/webhook/spark_cave/VENDOR.md
+++ b/services/webhook/spark_cave/VENDOR.md
@@ -1,0 +1,13 @@
+# Vendored: spark_cave
+
+Canonical source: **githumps/infra-public** `python/spark_cave/spark_cave/`
+Pinned at: `b8d8b3f5acf5bc5e233b8f2a76029633e5070089`
+
+Do NOT edit these files in grug. Fix upstream in infra-public, then re-vendor:
+
+    SHA=<infra-public-sha>
+    cp <infra-public>/python/spark_cave/spark_cave/*.py services/webhook/spark_cave/
+
+The shared SQS-airlock library (schema / packing / enqueue / results), public +
+zero-runtime-dep, so grug (public) and somatic-scripts (private) share one wire
+contract. See githumps/infra-public for the canonical package + its tests.

--- a/services/webhook/spark_cave/__init__.py
+++ b/services/webhook/spark_cave/__init__.py
@@ -1,0 +1,8 @@
+"""Spark Cave -- shared async owned-GPU LLM fallback over an SQS airlock.
+
+Persona-generic: distinct services (e.g. a `code-review` persona and a
+`meal-gen` persona) share the schema, payload packing, enqueue, and
+result-handling, in separate per-service queues.
+Import the submodules (`schema`, `packing`, `enqueue`, `results`) directly so a
+consumer that only needs the schema does not pull in the boto3-touching paths.
+"""

--- a/services/webhook/spark_cave/enqueue.py
+++ b/services/webhook/spark_cave/enqueue.py
@@ -1,0 +1,48 @@
+"""Enqueue a `FallbackJob` onto a Spark-Cave jobs FIFO (SQS).
+
+Packs the payload (inline or S3 spillover) then `SendMessage` with the FIFO
+`MessageGroupId` (`persona:principal`, so one lane's backlog can't starve
+another's) + `MessageDeduplicationId` (the job's `dedup_key`). The SQS client +
+the S3 putter are injected, so this is unit-testable with fakes -- no live AWS.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .packing import pack
+from .schema import SCHEMA_VERSION, FallbackJob
+
+# SQS standard max message body is 256 KB; spill well below it to leave room for
+# the JSON envelope around the payload.
+DEFAULT_INLINE_THRESHOLD_BYTES = 200_000
+
+
+def enqueue(
+    *,
+    sqs,
+    queue_url: str,
+    persona: str,
+    principal_id: str,
+    request_id: str,
+    payload: dict,
+    put_s3: Callable[[bytes], dict] | None = None,
+    inline_threshold_bytes: int = DEFAULT_INLINE_THRESHOLD_BYTES,
+) -> FallbackJob:
+    """Pack `payload` and send a `FallbackJob` to the jobs FIFO. Returns the
+    job that was sent (so callers can record its `request_id`/`dedup_key`)."""
+    ref = pack(payload, threshold_bytes=inline_threshold_bytes, put_s3=put_s3)
+    job = FallbackJob(
+        schema_version=SCHEMA_VERSION,
+        persona=persona,
+        principal_id=principal_id,
+        request_id=request_id,
+        payload=ref,
+    )
+    sqs.send_message(
+        QueueUrl=queue_url,
+        MessageBody=job.to_json(),
+        MessageGroupId=f"{persona}:{principal_id}",
+        MessageDeduplicationId=job.dedup_key,
+    )
+    return job

--- a/services/webhook/spark_cave/packing.py
+++ b/services/webhook/spark_cave/packing.py
@@ -1,0 +1,50 @@
+"""Pure pack/unpack of a job payload for the SQS airlock.
+
+A small payload rides INLINE inside the queue message; a large one (over a
+threshold, since SQS caps message size) is spilled to S3 and the message carries
+only a pointer. The S3 put/get are INJECTED as callables, so this module is pure
+and unit-testable with no boto3.
+"""
+
+# Spark-authored: cohere north-mini-code-1.0:bf16 on an on-prem DGX Spark,
+# 2026-06-27 -- the model's first production job. The pack/unpack logic below is
+# its generation; reviewed + hardened by Claude.
+# (git grep "Spark-authored" lists all on-prem-model-generated code.)
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from .schema import PayloadRef
+
+
+def pack(
+    payload: dict,
+    *,
+    threshold_bytes: int,
+    put_s3: Callable[[bytes], dict] | None = None,
+) -> PayloadRef:
+    """Inline when the serialized payload fits under `threshold_bytes`; else spill
+    the bytes to S3 via `put_s3` and carry an s3 ref."""
+    data = json.dumps(payload).encode("utf-8")
+    if len(data) <= threshold_bytes:
+        return PayloadRef(kind="inline", inline=payload, s3=None)
+    if put_s3 is None:
+        raise ValueError("payload exceeds threshold but no put_s3 provided")
+    ref = put_s3(data)
+    return PayloadRef(kind="s3", inline=None, s3=ref)
+
+
+def unpack(ref: PayloadRef, *, get_s3: Callable[[dict], bytes] | None = None) -> dict:
+    """Reverse `pack`: inline refs return their payload; s3 refs are fetched via
+    `get_s3` and JSON-decoded."""
+    if ref.kind == "inline":
+        return ref.inline or {}
+    if ref.kind == "s3":
+        if get_s3 is None:
+            raise ValueError("s3 payload but no get_s3 provided")
+        if ref.s3 is None:
+            raise ValueError("s3 payload ref missing its s3 pointer")
+        return json.loads(get_s3(ref.s3))
+    raise ValueError(f"unknown payload kind: {ref.kind}")

--- a/services/webhook/spark_cave/results.py
+++ b/services/webhook/spark_cave/results.py
@@ -1,0 +1,53 @@
+"""Consume a `FallbackResult` and dispatch it to a per-persona handler.
+
+Guarantees the consumer cares about: it NEVER raises back into the SQS consumer
+(a poison result must not retry-storm the queue), and it skips unknown personas.
+Idempotency on redelivery is the handler's responsibility (it dedups on
+`request_id`). Generalized from grug's `handle_fallback_result`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+
+from .schema import FallbackResult
+
+log = logging.getLogger("spark_cave.results")
+
+
+def handle_result(
+    body: str,
+    *,
+    handlers: Mapping[str, Callable[[FallbackResult], None]],
+) -> bool:
+    """Parse one result message and dispatch to `handlers[persona]`. Returns
+    True if a handler ran, else False. Never raises -- malformed bodies, unknown
+    personas, and handler exceptions are logged and swallowed so the consumer's
+    delete-on-success loop stays healthy."""
+    try:
+        result = FallbackResult.from_json(body)
+    except Exception as e:
+        log.warning("spark_cave: dropping unparseable result: %s", e)
+        return False
+
+    handler = handlers.get(result.persona)
+    if handler is None:
+        log.warning(
+            "spark_cave: no handler for persona %r (request %s)",
+            result.persona,
+            result.request_id,
+        )
+        return False
+
+    try:
+        handler(result)
+    except Exception as e:
+        log.warning(
+            "spark_cave: handler for %r raised on request %s: %s",
+            result.persona,
+            result.request_id,
+            e,
+        )
+        return False
+    return True

--- a/services/webhook/spark_cave/schema.py
+++ b/services/webhook/spark_cave/schema.py
@@ -1,0 +1,105 @@
+"""Wire schema for the Spark-Cave SQS airlock.
+
+A cloud service enqueues a `FallbackJob` (carrying a `persona` so an on-prem
+connector can route it to the right GPU model); the connector publishes a
+`FallbackResult` back. Persona-generic so distinct services (e.g. a
+`code-review` and a `meal-gen` persona) share one contract. Pure dataclasses +
+JSON round-trip + a deterministic FIFO dedup key. No I/O, no boto3.
+"""
+
+# Spark-authored: first-drafted on an on-prem DGX Spark by its then-resident
+# coder model (qwen3-coder-next), 2026-06-27; substantially cleaned, typed, and
+# finalized by Claude.
+# (git grep "Spark-authored" lists all on-prem-model-generated code.)
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadRef:
+    kind: str  # "inline" or "s3"
+    inline: dict | None  # the payload when kind == "inline"
+    s3: dict | None  # {"bucket": str, "key": str} when kind == "s3"
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackJob:
+    schema_version: int
+    persona: str
+    principal_id: str
+    request_id: str
+    payload: PayloadRef
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "schema_version": self.schema_version,
+                "persona": self.persona,
+                "principal_id": self.principal_id,
+                "request_id": self.request_id,
+                "payload": {
+                    "kind": self.payload.kind,
+                    "inline": self.payload.inline,
+                    "s3": self.payload.s3,
+                },
+            }
+        )
+
+    @classmethod
+    def from_json(cls, s: str) -> FallbackJob:
+        data = json.loads(s)
+        p = data["payload"]
+        return cls(
+            schema_version=data["schema_version"],
+            persona=data["persona"],
+            principal_id=data["principal_id"],
+            request_id=data["request_id"],
+            payload=PayloadRef(kind=p["kind"], inline=p.get("inline"), s3=p.get("s3")),
+        )
+
+    @property
+    def dedup_key(self) -> str:
+        """FIFO dedup id: a (persona, principal, request) is processed once."""
+        return f"{self.persona}:{self.principal_id}:{self.request_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class FallbackResult:
+    schema_version: int
+    persona: str
+    principal_id: str
+    request_id: str
+    ok: bool
+    result: dict | None
+    error: str | None
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "schema_version": self.schema_version,
+                "persona": self.persona,
+                "principal_id": self.principal_id,
+                "request_id": self.request_id,
+                "ok": self.ok,
+                "result": self.result,
+                "error": self.error,
+            }
+        )
+
+    @classmethod
+    def from_json(cls, s: str) -> FallbackResult:
+        data = json.loads(s)
+        return cls(
+            schema_version=data["schema_version"],
+            persona=data["persona"],
+            principal_id=data["principal_id"],
+            request_id=data["request_id"],
+            ok=data["ok"],
+            result=data.get("result"),
+            error=data.get("error"),
+        )

--- a/services/webhook/tests/test_cave_fallback.py
+++ b/services/webhook/tests/test_cave_fallback.py
@@ -1,9 +1,15 @@
-"""Tests for the Elder cave-fallback producer (#310, ADR-0005, spec 0018).
+"""Tests for the Elder cave-fallback producer + consumer (#310/#1610).
 
-External behavior only: the message-schema round-trip, and the enqueuer's
-flag-gate / dedup-key / message-shape / best-effort-degrade contract. The
-SQS client is patched (no real AWS) — same style as test_async_dispatch.
+External behavior only: the enqueuer's flag-gate / dedup / message-shape /
+best-effort-degrade contract, the DiffRef codec, and the result handler's heal.
+The SQS/S3 clients are patched (no real AWS).
+
+#1610: grug now rides the SHARED generic spark_cave envelope (one connector reads
+all lanes). grug's rich fields ride inside the envelope's `payload.inline`;
+principal_id = str(install_id), request_id = "<repo>:<pr>:<head>". The connector
+replies with a generic FallbackResult whose `result` carries findings + model.
 """
+
 from __future__ import annotations
 
 import json
@@ -11,69 +17,6 @@ from unittest.mock import patch
 
 import cave_fallback as cf
 from llm_client import Hunk
-
-
-# --- schema contract ------------------------------------------------------
-
-
-def test_fallback_job_to_json_round_trips():
-    job = cf.FallbackJob(
-        schema_version=cf.SCHEMA_VERSION,
-        install_id=42,
-        repo="acme/widget",
-        pr_number=7,
-        head_sha="deadbeef",
-        persona="elder",
-        diff_ref={"kind": "inline", "hunks": [{"path": "a.py", "body": "@@ x"}]},
-    )
-    d = json.loads(job.to_json())
-    assert d["install_id"] == 42
-    assert d["repo"] == "acme/widget"
-    assert d["persona"] == "elder"
-    assert d["schema_version"] == 2  # #311 bumped the wire shape
-    assert d["diff_ref"]["kind"] == "inline"
-    assert d["diff_ref"]["hunks"] == [{"path": "a.py", "body": "@@ x"}]
-
-
-def test_fallback_result_from_json_parses_findings():
-    raw = json.dumps(
-        {
-            "schema_version": 1,
-            "install_id": 9,
-            "repo": "acme/widget",
-            "pr_number": 3,
-            "head_sha": "cafef00d",
-            "persona": "elder",
-            "findings": [{"path": "a.py", "line": 4, "severity": "high"}],
-            "model": "cave-model",
-        }
-    )
-    res = cf.FallbackResult.from_json(raw)
-    assert res.install_id == 9
-    assert res.head_sha == "cafef00d"
-    assert res.findings[0]["severity"] == "high"
-    assert res.degraded is False
-    assert res.model == "cave-model"
-
-
-def test_fallback_result_from_json_drops_non_dict_findings_and_reads_degraded():
-    raw = json.dumps(
-        {
-            "schema_version": 1,
-            "install_id": 1,
-            "repo": "a/b",
-            "pr_number": 1,
-            "head_sha": "abc",
-            "findings": ["garbage", {"path": "x"}, 7],
-            "degraded": True,
-            "degraded_reason": "cave_unreachable",
-        }
-    )
-    res = cf.FallbackResult.from_json(raw)
-    assert res.findings == ({"path": "x"},)  # non-dicts dropped
-    assert res.degraded is True
-    assert res.degraded_reason == "cave_unreachable"
-
 
 # --- enqueuer contract ----------------------------------------------------
 
@@ -110,22 +53,28 @@ def test_enqueue_is_noop_on_empty_hunks(monkeypatch):
     send.assert_not_called()
 
 
-def test_enqueue_sends_with_install_group_and_head_scoped_dedup(monkeypatch):
+def test_enqueue_sends_generic_envelope_with_persona_group_and_head_scoped_dedup(monkeypatch):
     monkeypatch.setattr(cf, "_JOBS_QUEUE_URL", "https://sqs/jobs.fifo")
     with patch("secrets_loader.get_fallback_enabled", return_value=True), \
          patch.object(cf._sqs, "send_message") as send:
         assert _enqueue() is True
     kwargs = send.call_args.kwargs
     assert kwargs["QueueUrl"] == "https://sqs/jobs.fifo"
-    # Per-install ordering/rate-control.
-    assert kwargs["MessageGroupId"] == "42"
-    # Dedup includes head_sha so a new commit isn't deduped against the old job.
-    assert kwargs["MessageDeduplicationId"] == "42:acme/widget:7:elder:deadbeef0000"
+    # Generic envelope: FIFO group "persona:principal"; dedup adds the request_id
+    # (which carries head_sha) so a new commit is a new request, not a dup.
+    assert kwargs["MessageGroupId"] == "elder:42"
+    assert kwargs["MessageDeduplicationId"] == "elder:42:acme/widget:7:deadbeef0000"
     body = json.loads(kwargs["MessageBody"])
-    assert body["repo"] == "acme/widget" and body["head_sha"] == "deadbeef0000"
-    # Small diff → inline DiffRef (no S3).
-    assert body["diff_ref"]["kind"] == "inline"
-    assert body["diff_ref"]["hunks"] == [{"path": "a.py", "body": "@@ -1 +1 @@\n-x\n+y"}]
+    assert body["persona"] == "elder"
+    assert body["principal_id"] == "42"
+    assert body["request_id"] == "acme/widget:7:deadbeef0000"
+    # grug's rich fields ride inside the inline payload (small -> inline).
+    assert body["payload"]["kind"] == "inline"
+    payload = body["payload"]["inline"]
+    assert payload["install_id"] == 42 and payload["repo"] == "acme/widget"
+    assert payload["head_sha"] == "deadbeef0000" and payload["payload_version"] == 2
+    assert payload["diff_ref"]["kind"] == "inline"
+    assert payload["diff_ref"]["hunks"] == [{"path": "a.py", "body": "@@ -1 +1 @@\n-x\n+y"}]
     # The job must NOT carry any GitHub credential.
     assert "token" not in kwargs["MessageBody"].lower()
 
@@ -149,16 +98,29 @@ def test_enqueue_degrades_to_false_on_send_error(monkeypatch):
 
 # --- consumer: handle_fallback_result (heal) ------------------------------
 
+
 def _result_body(**over) -> str:
+    """Generic FallbackResult body (the connector's wire shape). grug coords are
+    encoded in principal_id + request_id; findings/model ride in `result`."""
+    install_id = over.pop("install_id", 42)
+    repo = over.pop("repo", "acme/widget")
+    pr = over.pop("pr_number", 7)
+    head = over.pop("head_sha", "deadbeef0000")
+    ok = over.pop("ok", True)
+    findings = over.pop(
+        "findings",
+        [{"file": "a.py", "line": 4, "severity": "high",
+          "rule_name": "null-deref", "message": "x may be None"}],
+    )
+    model = over.pop("model", "cave-model")
     d = {
         "schema_version": 1,
-        "install_id": 42,
-        "repo": "acme/widget",
-        "pr_number": 7,
-        "head_sha": "deadbeef0000",
         "persona": "elder",
-        "findings": [{"file": "a.py", "line": 4, "severity": "high",
-                      "rule_name": "null-deref", "message": "x may be None"}],
+        "principal_id": str(install_id),
+        "request_id": f"{repo}:{pr}:{head}",
+        "ok": ok,
+        "result": None if not ok else {"findings": findings, "model": model},
+        "error": over.pop("error", None),
     }
     d.update(over)
     return json.dumps(d)
@@ -169,8 +131,6 @@ def _event(*bodies) -> dict:
 
 
 def test_handle_result_heals_publishes_check_and_records_verdict():
-    # with_install_token_retry(install_id, fn) → invoke fn with a fake token so
-    # the real post_check_run call path is exercised (not stubbed away).
     with patch.object(cf, "with_install_token_retry", side_effect=lambda iid, fn: fn("tok")), \
          patch.object(cf, "post_check_run") as post, \
          patch.object(cf, "record_check_verdict") as rec:
@@ -189,15 +149,25 @@ def test_handle_result_heals_publishes_check_and_records_verdict():
     assert rkw["findings_count"] == 1
     assert rkw["degraded_reason"] is None
     assert rkw["head_sha"] == "deadbeef0000"
+    assert rkw["repo"] == "acme/widget" and rkw["pr_number"] == 7
+
+
+def test_handle_result_drops_non_dict_findings():
+    with patch.object(cf, "with_install_token_retry", side_effect=lambda iid, fn: fn("tok")), \
+         patch.object(cf, "post_check_run"), \
+         patch.object(cf, "record_check_verdict") as rec:
+        cf.handle_fallback_result(_event(_result_body(findings=["garbage", {"path": "x"}, 7])))
+    # Only the one dict finding counts (tolerance preserved from the old shape).
+    assert rec.call_args.kwargs["findings_count"] == 1
 
 
 def test_handle_result_degraded_does_not_fake_a_review():
-    # Cave ALSO failed → leave the verdict errored (no publish, no heal).
+    # Cave ALSO failed (ok=False) → leave the verdict errored (no publish, no heal).
     with patch.object(cf, "with_install_token_retry") as tok, \
          patch.object(cf, "post_check_run") as post, \
          patch.object(cf, "record_check_verdict") as rec:
         out = cf.handle_fallback_result(
-            _event(_result_body(degraded=True, degraded_reason="cave_unreachable", findings=[]))
+            _event(_result_body(ok=False, error="cave_unreachable"))
         )
     assert out == {"records": 1, "healed": 1, "failed": 0}  # processed, not failed
     post.assert_not_called()
@@ -236,11 +206,13 @@ def test_handle_result_clean_review_titles_no_omens():
 
 # --- peer-review hardenings (#322): size guard + markdown safety -----------
 
+
 def test_enqueue_skips_oversized_diff(monkeypatch):
-    """A diff over the SQS 256KB inline cap is skipped with a clear signal
-    (S3 spillover is #311) — not sent, not a generic failure."""
+    """A diff over the SQS 256KB inline cap with no S3 bucket is skipped with a
+    clear signal — not sent, not a generic failure."""
     big = [Hunk(path="big.py", body="x" * 260_000)]
     monkeypatch.setattr(cf, "_JOBS_QUEUE_URL", "https://sqs/jobs.fifo")
+    monkeypatch.setattr(cf, "_DIFF_BUCKET", "")
     with patch("secrets_loader.get_fallback_enabled", return_value=True), \
          patch.object(cf._sqs, "send_message") as send:
         out = cf.enqueue_fallback(big, installation_id=1, repo="a/b", pr_number=1, head_sha="h")
@@ -255,8 +227,7 @@ def test_summarize_neutralizes_markdown_from_connector_findings():
         {"severity": "high", "rule_name": "x`y|z",
          "file": "a.py", "line": 1, "message": "line1\nline2 `code` |pipe|"},
     ))
-    # No raw newlines or pipes survive into the per-finding line.
-    finding_line = [l for l in body.splitlines() if l.startswith("- ")][0]
+    finding_line = [line for line in body.splitlines() if line.startswith("- ")][0]
     assert "\n" not in finding_line
     assert "line1 line2" in finding_line  # newline collapsed to space
     assert "`code`" not in finding_line   # backticks neutralized
@@ -271,11 +242,11 @@ _BIG = [Hunk(path="big.py", body="x" * 260_000)]
 
 
 def test_pack_diff_inline_for_small_diff(monkeypatch):
-    monkeypatch.setattr(cf, "_DIFF_BUCKET", "")  # no bucket needed for inline
+    monkeypatch.setattr(cf, "_DIFF_BUCKET", "")
     with patch.object(cf._s3, "put_object") as put:
         ref = cf.pack_diff(_SMALL, install_id=1, head_sha="h")
     assert ref == {"kind": "inline", "hunks": [{"path": "a.py", "body": "@@ -1 +1 @@\n-x\n+y"}]}
-    put.assert_not_called()  # small diff never touches S3
+    put.assert_not_called()
 
 
 def test_pack_diff_spills_large_diff_to_s3(monkeypatch):
@@ -290,13 +261,13 @@ def test_pack_diff_spills_large_diff_to_s3(monkeypatch):
 
 def test_pack_diff_none_when_large_and_no_bucket(monkeypatch):
     monkeypatch.setattr(cf, "_DIFF_BUCKET", "")
-    assert cf.pack_diff(_BIG, install_id=1, head_sha="h") is None  # can't spill → no-op
+    assert cf.pack_diff(_BIG, install_id=1, head_sha="h") is None
 
 
 def test_pack_diff_none_when_spill_fails(monkeypatch):
     monkeypatch.setattr(cf, "_DIFF_BUCKET", "grug-cave-diffs")
     with patch.object(cf._s3, "put_object", side_effect=RuntimeError("s3 down")):
-        assert cf.pack_diff(_BIG, install_id=1, head_sha="h") is None  # best-effort
+        assert cf.pack_diff(_BIG, install_id=1, head_sha="h") is None
 
 
 def test_unpack_diff_inline_round_trips():
@@ -314,7 +285,6 @@ def test_unpack_diff_s3_fetches_and_reconstructs(monkeypatch):
 
 
 def test_unpack_diff_round_trips_large_via_s3(monkeypatch):
-    # pack (spill) then unpack (fetch) reconstructs the SAME hunks.
     monkeypatch.setattr(cf, "_DIFF_BUCKET", "grug-cave-diffs")
     stored = {}
     monkeypatch.setattr(cf._s3, "put_object",
@@ -340,7 +310,10 @@ def test_enqueue_spills_large_diff_and_sends_s3_ref(monkeypatch):
          patch.object(cf._sqs, "send_message") as send:
         out = cf.enqueue_fallback(_BIG, installation_id=42, repo="a/b", pr_number=1, head_sha="deadbeef")
     assert out is True
-    put.assert_called_once()  # spilled
+    put.assert_called_once()  # diff spilled to S3
     body = json.loads(send.call_args.kwargs["MessageBody"])
-    assert body["diff_ref"]["kind"] == "s3"  # message carries only the pointer
-    assert "hunks" not in body["diff_ref"]   # the big diff is NOT inline
+    # Envelope payload stays INLINE (it's just metadata + an S3 pointer)...
+    assert body["payload"]["kind"] == "inline"
+    diff_ref = body["payload"]["inline"]["diff_ref"]
+    assert diff_ref["kind"] == "s3"        # ...but the big diff is an S3 ref
+    assert "hunks" not in diff_ref         # the big diff is NOT inline


### PR DESCRIPTION
## Why / Summary

Cuts grug's Elder cave-fallback over to the **shared, persona-generic `spark_cave` envelope** (#1610), so ONE on-prem connector can read grug's lane and the macchina lane through a single wire contract.

The shared library is vendored from **githumps/infra-public** (`services/webhook/spark_cave/`, SHA-pinned in `VENDOR.md`) — a PUBLIC, zero-runtime-dep package, so grug (public) and the macchina lane (private) share the contract without either repo leaking into the other.

grug's review job/result now ride the generic `FallbackJob`/`FallbackResult`: `persona="elder"`, `principal_id=str(install_id)`, `request_id="<repo>:<pr>:<head_sha>"`, with grug's rich fields (`install_id`/`repo`/`pr`/`head_sha`/`diff_ref`) **inside** the envelope's `payload`. The `DiffRef`/`Hunk` codec still spills a large diff to S3 *before* the envelope, so the packed payload is always small (inline). The connector replies with a generic `FallbackResult` whose `result` carries findings + model; `ok=False` is the degraded marker.

**No behavior change** at the public API (`enqueue_fallback` / `handle_fallback_result` signatures unchanged) or in producer/consumer logic (flag-gate, head-scoped dedup, best-effort no-op, never-raise-to-Lambda, advisory NEUTRAL heal). The **wire bytes** change to the generic shape — safe because the connector (#316) is not live yet (the deliberate one-connector-one-format migration).

## Acceptance criteria

- [x] `enqueue_fallback` sends the generic envelope: group `elder:<install>`, dedup `elder:<install>:<repo>:<pr>:<head>`, grug fields in `payload.inline`, no GitHub token in the body.
- [x] Large diff still spills to S3; the envelope payload stays inline carrying only the pointer.
- [x] `handle_fallback_result` decodes principal_id/request_id back to grug coords, heals the check-run + verdict, drops non-dict findings, treats `ok=False` as degraded (no fake review), never raises out of the ESM.
- [x] Public-API callers untouched (dispatch, lambda_handler, consumer).

## Test plan

- 24 cave tests rewritten for the new envelope (`tests/test_cave_fallback.py`).
- Adjacent suites green: `test_lambda_handler_routing`, `test_consumer`, `test_code_reviewer_dispatch`.
- Full webhook suite: **748 passed, 2 skipped**.

## Size

Size: M

## Out of scope

The connector that dequeues this (#316) and macchina-side result handling. This is grug's producer/consumer cutover only.

## Issue

Closes githumps/somatic-scripts#1610.
