### PR TITLE
Add tls-verification-disabled Elder rule (weekly harvest)

### DIFF
--- a/services/api/code_review_prompt.py
+++ b/services/api/code_review_prompt.py
@@ -346,6 +346,23 @@ RULES: tuple[ReviewRule, ...] = (
         good_example="subprocess.run(cmd, capture_output=True, timeout=600)",
         severity="medium",
     ),
+    # ── weekly harvest: disabled-TLS-verification class (infrastructure #1390/#1391) ──
+    ReviewRule(
+        name="tls-verification-disabled",
+        bug_class="security",
+        description="TLS/certificate verification turned OFF on an outbound "
+        "connection: `verify=False` (requests/httpx), `ssl.CERT_NONE` "
+        "(ssl/urllib), `rejectUnauthorized: false` (Node), or "
+        "`InsecureSkipVerify: true` (Go). Any API key / token / data then "
+        "rides a link a MITM can read or forge. A self-signed peer is NOT an "
+        "excuse — pin its CA instead. Do NOT flag `check_hostname=False` while "
+        "`verify_mode` stays `CERT_REQUIRED` against a pinned CA — that is the "
+        "legitimate connect-by-IP-with-pinned-cert pattern, not disabled "
+        "verification.",
+        bad_example="ctx.verify_mode = ssl.CERT_NONE  # sends X-API-KEY to any peer",
+        good_example="ctx = ssl.create_default_context(cafile=pinned_ca)  # CERT_REQUIRED",
+        severity="high",
+    ),
 )
 
 

--- a/services/api/tests/test_code_review_prompt.py
+++ b/services/api/tests/test_code_review_prompt.py
@@ -171,3 +171,11 @@ def test_subprocess_no_timeout_rule_present():
     provider hangs the whole chain (claude-stuff #356, #368)."""
     assert any(r.name == "subprocess-no-timeout" for r in crp.RULES)
     assert "subprocess-no-timeout" in crp.build_system_prompt()
+
+
+def test_tls_verification_disabled_rule_present():
+    """Weekly harvest: disabling TLS/cert verification (CERT_NONE / verify=False
+    / rejectUnauthorized:false / InsecureSkipVerify) sends credentials over a
+    MITM-able link — pin the CA instead (infrastructure #1390/#1391)."""
+    assert any(r.name == "tls-verification-disabled" for r in crp.RULES)
+    assert "tls-verification-disabled" in crp.build_system_prompt()

--- a/services/webhook/code_review_prompt.py
+++ b/services/webhook/code_review_prompt.py
@@ -346,6 +346,23 @@ RULES: tuple[ReviewRule, ...] = (
         good_example="subprocess.run(cmd, capture_output=True, timeout=600)",
         severity="medium",
     ),
+    # ── weekly harvest: disabled-TLS-verification class (infrastructure #1390/#1391) ──
+    ReviewRule(
+        name="tls-verification-disabled",
+        bug_class="security",
+        description="TLS/certificate verification turned OFF on an outbound "
+        "connection: `verify=False` (requests/httpx), `ssl.CERT_NONE` "
+        "(ssl/urllib), `rejectUnauthorized: false` (Node), or "
+        "`InsecureSkipVerify: true` (Go). Any API key / token / data then "
+        "rides a link a MITM can read or forge. A self-signed peer is NOT an "
+        "excuse — pin its CA instead. Do NOT flag `check_hostname=False` while "
+        "`verify_mode` stays `CERT_REQUIRED` against a pinned CA — that is the "
+        "legitimate connect-by-IP-with-pinned-cert pattern, not disabled "
+        "verification.",
+        bad_example="ctx.verify_mode = ssl.CERT_NONE  # sends X-API-KEY to any peer",
+        good_example="ctx = ssl.create_default_context(cafile=pinned_ca)  # CERT_REQUIRED",
+        severity="high",
+    ),
 )
 
 

--- a/services/webhook/tests/test_code_review_prompt.py
+++ b/services/webhook/tests/test_code_review_prompt.py
@@ -203,6 +203,14 @@ def test_subprocess_no_timeout_rule_present():
     assert "subprocess-no-timeout" in crp.build_system_prompt()
 
 
+def test_tls_verification_disabled_rule_present():
+    """Weekly harvest: disabling TLS/cert verification (CERT_NONE / verify=False
+    / rejectUnauthorized:false / InsecureSkipVerify) sends credentials over a
+    MITM-able link — pin the CA instead (infrastructure #1390/#1391)."""
+    assert any(r.name == "tls-verification-disabled" for r in crp.RULES)
+    assert "tls-verification-disabled" in crp.build_system_prompt()
+
+
 def test_voice_has_mandatory_bookend_structure():
     """#343: the voice instruction mandates the structural bookends that
     keep the caveman cadence from slipping to plain English under technical


### PR DESCRIPTION
## Why

The weekly fix-PR harvest surfaced a single-diff, LLM-checkable security shape the Elder doesn't yet catch: **TLS/certificate verification turned OFF on an outbound connection**. It's grounded in a real security-review follow-up — infrastructure #1390/#1391, where the `unifi-wan-scraper` sent its `X-API-KEY` over an unverified connection (`ssl.CERT_NONE`), letting a Main-VLAN MITM capture the key; the fix pinned the UDM's self-signed CA (`CERT_REQUIRED` against a pinned `cafile`). A human reviewer caught this; the Elder should catch it automatically on every PR. The new rule covers the cross-language forms (`verify=False`, `ssl.CERT_NONE`, `rejectUnauthorized: false`, `InsecureSkipVerify: true`) and explicitly exempts the legitimate `check_hostname=False` + `CERT_REQUIRED`-against-a-pinned-CA pattern so it won't false-positive on connect-by-IP-with-pinned-cert.

## Acceptance criteria

- [x] One `ReviewRule` (`tls-verification-disabled`, bug_class `security`, severity `high`, bad+good example) appended to `RULES` in `services/webhook/code_review_prompt.py`
- [x] Identical edit mirrored to `services/api/code_review_prompt.py` (ADR-0001); `bash scripts/check-mirrored-files.sh` green (33 pairs verified)
- [x] Rule-present test added on both sides; `test_code_review_prompt.py` passes (webhook 24, api 20)
- [x] No new bug_class needed (`security` already in `_BUG_CLASSES`); rule renders into the built prompt

## Size

**Size:** S

## Dependencies

Refs githumps/infrastructure#1390, githumps/infrastructure#1391 (the source fix this rule generalizes). No blocking PRs.

## Out of scope

- Any change to the confidence-bias A/B variants, the voice clause, or the dispatch path.
- Catching TLS-disable at the IaC/runtime layer (kept to the per-diff rule here).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrxPob2U4R8bMu8YXkLVMh)_