### PR TITLE
ci(iac.deploy): bound the meta job with timeout-minutes (hygiene Rule 7)

### DIFF
--- a/.github/workflows/iac.deploy.yml
+++ b/.github/workflows/iac.deploy.yml
@@ -35,6 +35,7 @@ concurrency:
 jobs:
   meta:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       tag: ${{ steps.t.outputs.tag }}
     steps:


### PR DESCRIPTION
## Why

Fleet CI standard `infrastructure/.github/scripts/workflow_hygiene.py` **Rule 7** (infra #709) requires every job with an inline `runs-on:` to declare a `timeout-minutes:`. Without it a wedged step inherits GitHub's **360-minute (6h)** default and holds a runner slot until that cap.

In `iac.deploy.yml` the `meta` job (`.github/workflows/iac.deploy.yml:36-42`) was the **only** inline `runs-on:` job in the file without a `timeout-minutes:` — its two siblings already set one (`infra-test: 10` at :52, `pulumi-up: 20` at :66), so this was a pre-existing outlier, not a convention. `grug`'s only hygiene gate (`check.drift-lint.yml`) checks mirrored `services/api|webhook/` files only and does not run `workflow_hygiene.py`, so Rule 7 was unenforced here.

## What changed

- `.github/workflows/iac.deploy.yml` — added `timeout-minutes: 5` to the `meta` job (a single `echo` step; 5 is generous). Single-file, one-line change.

## Acceptance criteria

- [x] The `meta` job declares an explicit `timeout-minutes:` (5).
- [x] Every inline `runs-on:` job in `iac.deploy.yml` now carries a `timeout-minutes:` (`meta` 5, `infra-test` 10, `pulumi-up` 20).
- [x] No happy-path behavioral change — only a ceiling is added; the `tag` output is unchanged.

Size: XS

## Out of scope

- The reusable-caller `smoke` job (delegates via `uses:`; exempt from Rule 7).
- The `benchmark.sast.yml` environment-binding contradiction (#453).
- Porting a `workflow_hygiene.py` Rule-7 drift-lint gate into this repo (larger follow-up).

Closes #455

---
_Automated fix by nightly fleet-health bot._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014CCtSPB4sinXqt6Ye6tetj)_