### PR TITLE
ci(iac): add timeout-minutes to meta job (hygiene Rule 7)

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   meta:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       tag: ${{ steps.t.outputs.tag }}
     steps:


### PR DESCRIPTION
## Why

`iac.deploy.yml`'s `meta` job was the only inline `runs-on:` job in the file without a `timeout-minutes:`, inheriting GitHub's 360-minute (6h) default. Both siblings already set one (`infra-test: 10`, `pulumi-up: 20`), so this was a pre-existing fleet-hygiene **Rule 7** outlier (`infrastructure/.github/scripts/workflow_hygiene.py`, infra #709). grug's only hygiene gate (`check.drift-lint.yml`) checks mirrored `services/` files only, so Rule 7 is not machine-checked here and the gap went unflagged since PR #374.

## What changed

- `.github/workflows/iac.deploy.yml` — added `timeout-minutes: 5` to the `meta` job (single line; the job body is one `echo`, so 5m is ample).

## Acceptance criteria

- [x] `meta` job declares `timeout-minutes: 5`.
- [x] Every inline `runs-on:` job in the file now carries a `timeout-minutes:` (`meta`/`infra-test`/`pulumi-up`).
- [x] No happy-path behavior change — only a ceiling is added; the `tag` output is unchanged. `yaml.safe_load` parses the file.

Size: XS

## Out of scope

- The reusable-caller `smoke` job (delegates via `uses:`; exempt from Rule 7).
- `benchmark.sast.yml` environment binding (#453).
- Porting a Rule-7 drift-lint gate into this repo (follow-up).

Closes #455

---
_Automated fix by nightly fleet-health bot._

---
_Generated by [Claude Code](https://claude.ai/code/session_01XozMEuq294kiqAaqtEPCq7)_